### PR TITLE
fix: remove hx-trigger load to prevent Alpine scope loss on kanban board

### DIFF
--- a/templates/partials/kanban.html
+++ b/templates/partials/kanban.html
@@ -1,6 +1,7 @@
 <div id="kanban-board"
      hx-get="/api/dashboard/kanban"
-     hx-trigger="load, sse:feature_updated"
+     hx-trigger="sse:feature_updated"
+     hx-swap="outerHTML"
      x-data="kanbanBoard()"
      class="flex gap-4 p-4 overflow-x-auto">
   {% for (state, col_cards) in cards %}


### PR DESCRIPTION
## Summary
- Remove `hx-trigger="load"` from kanban board div - the initial page render already contains the data, so the immediate refetch was redundant and caused Alpine.js `x-data` scope to be lost via innerHTML swap
- Add `hx-swap="outerHTML"` so SSE-triggered updates replace the full Alpine component boundary
- Fixes `draggingId is not defined` errors on all feature cards

## Test plan
- [ ] Load dashboard - kanban board renders with styling and no console errors
- [ ] Drag a feature card - no Alpine expression errors
- [ ] Verify SSE updates still refresh the board

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Kanban board now updates dynamically via real-time events, replacing the entire board when changes occur for improved synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->