### PR TITLE
fix: replace fake SpecKitty project with real Phenotype org repos

### DIFF
--- a/crates/agileplus-dashboard/src/app_state.rs
+++ b/crates/agileplus-dashboard/src/app_state.rs
@@ -46,7 +46,18 @@ impl DashboardStore {
         let (features, work_packages) = crate::seed::seed_dogfood_features();
         let projects = vec![
             Project::with_id(1, "agileplus", "AgilePlus", "Spec-driven development platform"),
-            Project::with_id(2, "speckitty", "SpecKitty", "Spec Kitty CLI and framework"),
+            Project::with_id(2, "bifrost-extensions", "Bifrost Extensions", "Clean extension layer for Bifrost LLM gateway"),
+            Project::with_id(3, "cliproxyapi-plusplus", "CLIProxy API++", "CLI proxy with third-party provider support"),
+            Project::with_id(4, "agentapi-plusplus", "AgentAPI++", "AgentAPI fork with provider support and OAuth"),
+            Project::with_id(5, "colab", "Colab", "Hybrid web browser and local code editor"),
+            Project::with_id(6, "helios", "Helios", "Helios application and CLI"),
+            Project::with_id(7, "thegent", "TheGent", "Agent orchestration, governance, and lifecycle framework"),
+            Project::with_id(8, "tokenledger", "TokenLedger", "Token management and pricing governance for AI agents"),
+            Project::with_id(9, "trace", "Trace", "Multi-view requirements traceability system"),
+            Project::with_id(10, "phenotype-config", "Phenotype Config", "Local-first config, feature flags, and secrets"),
+            Project::with_id(11, "phenotype-infra", "Phenotype Infra", "Shared actions, design tokens, and doc federation"),
+            Project::with_id(12, "portage", "Portage", "Agent and LLM evaluation framework"),
+            Project::with_id(13, "civ", "Civ", "Deterministic simulation and policy architecture"),
         ];
         Self {
             features,

--- a/crates/agileplus-dashboard/src/seed.rs
+++ b/crates/agileplus-dashboard/src/seed.rs
@@ -467,7 +467,7 @@ pub fn seed_dogfood_features() -> (Vec<Feature>, HashMap<i64, Vec<WorkPackage>>)
 
     let mut wp_id = work_packages.values().flatten().map(|wp| wp.id).max().unwrap_or(0) + 1;
     for (id, slug, name, labels) in speckitty_specs {
-        features.push(make_shipped_feature(id, slug, name, labels, Some(2)));
+        features.push(make_shipped_feature(id, slug, name, labels, Some(1)));
         let wps = make_shipped_wps(
             id,
             wp_id,


### PR DESCRIPTION
## Summary
- Remove placeholder SpecKitty project from dashboard seed data
- Add 12 real Phenotype org projects (Bifrost Extensions, CLIProxy API++, AgentAPI++, Colab, Helios, TheGent, TokenLedger, Trace, Phenotype Config, Phenotype Infra, Portage, Civ)
- Reassign all 33 dogfood features from SpecKitty to AgilePlus project

## Test plan
- [ ] Dashboard shows AgilePlus + 12 real Phenotype projects in project switcher
- [ ] All 37 features appear under AgilePlus when filtered
- [ ] No SpecKitty project visible

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated sample project data in the dashboard with an expanded collection of demo projects for testing and evaluation.
  * Adjusted project associations for sample features to align with the updated project structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->