### PR TITLE
fix: add missing project_for_feature and feature_counts_for_project methods

### DIFF
--- a/crates/agileplus-dashboard/src/app_state.rs
+++ b/crates/agileplus-dashboard/src/app_state.rs
@@ -87,6 +87,24 @@ impl DashboardStore {
             None => self.features.iter().collect(),
         }
     }
+
+    pub fn project_for_feature(&self, feature: &Feature) -> Option<&Project> {
+        feature.project_id.and_then(|pid| self.projects.iter().find(|p| p.id == pid))
+    }
+
+    pub fn feature_counts_for_project(&self, project_id: i64) -> (usize, usize, usize) {
+        let features: Vec<&Feature> = self.features.iter()
+            .filter(|f| f.project_id == Some(project_id))
+            .collect();
+        let total = features.len();
+        let active = features.iter()
+            .filter(|f| !matches!(f.state, FeatureState::Shipped | FeatureState::Retrospected))
+            .count();
+        let shipped = features.iter()
+            .filter(|f| matches!(f.state, FeatureState::Shipped | FeatureState::Retrospected))
+            .count();
+        (total, active, shipped)
+    }
 }
 
 pub fn default_health() -> Vec<ServiceHealth> {


### PR DESCRIPTION
## Summary
- Add project_for_feature() to look up a feature's parent project
- Add feature_counts_for_project() returning (total, active, shipped) counts
- Fixes build failure from missing methods referenced in routes.rs

## Test plan
- [x] cargo check --workspace passes

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added internal utilities for dashboard state management to retrieve project information and feature counts by project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->