### PR TITLE
chore: add worktrees/ and agent directories to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ kitty-specs/
 
 # Reference repos (not submodules)
 references/
+worktrees/
+.claude/
+.codex/
+.cursor/


### PR DESCRIPTION
## Summary
Standardize working directory ignore patterns by adding worktrees/ and agent directories to gitignore.

## Changes
- Add worktrees/ to gitignore
- Add .claude/, .codex/, .cursor/ to gitignore

## Notes
- Part of breadth-first ecosystem evaluation
---
*Generated by breadth-first ecosystem evaluation*