### PR TITLE
feat(docs): major docs overhaul - 48 pages, module switcher, mermaid, workflow phases

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,8 @@
       },
       "devDependencies": {
         "markdownlint-cli": "^0.42.0",
+        "mermaid": "^11.12.3",
+        "vitepress-plugin-mermaid": "^2.0.17",
       },
     },
   },
@@ -50,6 +52,8 @@
 
     "@algolia/requester-node-http": ["@algolia/requester-node-http@5.49.1", "", { "dependencies": { "@algolia/client-common": "5.49.1" } }, "sha512-zA5bkUOB5PPtTr182DJmajCiizHp0rCJQ0Chf96zNFvkdESKYlDeYA3tQ7r2oyHbu/8DiohAQ5PZ85edctzbXA=="],
 
+    "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
+
     "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
 
     "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
@@ -57,6 +61,18 @@
     "@babel/parser": ["@babel/parser@7.29.0", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": { "parser": "bin/babel-parser.js" } }, "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww=="],
 
     "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "@braintree/sanitize-url": ["@braintree/sanitize-url@7.1.2", "", {}, "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA=="],
+
+    "@chevrotain/cst-dts-gen": ["@chevrotain/cst-dts-gen@11.1.2", "", { "dependencies": { "@chevrotain/gast": "11.1.2", "@chevrotain/types": "11.1.2", "lodash-es": "4.17.23" } }, "sha512-XTsjvDVB5nDZBQB8o0o/0ozNelQtn2KrUVteIHSlPd2VAV2utEb6JzyCJaJ8tGxACR4RiBNWy5uYUHX2eji88Q=="],
+
+    "@chevrotain/gast": ["@chevrotain/gast@11.1.2", "", { "dependencies": { "@chevrotain/types": "11.1.2", "lodash-es": "4.17.23" } }, "sha512-Z9zfXR5jNZb1Hlsd/p+4XWeUFugrHirq36bKzPWDSIacV+GPSVXdk+ahVWZTwjhNwofAWg/sZg58fyucKSQx5g=="],
+
+    "@chevrotain/regexp-to-ast": ["@chevrotain/regexp-to-ast@11.1.2", "", {}, "sha512-nMU3Uj8naWer7xpZTYJdxbAs6RIv/dxYzkYU8GSwgUtcAAlzjcPfX1w+RKRcYG8POlzMeayOQ/znfwxEGo5ulw=="],
+
+    "@chevrotain/types": ["@chevrotain/types@11.1.2", "", {}, "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw=="],
+
+    "@chevrotain/utils": ["@chevrotain/utils@11.1.2", "", {}, "sha512-4mudFAQ6H+MqBTfqLmU7G1ZwRzCLfJEooL/fsF6rCX5eePMbGhoy5n4g+G4vlh2muDcsCTJtL+uKbOzWxs5LHA=="],
 
     "@docsearch/css": ["@docsearch/css@3.8.2", "", {}, "sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ=="],
 
@@ -114,6 +130,8 @@
 
     "@iconify/types": ["@iconify/types@2.0.0", "", {}, "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg=="],
 
+    "@iconify/utils": ["@iconify/utils@3.1.0", "", { "dependencies": { "@antfu/install-pkg": "^1.1.0", "@iconify/types": "^2.0.0", "mlly": "^1.8.0" } }, "sha512-Zlzem1ZXhI1iHeeERabLNzBHdOa4VhQbqAcOQaMKuTuyZCpwKbC2R4Dd0Zo3g9EAc+Y4fiarO8HIHRAth7+skw=="],
+
     "@isaacs/balanced-match": ["@isaacs/balanced-match@4.0.1", "", {}, "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ=="],
 
     "@isaacs/brace-expansion": ["@isaacs/brace-expansion@5.0.1", "", { "dependencies": { "@isaacs/balanced-match": "^4.0.1" } }, "sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ=="],
@@ -121,6 +139,10 @@
     "@isaacs/cliui": ["@isaacs/cliui@9.0.0", "", {}, "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg=="],
 
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@mermaid-js/mermaid-mindmap": ["@mermaid-js/mermaid-mindmap@9.3.0", "", { "dependencies": { "@braintree/sanitize-url": "^6.0.0", "cytoscape": "^3.23.0", "cytoscape-cose-bilkent": "^4.1.0", "cytoscape-fcose": "^2.1.0", "d3": "^7.0.0", "khroma": "^2.0.0", "non-layered-tidy-tree-layout": "^2.0.2" } }, "sha512-IhtYSVBBRYviH1Ehu8gk69pMDF8DSRqXBRDMWrEfHoaMruHeaP2DXA3PBnuwsMaCdPQhlUUcy/7DBLAEIXvCAw=="],
+
+    "@mermaid-js/parser": ["@mermaid-js/parser@1.0.0", "", { "dependencies": { "langium": "^4.0.0" } }, "sha512-vvK0Hi/VWndxoh03Mmz6wa1KDriSPjS2XMZL/1l19HFwygiObEEoEwSDxOqyLzzAI6J2PU3261JjTMTO7x+BPw=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.59.0", "", { "os": "android", "cpu": "arm" }, "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg=="],
 
@@ -188,7 +210,71 @@
 
     "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
 
+    "@types/d3": ["@types/d3@7.4.3", "", { "dependencies": { "@types/d3-array": "*", "@types/d3-axis": "*", "@types/d3-brush": "*", "@types/d3-chord": "*", "@types/d3-color": "*", "@types/d3-contour": "*", "@types/d3-delaunay": "*", "@types/d3-dispatch": "*", "@types/d3-drag": "*", "@types/d3-dsv": "*", "@types/d3-ease": "*", "@types/d3-fetch": "*", "@types/d3-force": "*", "@types/d3-format": "*", "@types/d3-geo": "*", "@types/d3-hierarchy": "*", "@types/d3-interpolate": "*", "@types/d3-path": "*", "@types/d3-polygon": "*", "@types/d3-quadtree": "*", "@types/d3-random": "*", "@types/d3-scale": "*", "@types/d3-scale-chromatic": "*", "@types/d3-selection": "*", "@types/d3-shape": "*", "@types/d3-time": "*", "@types/d3-time-format": "*", "@types/d3-timer": "*", "@types/d3-transition": "*", "@types/d3-zoom": "*" } }, "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww=="],
+
+    "@types/d3-array": ["@types/d3-array@3.2.2", "", {}, "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="],
+
+    "@types/d3-axis": ["@types/d3-axis@3.0.6", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw=="],
+
+    "@types/d3-brush": ["@types/d3-brush@3.0.6", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A=="],
+
+    "@types/d3-chord": ["@types/d3-chord@3.0.6", "", {}, "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg=="],
+
+    "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
+
+    "@types/d3-contour": ["@types/d3-contour@3.0.6", "", { "dependencies": { "@types/d3-array": "*", "@types/geojson": "*" } }, "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg=="],
+
+    "@types/d3-delaunay": ["@types/d3-delaunay@6.0.4", "", {}, "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw=="],
+
+    "@types/d3-dispatch": ["@types/d3-dispatch@3.0.7", "", {}, "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA=="],
+
+    "@types/d3-drag": ["@types/d3-drag@3.0.7", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ=="],
+
+    "@types/d3-dsv": ["@types/d3-dsv@3.0.7", "", {}, "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g=="],
+
+    "@types/d3-ease": ["@types/d3-ease@3.0.2", "", {}, "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="],
+
+    "@types/d3-fetch": ["@types/d3-fetch@3.0.7", "", { "dependencies": { "@types/d3-dsv": "*" } }, "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA=="],
+
+    "@types/d3-force": ["@types/d3-force@3.0.10", "", {}, "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw=="],
+
+    "@types/d3-format": ["@types/d3-format@3.0.4", "", {}, "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g=="],
+
+    "@types/d3-geo": ["@types/d3-geo@3.1.0", "", { "dependencies": { "@types/geojson": "*" } }, "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ=="],
+
+    "@types/d3-hierarchy": ["@types/d3-hierarchy@3.1.7", "", {}, "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg=="],
+
+    "@types/d3-interpolate": ["@types/d3-interpolate@3.0.4", "", { "dependencies": { "@types/d3-color": "*" } }, "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA=="],
+
+    "@types/d3-path": ["@types/d3-path@3.1.1", "", {}, "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="],
+
+    "@types/d3-polygon": ["@types/d3-polygon@3.0.2", "", {}, "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA=="],
+
+    "@types/d3-quadtree": ["@types/d3-quadtree@3.0.6", "", {}, "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg=="],
+
+    "@types/d3-random": ["@types/d3-random@3.0.3", "", {}, "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ=="],
+
+    "@types/d3-scale": ["@types/d3-scale@4.0.9", "", { "dependencies": { "@types/d3-time": "*" } }, "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw=="],
+
+    "@types/d3-scale-chromatic": ["@types/d3-scale-chromatic@3.1.0", "", {}, "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ=="],
+
+    "@types/d3-selection": ["@types/d3-selection@3.0.11", "", {}, "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w=="],
+
+    "@types/d3-shape": ["@types/d3-shape@3.1.8", "", { "dependencies": { "@types/d3-path": "*" } }, "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w=="],
+
+    "@types/d3-time": ["@types/d3-time@3.0.4", "", {}, "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="],
+
+    "@types/d3-time-format": ["@types/d3-time-format@4.0.3", "", {}, "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg=="],
+
+    "@types/d3-timer": ["@types/d3-timer@3.0.2", "", {}, "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="],
+
+    "@types/d3-transition": ["@types/d3-transition@3.0.9", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg=="],
+
+    "@types/d3-zoom": ["@types/d3-zoom@3.0.8", "", { "dependencies": { "@types/d3-interpolate": "*", "@types/d3-selection": "*" } }, "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw=="],
+
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@types/geojson": ["@types/geojson@7946.0.16", "", {}, "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg=="],
 
     "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
 
@@ -199,6 +285,8 @@
     "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
 
     "@types/mdurl": ["@types/mdurl@2.0.0", "", {}, "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg=="],
+
+    "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
@@ -240,6 +328,8 @@
 
     "@vueuse/shared": ["@vueuse/shared@12.8.2", "", { "dependencies": { "vue": "^3.5.13" } }, "sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w=="],
 
+    "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
+
     "algoliasearch": ["algoliasearch@5.49.1", "", { "dependencies": { "@algolia/abtesting": "1.15.1", "@algolia/client-abtesting": "5.49.1", "@algolia/client-analytics": "5.49.1", "@algolia/client-common": "5.49.1", "@algolia/client-insights": "5.49.1", "@algolia/client-personalization": "5.49.1", "@algolia/client-query-suggestions": "5.49.1", "@algolia/client-search": "5.49.1", "@algolia/ingestion": "1.49.1", "@algolia/monitoring": "1.49.1", "@algolia/recommend": "5.49.1", "@algolia/requester-browser-xhr": "5.49.1", "@algolia/requester-fetch": "5.49.1", "@algolia/requester-node-http": "5.49.1" } }, "sha512-X3Pp2aRQhg4xUC6PQtkubn5NpRKuUPQ9FPDQlx36SmpFwwH2N0/tw4c+NXV3nw3PsgeUs+BuWGP0gjz3TvENLQ=="],
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
@@ -252,21 +342,107 @@
 
     "character-entities-legacy": ["character-entities-legacy@3.0.0", "", {}, "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="],
 
+    "chevrotain": ["chevrotain@11.1.2", "", { "dependencies": { "@chevrotain/cst-dts-gen": "11.1.2", "@chevrotain/gast": "11.1.2", "@chevrotain/regexp-to-ast": "11.1.2", "@chevrotain/types": "11.1.2", "@chevrotain/utils": "11.1.2", "lodash-es": "4.17.23" } }, "sha512-opLQzEVriiH1uUQ4Kctsd49bRoFDXGGSC4GUqj7pGyxM3RehRhvTlZJc1FL/Flew2p5uwxa1tUDWKzI4wNM8pg=="],
+
+    "chevrotain-allstar": ["chevrotain-allstar@0.3.1", "", { "dependencies": { "lodash-es": "^4.17.21" }, "peerDependencies": { "chevrotain": "^11.0.0" } }, "sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw=="],
+
     "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
 
     "commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
 
+    "confbox": ["confbox@0.1.8", "", {}, "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w=="],
+
     "copy-anything": ["copy-anything@4.0.5", "", { "dependencies": { "is-what": "^5.2.0" } }, "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA=="],
+
+    "cose-base": ["cose-base@1.0.3", "", { "dependencies": { "layout-base": "^1.0.0" } }, "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
+    "cytoscape": ["cytoscape@3.33.1", "", {}, "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ=="],
+
+    "cytoscape-cose-bilkent": ["cytoscape-cose-bilkent@4.1.0", "", { "dependencies": { "cose-base": "^1.0.0" }, "peerDependencies": { "cytoscape": "^3.2.0" } }, "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ=="],
+
+    "cytoscape-fcose": ["cytoscape-fcose@2.2.0", "", { "dependencies": { "cose-base": "^2.2.0" }, "peerDependencies": { "cytoscape": "^3.2.0" } }, "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ=="],
+
+    "d3": ["d3@7.9.0", "", { "dependencies": { "d3-array": "3", "d3-axis": "3", "d3-brush": "3", "d3-chord": "3", "d3-color": "3", "d3-contour": "4", "d3-delaunay": "6", "d3-dispatch": "3", "d3-drag": "3", "d3-dsv": "3", "d3-ease": "3", "d3-fetch": "3", "d3-force": "3", "d3-format": "3", "d3-geo": "3", "d3-hierarchy": "3", "d3-interpolate": "3", "d3-path": "3", "d3-polygon": "3", "d3-quadtree": "3", "d3-random": "3", "d3-scale": "4", "d3-scale-chromatic": "3", "d3-selection": "3", "d3-shape": "3", "d3-time": "3", "d3-time-format": "4", "d3-timer": "3", "d3-transition": "3", "d3-zoom": "3" } }, "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA=="],
+
+    "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
+
+    "d3-axis": ["d3-axis@3.0.0", "", {}, "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw=="],
+
+    "d3-brush": ["d3-brush@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "3", "d3-transition": "3" } }, "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ=="],
+
+    "d3-chord": ["d3-chord@3.0.1", "", { "dependencies": { "d3-path": "1 - 3" } }, "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g=="],
+
+    "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
+
+    "d3-contour": ["d3-contour@4.0.2", "", { "dependencies": { "d3-array": "^3.2.0" } }, "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA=="],
+
+    "d3-delaunay": ["d3-delaunay@6.0.4", "", { "dependencies": { "delaunator": "5" } }, "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A=="],
+
+    "d3-dispatch": ["d3-dispatch@3.0.1", "", {}, "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg=="],
+
+    "d3-drag": ["d3-drag@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-selection": "3" } }, "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg=="],
+
+    "d3-dsv": ["d3-dsv@3.0.1", "", { "dependencies": { "commander": "7", "iconv-lite": "0.6", "rw": "1" }, "bin": { "csv2json": "bin/dsv2json.js", "csv2tsv": "bin/dsv2dsv.js", "dsv2dsv": "bin/dsv2dsv.js", "dsv2json": "bin/dsv2json.js", "json2csv": "bin/json2dsv.js", "json2dsv": "bin/json2dsv.js", "json2tsv": "bin/json2dsv.js", "tsv2csv": "bin/dsv2dsv.js", "tsv2json": "bin/dsv2json.js" } }, "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q=="],
+
+    "d3-ease": ["d3-ease@3.0.1", "", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
+
+    "d3-fetch": ["d3-fetch@3.0.1", "", { "dependencies": { "d3-dsv": "1 - 3" } }, "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw=="],
+
+    "d3-force": ["d3-force@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-quadtree": "1 - 3", "d3-timer": "1 - 3" } }, "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg=="],
+
+    "d3-format": ["d3-format@3.1.2", "", {}, "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="],
+
+    "d3-geo": ["d3-geo@3.1.1", "", { "dependencies": { "d3-array": "2.5.0 - 3" } }, "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q=="],
+
+    "d3-hierarchy": ["d3-hierarchy@3.1.2", "", {}, "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA=="],
+
+    "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
+
+    "d3-path": ["d3-path@3.1.0", "", {}, "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="],
+
+    "d3-polygon": ["d3-polygon@3.0.1", "", {}, "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg=="],
+
+    "d3-quadtree": ["d3-quadtree@3.0.1", "", {}, "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw=="],
+
+    "d3-random": ["d3-random@3.0.1", "", {}, "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ=="],
+
+    "d3-sankey": ["d3-sankey@0.12.3", "", { "dependencies": { "d3-array": "1 - 2", "d3-shape": "^1.2.0" } }, "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ=="],
+
+    "d3-scale": ["d3-scale@4.0.2", "", { "dependencies": { "d3-array": "2.10.0 - 3", "d3-format": "1 - 3", "d3-interpolate": "1.2.0 - 3", "d3-time": "2.1.1 - 3", "d3-time-format": "2 - 4" } }, "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ=="],
+
+    "d3-scale-chromatic": ["d3-scale-chromatic@3.1.0", "", { "dependencies": { "d3-color": "1 - 3", "d3-interpolate": "1 - 3" } }, "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ=="],
+
+    "d3-selection": ["d3-selection@3.0.0", "", {}, "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="],
+
+    "d3-shape": ["d3-shape@3.2.0", "", { "dependencies": { "d3-path": "^3.1.0" } }, "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA=="],
+
+    "d3-time": ["d3-time@3.1.0", "", { "dependencies": { "d3-array": "2 - 3" } }, "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q=="],
+
+    "d3-time-format": ["d3-time-format@4.1.0", "", { "dependencies": { "d3-time": "1 - 3" } }, "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg=="],
+
+    "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
+
+    "d3-transition": ["d3-transition@3.0.1", "", { "dependencies": { "d3-color": "1 - 3", "d3-dispatch": "1 - 3", "d3-ease": "1 - 3", "d3-interpolate": "1 - 3", "d3-timer": "1 - 3" }, "peerDependencies": { "d3-selection": "2 - 3" } }, "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w=="],
+
+    "d3-zoom": ["d3-zoom@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "2 - 3", "d3-transition": "2 - 3" } }, "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw=="],
+
+    "dagre-d3-es": ["dagre-d3-es@7.0.13", "", { "dependencies": { "d3": "^7.9.0", "lodash-es": "^4.17.21" } }, "sha512-efEhnxpSuwpYOKRm/L5KbqoZmNNukHa/Flty4Wp62JRvgH2ojwVgPgdYyr4twpieZnyRDdIH7PY2mopX26+j2Q=="],
+
+    "dayjs": ["dayjs@1.11.19", "", {}, "sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw=="],
+
     "deep-extend": ["deep-extend@0.6.0", "", {}, "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="],
+
+    "delaunator": ["delaunator@5.0.1", "", { "dependencies": { "robust-predicates": "^3.0.2" } }, "sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw=="],
 
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
+
+    "dompurify": ["dompurify@3.3.1", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q=="],
 
     "emoji-regex-xs": ["emoji-regex-xs@1.0.0", "", {}, "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg=="],
 
@@ -286,6 +462,8 @@
 
     "glob": ["glob@11.0.3", "", { "dependencies": { "foreground-child": "^3.3.1", "jackspeak": "^4.1.1", "minimatch": "^10.0.3", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^2.0.0" }, "bin": "dist/esm/bin.mjs" }, "sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA=="],
 
+    "hachure-fill": ["hachure-fill@0.5.2", "", {}, "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg=="],
+
     "hast-util-to-html": ["hast-util-to-html@9.0.5", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-whitespace": "^3.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "stringify-entities": "^4.0.0", "zwitch": "^2.0.4" } }, "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw=="],
 
     "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
@@ -294,9 +472,13 @@
 
     "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
 
+    "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
     "ignore": ["ignore@6.0.2", "", {}, "sha512-InwqeHHN2XpumIkMvpl/DCJVrAHgCsG5+cn1XlnLWGwtZBm8QJfSusItfrwx81CTp5agNZqpKU2J/ccC5nGT4A=="],
 
     "ini": ["ini@4.1.3", "", {}, "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg=="],
+
+    "internmap": ["internmap@1.0.1", "", {}, "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="],
 
     "is-what": ["is-what@5.5.0", "", {}, "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw=="],
 
@@ -310,7 +492,17 @@
 
     "jsonpointer": ["jsonpointer@5.0.1", "", {}, "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ=="],
 
+    "katex": ["katex@0.16.33", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-q3N5u+1sY9Bu7T4nlXoiRBXWfwSefNGoKeOwekV+gw0cAXQlz2Ww6BLcmBxVDeXBMUDQv6fK5bcNaJLxob3ZQA=="],
+
+    "khroma": ["khroma@2.1.0", "", {}, "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="],
+
+    "langium": ["langium@4.2.1", "", { "dependencies": { "chevrotain": "~11.1.1", "chevrotain-allstar": "~0.3.1", "vscode-languageserver": "~9.0.1", "vscode-languageserver-textdocument": "~1.0.11", "vscode-uri": "~3.1.0" } }, "sha512-zu9QWmjpzJcomzdJQAHgDVhLGq5bLosVak1KVa40NzQHXfqr4eAHupvnPOVXEoLkg6Ocefvf/93d//SB7du4YQ=="],
+
+    "layout-base": ["layout-base@1.0.2", "", {}, "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg=="],
+
     "linkify-it": ["linkify-it@5.0.0", "", { "dependencies": { "uc.micro": "^2.0.0" } }, "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ=="],
+
+    "lodash-es": ["lodash-es@4.17.23", "", {}, "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg=="],
 
     "lru-cache": ["lru-cache@11.2.6", "", {}, "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ=="],
 
@@ -326,9 +518,13 @@
 
     "markdownlint-micromark": ["markdownlint-micromark@0.1.10", "", {}, "sha512-no5ZfdqAdWGxftCLlySHSgddEjyW4kui4z7amQcGsSKfYC5v/ou+8mIQVyg9KQMeEZLNtz9OPDTj7nnTnoR4FQ=="],
 
+    "marked": ["marked@16.4.2", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA=="],
+
     "mdast-util-to-hast": ["mdast-util-to-hast@13.2.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@ungap/structured-clone": "^1.0.0", "devlop": "^1.0.0", "micromark-util-sanitize-uri": "^2.0.0", "trim-lines": "^3.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA=="],
 
     "mdurl": ["mdurl@2.0.0", "", {}, "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w=="],
+
+    "mermaid": ["mermaid@11.12.3", "", { "dependencies": { "@braintree/sanitize-url": "^7.1.1", "@iconify/utils": "^3.0.1", "@mermaid-js/parser": "^1.0.0", "@types/d3": "^7.4.3", "cytoscape": "^3.29.3", "cytoscape-cose-bilkent": "^4.1.0", "cytoscape-fcose": "^2.2.0", "d3": "^7.9.0", "d3-sankey": "^0.12.3", "dagre-d3-es": "7.0.13", "dayjs": "^1.11.18", "dompurify": "^3.2.5", "katex": "^0.16.22", "khroma": "^2.1.0", "lodash-es": "^4.17.23", "marked": "^16.2.1", "roughjs": "^4.6.6", "stylis": "^4.3.6", "ts-dedent": "^2.2.0", "uuid": "^11.1.0" } }, "sha512-wN5ZSgJQIC+CHJut9xaKWsknLxaFBwCPwPkGTSUYrTiHORWvpT8RxGk849HPnpUAQ+/9BPRqYb80jTpearrHzQ=="],
 
     "micromark-util-character": ["micromark-util-character@2.1.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="],
 
@@ -350,19 +546,35 @@
 
     "mitt": ["mitt@3.0.1", "", {}, "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="],
 
+    "mlly": ["mlly@1.8.0", "", { "dependencies": { "acorn": "^8.15.0", "pathe": "^2.0.3", "pkg-types": "^1.3.1", "ufo": "^1.6.1" } }, "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g=="],
+
     "nanoid": ["nanoid@3.3.11", "", { "bin": "bin/nanoid.cjs" }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+
+    "non-layered-tidy-tree-layout": ["non-layered-tidy-tree-layout@2.0.2", "", {}, "sha512-gkXMxRzUH+PB0ax9dUN0yYF0S25BqeAYqhgMaLUFmpXLEk7Fcu8f4emJuOAY0V8kjDICxROIKsTAKsV/v355xw=="],
 
     "oniguruma-to-es": ["oniguruma-to-es@3.1.1", "", { "dependencies": { "emoji-regex-xs": "^1.0.0", "regex": "^6.0.1", "regex-recursion": "^6.0.2" } }, "sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ=="],
 
     "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
 
+    "package-manager-detector": ["package-manager-detector@1.6.0", "", {}, "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA=="],
+
+    "path-data-parser": ["path-data-parser@0.1.0", "", {}, "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w=="],
+
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
     "path-scurry": ["path-scurry@2.0.2", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg=="],
 
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
     "perfect-debounce": ["perfect-debounce@1.0.0", "", {}, "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "pkg-types": ["pkg-types@1.3.1", "", { "dependencies": { "confbox": "^0.1.8", "mlly": "^1.7.4", "pathe": "^2.0.1" } }, "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ=="],
+
+    "points-on-curve": ["points-on-curve@0.2.0", "", {}, "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A=="],
+
+    "points-on-path": ["points-on-path@0.2.1", "", { "dependencies": { "path-data-parser": "0.1.0", "points-on-curve": "0.2.0" } }, "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g=="],
 
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
@@ -380,9 +592,17 @@
 
     "rfdc": ["rfdc@1.4.1", "", {}, "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="],
 
+    "robust-predicates": ["robust-predicates@3.0.2", "", {}, "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg=="],
+
     "rollup": ["rollup@4.59.0", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.59.0", "@rollup/rollup-android-arm64": "4.59.0", "@rollup/rollup-darwin-arm64": "4.59.0", "@rollup/rollup-darwin-x64": "4.59.0", "@rollup/rollup-freebsd-arm64": "4.59.0", "@rollup/rollup-freebsd-x64": "4.59.0", "@rollup/rollup-linux-arm-gnueabihf": "4.59.0", "@rollup/rollup-linux-arm-musleabihf": "4.59.0", "@rollup/rollup-linux-arm64-gnu": "4.59.0", "@rollup/rollup-linux-arm64-musl": "4.59.0", "@rollup/rollup-linux-loong64-gnu": "4.59.0", "@rollup/rollup-linux-loong64-musl": "4.59.0", "@rollup/rollup-linux-ppc64-gnu": "4.59.0", "@rollup/rollup-linux-ppc64-musl": "4.59.0", "@rollup/rollup-linux-riscv64-gnu": "4.59.0", "@rollup/rollup-linux-riscv64-musl": "4.59.0", "@rollup/rollup-linux-s390x-gnu": "4.59.0", "@rollup/rollup-linux-x64-gnu": "4.59.0", "@rollup/rollup-linux-x64-musl": "4.59.0", "@rollup/rollup-openbsd-x64": "4.59.0", "@rollup/rollup-openharmony-arm64": "4.59.0", "@rollup/rollup-win32-arm64-msvc": "4.59.0", "@rollup/rollup-win32-ia32-msvc": "4.59.0", "@rollup/rollup-win32-x64-gnu": "4.59.0", "@rollup/rollup-win32-x64-msvc": "4.59.0", "fsevents": "~2.3.2" }, "bin": "dist/bin/rollup" }, "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg=="],
 
+    "roughjs": ["roughjs@4.6.6", "", { "dependencies": { "hachure-fill": "^0.5.2", "path-data-parser": "^0.1.0", "points-on-curve": "^0.2.0", "points-on-path": "^0.2.1" } }, "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ=="],
+
     "run-con": ["run-con@1.3.2", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~4.1.0", "minimist": "^1.2.8", "strip-json-comments": "~3.1.1" }, "bin": "cli.js" }, "sha512-CcfE+mYiTcKEzg0IqS08+efdnH0oJ3zV0wSUFBNrMHMuxCtXvBCLzCJHatwuXDcu/RlhjTziTo/a1ruQik6/Yg=="],
+
+    "rw": ["rw@1.3.3", "", {}, "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
     "search-insights": ["search-insights@2.17.3", "", {}, "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ=="],
 
@@ -406,13 +626,21 @@
 
     "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
 
+    "stylis": ["stylis@4.3.6", "", {}, "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ=="],
+
     "superjson": ["superjson@2.2.6", "", { "dependencies": { "copy-anything": "^4" } }, "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA=="],
 
     "tabbable": ["tabbable@6.4.0", "", {}, "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg=="],
 
+    "tinyexec": ["tinyexec@1.0.2", "", {}, "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg=="],
+
     "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
 
+    "ts-dedent": ["ts-dedent@2.2.0", "", {}, "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ=="],
+
     "uc.micro": ["uc.micro@2.1.0", "", {}, "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="],
+
+    "ufo": ["ufo@1.6.3", "", {}, "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q=="],
 
     "unist-util-is": ["unist-util-is@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="],
 
@@ -424,6 +652,8 @@
 
     "unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
 
+    "uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
+
     "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
 
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
@@ -432,12 +662,42 @@
 
     "vitepress": ["vitepress@1.6.4", "", { "dependencies": { "@docsearch/css": "3.8.2", "@docsearch/js": "3.8.2", "@iconify-json/simple-icons": "^1.2.21", "@shikijs/core": "^2.1.0", "@shikijs/transformers": "^2.1.0", "@shikijs/types": "^2.1.0", "@types/markdown-it": "^14.1.2", "@vitejs/plugin-vue": "^5.2.1", "@vue/devtools-api": "^7.7.0", "@vue/shared": "^3.5.13", "@vueuse/core": "^12.4.0", "@vueuse/integrations": "^12.4.0", "focus-trap": "^7.6.4", "mark.js": "8.11.1", "minisearch": "^7.1.1", "shiki": "^2.1.0", "vite": "^5.4.14", "vue": "^3.5.13" }, "peerDependencies": { "markdown-it-mathjax3": "^4", "postcss": "^8" }, "optionalPeers": ["markdown-it-mathjax3"], "bin": "bin/vitepress.js" }, "sha512-+2ym1/+0VVrbhNyRoFFesVvBvHAVMZMK0rw60E3X/5349M1GuVdKeazuksqopEdvkKwKGs21Q729jX81/bkBJg=="],
 
+    "vitepress-plugin-mermaid": ["vitepress-plugin-mermaid@2.0.17", "", { "optionalDependencies": { "@mermaid-js/mermaid-mindmap": "^9.3.0" }, "peerDependencies": { "mermaid": "10 || 11", "vitepress": "^1.0.0 || ^1.0.0-alpha" } }, "sha512-IUzYpwf61GC6k0XzfmAmNrLvMi9TRrVRMsUyCA8KNXhg/mQ1VqWnO0/tBVPiX5UoKF1mDUwqn5QV4qAJl6JnUg=="],
+
+    "vscode-jsonrpc": ["vscode-jsonrpc@8.2.0", "", {}, "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA=="],
+
+    "vscode-languageserver": ["vscode-languageserver@9.0.1", "", { "dependencies": { "vscode-languageserver-protocol": "3.17.5" }, "bin": { "installServerIntoExtension": "bin/installServerIntoExtension" } }, "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g=="],
+
+    "vscode-languageserver-protocol": ["vscode-languageserver-protocol@3.17.5", "", { "dependencies": { "vscode-jsonrpc": "8.2.0", "vscode-languageserver-types": "3.17.5" } }, "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg=="],
+
+    "vscode-languageserver-textdocument": ["vscode-languageserver-textdocument@1.0.12", "", {}, "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA=="],
+
+    "vscode-languageserver-types": ["vscode-languageserver-types@3.17.5", "", {}, "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="],
+
+    "vscode-uri": ["vscode-uri@3.1.0", "", {}, "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ=="],
+
     "vue": ["vue@3.5.29", "", { "dependencies": { "@vue/compiler-dom": "3.5.29", "@vue/compiler-sfc": "3.5.29", "@vue/runtime-dom": "3.5.29", "@vue/server-renderer": "3.5.29", "@vue/shared": "3.5.29" }, "peerDependencies": { "typescript": "*" }, "optionalPeers": ["typescript"] }, "sha512-BZqN4Ze6mDQVNAni0IHeMJ5mwr8VAJ3MQC9FmprRhcBYENw+wOAAjRj8jfmN6FLl0j96OXbR+CjWhmAmM+QGnA=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
+    "@mermaid-js/mermaid-mindmap/@braintree/sanitize-url": ["@braintree/sanitize-url@6.0.4", "", {}, "sha512-s3jaWicZd0pkP0jf5ysyHUI/RE7MHos6qlToFcGWXVp+ykHOy77OUMrfbgJ9it2C5bow7OIQwYYaHjk9XlBQ2A=="],
+
     "@vue/compiler-core/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+
+    "cytoscape-fcose/cose-base": ["cose-base@2.2.0", "", { "dependencies": { "layout-base": "^2.0.0" } }, "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g=="],
+
+    "d3-dsv/commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
+
+    "d3-sankey/d3-array": ["d3-array@2.12.1", "", { "dependencies": { "internmap": "^1.0.0" } }, "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ=="],
+
+    "d3-sankey/d3-shape": ["d3-shape@1.3.7", "", { "dependencies": { "d3-path": "1" } }, "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw=="],
+
+    "katex/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
+
+    "cytoscape-fcose/cose-base/layout-base": ["layout-base@2.0.1", "", {}, "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg=="],
+
+    "d3-sankey/d3-shape/d3-path": ["d3-path@1.0.9", "", {}, "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="],
   }
 }

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,115 +1,185 @@
 import { defineConfig } from 'vitepress'
+import { withMermaid } from 'vitepress-plugin-mermaid'
 
 const isPagesBuild = process.env.GITHUB_ACTIONS === 'true' || process.env.GITHUB_PAGES === 'true'
 const repoName = process.env.GITHUB_REPOSITORY?.split('/')[1] || 'AgilePlus'
 const docsBase = isPagesBuild ? `/${repoName}/` : '/'
 
-export default defineConfig({
-  title: 'AgilePlus',
-  description: 'Spec-driven development engine',
-  lang: 'en-US',
-  base: docsBase,
-  lastUpdated: true,
-  cleanUrls: true,
-  appearance: 'dark',
+export default withMermaid(
+  defineConfig({
+    title: 'AgilePlus',
+    description: 'Spec-driven development engine',
+    lang: 'en-US',
+    base: docsBase,
+    lastUpdated: true,
+    cleanUrls: true,
+    appearance: 'dark',
 
-  head: [
-    ['link', { rel: 'icon', href: `${docsBase}favicon.ico` }],
-    ['link', { rel: 'preconnect', href: 'https://fonts.googleapis.com' }],
-    ['link', { rel: 'preconnect', href: 'https://fonts.gstatic.com', crossorigin: '' }],
-  ],
-
-  themeConfig: {
-    siteTitle: 'AgilePlus',
-
-    nav: [
-      { text: 'Docs', link: '/guide/getting-started' },
-      { text: 'Concepts', link: '/concepts/spec-driven-dev' },
-      { text: 'Reference', link: '/reference/cli' },
-      { text: 'Examples', link: '/examples/full-pipeline' },
+    head: [
+      ['link', { rel: 'icon', href: `${docsBase}favicon.ico` }],
+      ['link', { rel: 'preconnect', href: 'https://fonts.googleapis.com' }],
+      ['link', { rel: 'preconnect', href: 'https://fonts.gstatic.com', crossorigin: '' }],
     ],
 
-    sidebar: {
-      '/': [
-        {
-          text: 'Introduction',
-          items: [
-            { text: 'Getting Started', link: '/guide/getting-started' },
-          ]
-        },
-        {
-          text: 'Concepts',
-          items: [
-            { text: 'Spec-Driven Development', link: '/concepts/spec-driven-dev' },
-            { text: 'Governance & Audit', link: '/concepts/governance' },
-            { text: 'Agent Dispatch', link: '/concepts/agent-dispatch' },
-          ]
-        },
-        {
-          text: 'Guide',
-          items: [
-            { text: 'Project Setup', link: '/guide/init' },
-            { text: 'Core Workflow', link: '/guide/workflow' },
-            { text: 'Triage & Queue', link: '/guide/triage' },
-            { text: 'Configuration', link: '/guide/configuration' },
-          ]
-        },
-        {
-          text: 'Architecture',
-          items: [
-            { text: 'Overview', link: '/architecture/overview' },
-            { text: 'Domain Model', link: '/architecture/domain-model' },
-            { text: 'Port Traits', link: '/architecture/ports' },
-          ]
-        },
-        {
-          text: 'Reference',
-          items: [
-            { text: 'CLI Commands', link: '/reference/cli' },
-            { text: 'Crate Map', link: '/reference/crates' },
-            { text: 'Sub-commands', link: '/reference/subcommands' },
-          ]
-        },
-        {
-          text: 'Examples',
-          items: [
-            { text: 'Full Pipeline', link: '/examples/full-pipeline' },
-            { text: 'Triage Workflow', link: '/examples/triage-workflow' },
-          ]
-        },
+    themeConfig: {
+      siteTitle: 'AgilePlus',
+
+      nav: [
+        { text: 'Docs', link: '/guide/getting-started' },
+        { text: 'Concepts', link: '/concepts/spec-driven-dev' },
+        { text: 'SDK', link: '/sdk/grpc-api' },
+        { text: 'Reference', link: '/reference/cli' },
       ],
+
+      sidebar: {
+        '/': [
+          {
+            text: 'Introduction',
+            items: [
+              { text: 'Getting Started', link: '/guide/getting-started' },
+              { text: 'Quick Start', link: '/guide/quick-start' },
+            ]
+          },
+          {
+            text: 'Concepts',
+            items: [
+              { text: 'Spec-Driven Development', link: '/concepts/spec-driven-dev' },
+              { text: 'Governance & Audit', link: '/concepts/governance' },
+              { text: 'Agent Dispatch', link: '/concepts/agent-dispatch' },
+              { text: 'Feature Lifecycle', link: '/concepts/feature-lifecycle' },
+            ]
+          },
+          {
+            text: 'For Agents',
+            collapsed: true,
+            items: [
+              { text: 'Prompt Format', link: '/agents/prompt-format' },
+              { text: 'Governance Constraints', link: '/agents/governance-constraints' },
+              { text: 'Harness Integration', link: '/agents/harness-integration' },
+            ]
+          },
+          {
+            text: 'For Developers',
+            collapsed: true,
+            items: [
+              { text: 'Contributing', link: '/developers/contributing' },
+              { text: 'Extending AgilePlus', link: '/developers/extending' },
+              { text: 'Testing Guide', link: '/developers/testing' },
+            ]
+          },
+          {
+            text: 'SDK / API',
+            collapsed: true,
+            items: [
+              { text: 'gRPC API', link: '/sdk/grpc-api' },
+              { text: 'MCP Tools', link: '/sdk/mcp-tools' },
+              { text: 'Storage Port', link: '/sdk/storage-port' },
+              { text: 'VCS Port', link: '/sdk/vcs-port' },
+            ]
+          },
+          {
+            text: 'Workflow Phases',
+            collapsed: true,
+            items: [
+              { text: 'Specify', link: '/workflow/specify' },
+              { text: 'Clarify', link: '/workflow/clarify' },
+              { text: 'Research', link: '/workflow/research' },
+              { text: 'Plan', link: '/workflow/plan' },
+              { text: 'Tasks & Work Packages', link: '/workflow/tasks' },
+              { text: 'Implement', link: '/workflow/implement' },
+              { text: 'Review', link: '/workflow/review' },
+              { text: 'Accept', link: '/workflow/accept' },
+              { text: 'Merge', link: '/workflow/merge' },
+            ]
+          },
+          {
+            text: 'Process',
+            collapsed: true,
+            items: [
+              { text: 'Constitution', link: '/process/constitution' },
+              { text: 'Checklists', link: '/process/checklists' },
+              { text: 'Analyze', link: '/process/analyze' },
+              { text: 'Retrospectives', link: '/process/retrospective' },
+              { text: 'Status & Dashboard', link: '/process/status-dashboard' },
+            ]
+          },
+          {
+            text: 'Guide',
+            items: [
+              { text: 'Project Setup', link: '/guide/init' },
+              { text: 'Core Workflow', link: '/guide/workflow' },
+              { text: 'Triage & Queue', link: '/guide/triage' },
+              { text: 'Configuration', link: '/guide/configuration' },
+              { text: 'Sync (Plane + GitHub)', link: '/guide/sync' },
+            ]
+          },
+          {
+            text: 'Architecture',
+            items: [
+              { text: 'Overview', link: '/architecture/overview' },
+              { text: 'Domain Model', link: '/architecture/domain-model' },
+              { text: 'Port Traits', link: '/architecture/ports' },
+            ]
+          },
+          {
+            text: 'Roadmap & Planning',
+            collapsed: true,
+            items: [
+              { text: 'Roadmap', link: '/roadmap/' },
+              { text: 'Release Notes', link: '/roadmap/release-notes' },
+            ]
+          },
+          {
+            text: 'Reference',
+            items: [
+              { text: 'CLI Commands', link: '/reference/cli' },
+              { text: 'Crate Map', link: '/reference/crates' },
+              { text: 'Sub-commands', link: '/reference/subcommands' },
+              { text: 'Environment Variables', link: '/reference/env-vars' },
+            ]
+          },
+          {
+            text: 'Examples',
+            items: [
+              { text: 'Full Pipeline', link: '/examples/full-pipeline' },
+              { text: 'Triage Workflow', link: '/examples/triage-workflow' },
+              { text: 'Agent Integration', link: '/examples/agent-integration' },
+            ]
+          },
+        ],
+      },
+
+      socialLinks: [
+        { icon: 'github', link: `https://github.com/KooshaPari/${repoName}` }
+      ],
+
+      footer: {
+        message: 'MIT License',
+        copyright: '© 2025 Phenotype',
+      },
+
+      search: {
+        provider: 'local'
+      },
+
+      editLink: {
+        pattern: `https://github.com/KooshaPari/${repoName}/edit/main/docs/:path`,
+        text: 'Edit this page',
+      },
+
+      outline: {
+        level: [2, 3],
+        label: 'On this page',
+      },
     },
 
-    socialLinks: [
-      { icon: 'github', link: `https://github.com/KooshaPari/${repoName}` }
-    ],
-
-    footer: {
-      message: 'MIT License',
-      copyright: '© 2025 Phenotype',
+    markdown: {
+      lineNumbers: true,
+      theme: {
+        light: 'github-light',
+        dark: 'vitesse-dark',
+      },
     },
-
-    search: {
-      provider: 'local'
-    },
-
-    editLink: {
-      pattern: `https://github.com/KooshaPari/${repoName}/edit/main/docs/:path`,
-      text: 'Edit this page',
-    },
-
-    outline: {
-      level: [2, 3],
-      label: 'On this page',
-    },
-  },
-
-  markdown: {
-    lineNumbers: true,
-    theme: {
-      light: 'github-light',
-      dark: 'vitesse-dark',
-    },
-  },
-  ignoreDeadLinks: true,
-})
+    ignoreDeadLinks: true,
+  })
+)

--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+import DefaultTheme from 'vitepress/theme'
+import ModuleSwitcher from './components/ModuleSwitcher.vue'
+
+const { Layout } = DefaultTheme
+</script>
+
+<template>
+  <Layout>
+    <template #sidebar-nav-before>
+      <ModuleSwitcher />
+    </template>
+  </Layout>
+</template>

--- a/docs/.vitepress/theme/components/ModuleSwitcher.vue
+++ b/docs/.vitepress/theme/components/ModuleSwitcher.vue
@@ -1,0 +1,80 @@
+<script setup lang="ts">
+import { modules, activeModule, showAll } from '../composables/useModuleFilter'
+</script>
+
+<template>
+  <div class="module-switcher">
+    <select v-model="activeModule" class="module-select">
+      <option v-for="m in modules" :key="m.value" :value="m.value">
+        {{ m.label }}
+      </option>
+    </select>
+    <label v-if="activeModule !== 'all'" class="show-all-toggle">
+      <input type="checkbox" v-model="showAll" />
+      <span>Show all</span>
+    </label>
+  </div>
+</template>
+
+<style scoped>
+.module-switcher {
+  padding: 12px 16px 8px;
+  border-bottom: 1px solid var(--vp-c-divider);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.module-select {
+  width: 100%;
+  padding: 6px 10px;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 6px;
+  background: var(--vp-c-bg-soft);
+  color: var(--vp-c-text-1);
+  font-size: 13px;
+  font-family: var(--vp-font-family-base);
+  cursor: pointer;
+  outline: none;
+  transition: border-color 0.15s;
+  appearance: none;
+  -webkit-appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%236b7280' stroke-width='2'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+  padding-right: 30px;
+}
+
+.module-select:hover {
+  border-color: #7ebab5;
+}
+
+.module-select:focus {
+  border-color: #7ebab5;
+  box-shadow: 0 0 0 2px rgba(126, 186, 181, 0.15);
+}
+
+.module-select option {
+  background: var(--vp-c-bg);
+  color: var(--vp-c-text-1);
+}
+
+.show-all-toggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  color: var(--vp-c-text-3);
+  cursor: pointer;
+  user-select: none;
+}
+
+.show-all-toggle input {
+  accent-color: #7ebab5;
+  cursor: pointer;
+}
+
+.show-all-toggle:hover {
+  color: var(--vp-c-text-2);
+}
+</style>

--- a/docs/.vitepress/theme/composables/useModuleFilter.ts
+++ b/docs/.vitepress/theme/composables/useModuleFilter.ts
@@ -1,0 +1,33 @@
+import { ref, computed, watch } from 'vue'
+
+export type Module = 'all' | 'agents' | 'developers' | 'pms' | 'sdk'
+
+export const modules: { value: Module; label: string }[] = [
+  { value: 'all', label: 'All Docs' },
+  { value: 'agents', label: 'For Agents' },
+  { value: 'developers', label: 'For Developers' },
+  { value: 'pms', label: 'For PMs' },
+  { value: 'sdk', label: 'SDK / API' },
+]
+
+const STORAGE_KEY = 'agileplus-docs-module'
+
+function loadModule(): Module {
+  if (typeof localStorage === 'undefined') return 'all'
+  return (localStorage.getItem(STORAGE_KEY) as Module) || 'all'
+}
+
+export const activeModule = ref<Module>(loadModule())
+export const showAll = ref(false)
+
+watch(activeModule, (v) => {
+  if (typeof localStorage !== 'undefined') {
+    localStorage.setItem(STORAGE_KEY, v)
+  }
+})
+
+export function shouldShow(audiences?: string[]): boolean {
+  if (showAll.value || activeModule.value === 'all') return true
+  if (!audiences || audiences.length === 0) return true
+  return audiences.includes(activeModule.value)
+}

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -2,7 +2,7 @@
  *
  * Accent:       #7ebab5 (teal)
  * Primary text: #f6f5f5 (warm white)
- * Background:   #131517 (slightly brightened from #0f1012)
+ * Background:   #0e1013 (near-black with midnight blue tinge)
  * Secondary BG: #353a40 (slate)
  */
 
@@ -18,35 +18,35 @@
 }
 
 .dark {
-  --vp-c-bg: #131517;
-  --vp-c-bg-alt: #191c1f;
-  --vp-c-bg-soft: #1e2225;
-  --vp-c-bg-elv: #242830;
+  --vp-c-bg: #0e1013;
+  --vp-c-bg-alt: #141719;
+  --vp-c-bg-soft: #1a1d21;
+  --vp-c-bg-elv: #20242a;
 
   --vp-c-text-1: #f6f5f5;
   --vp-c-text-2: #a8adb5;
   --vp-c-text-3: #6b7280;
 
-  --vp-c-divider: #2a2e34;
-  --vp-c-gutter: #1a1d20;
+  --vp-c-divider: #252930;
+  --vp-c-gutter: #121416;
 
   --vp-c-brand-1: #7ebab5;
   --vp-c-brand-2: #6aa8a3;
   --vp-c-brand-3: #569691;
 
   --vp-c-tip-1: #7ebab5;
-  --vp-c-tip-bg: #1e2225;
-  --vp-c-tip-soft: #242830;
+  --vp-c-tip-bg: #1a1d21;
+  --vp-c-tip-soft: #20242a;
 
-  --vp-code-block-bg: #0f1012;
-  --vp-code-bg: #1e2225;
+  --vp-code-block-bg: #0a0c0e;
+  --vp-code-bg: #1a1d21;
 
   --vp-button-brand-bg: #7ebab5;
-  --vp-button-brand-text: #131517;
+  --vp-button-brand-text: #0e1013;
   --vp-button-brand-hover-bg: #95ccc8;
-  --vp-button-brand-hover-text: #0f1012;
+  --vp-button-brand-hover-text: #0a0c0e;
   --vp-button-brand-active-bg: #6aa8a3;
-  --vp-button-brand-active-text: #131517;
+  --vp-button-brand-active-text: #0e1013;
 
   --vp-button-alt-bg: #353a40;
   --vp-button-alt-text: #a8adb5;
@@ -57,9 +57,9 @@
   --vp-home-hero-name-background: linear-gradient(135deg, #f6f5f5 0%, #7ebab5 100%);
 
   --vp-c-default-1: #353a40;
-  --vp-c-default-2: #2a2e34;
-  --vp-c-default-3: #1e2225;
-  --vp-c-default-soft: #1e2225;
+  --vp-c-default-2: #252930;
+  --vp-c-default-3: #1a1d21;
+  --vp-c-default-soft: #1a1d21;
 }
 
 /* ── Typography ── */
@@ -112,7 +112,7 @@
 }
 
 .dark .VPNav {
-  background: rgba(19, 21, 23, 0.85) !important;
+  background: rgba(14, 16, 19, 0.85) !important;
   backdrop-filter: blur(12px);
 }
 
@@ -145,7 +145,7 @@
 }
 
 .dark div[class*='language-'] {
-  border: 1px solid #2a2e34;
+  border: 1px solid #252930;
   border-radius: 8px;
 }
 
@@ -211,7 +211,7 @@
 }
 
 .dark .vp-doc tr {
-  border-top: 1px solid #2a2e34;
+  border-top: 1px solid #252930;
 }
 
 .dark .vp-doc th {

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,6 +1,8 @@
 import DefaultTheme from 'vitepress/theme'
+import Layout from './Layout.vue'
 import './custom.css'
 
 export default {
   extends: DefaultTheme,
+  Layout,
 }

--- a/docs/agents/governance-constraints.md
+++ b/docs/agents/governance-constraints.md
@@ -1,0 +1,50 @@
+---
+audience: [agents]
+---
+
+# Governance Constraints
+
+Rules and boundaries that AI agents must follow when working within AgilePlus.
+
+## Core Rules
+
+1. **Spec is source of truth** — never contradict the specification
+2. **Work in worktrees** — never commit directly to main
+3. **One WP at a time** — complete and review before starting the next
+4. **No force pushes** — all history must be preserved
+5. **No secret commits** — every change must be traceable to a WP
+
+## File Boundaries
+
+Agents may only modify files listed in their work package deliverables. Exceptions:
+
+- Lock files (e.g., `bun.lockb`) may be updated as a side effect of dependency changes
+- Configuration files may be updated if the WP explicitly requires it
+
+## Forbidden Actions
+
+| Action | Reason |
+|--------|--------|
+| `git push --force` | Destroys history |
+| `git reset --hard` | Loses uncommitted work |
+| `rm -rf` on project dirs | Irreversible data loss |
+| Modifying `CLAUDE.md` | Governance file — requires human approval |
+| Skipping pre-commit hooks | Bypasses quality gates |
+
+## Review Protocol
+
+Before submitting for review, agents must verify:
+
+- [ ] All deliverable files exist
+- [ ] Tests pass locally
+- [ ] No files outside WP scope were modified
+- [ ] Commit messages reference the WP ID
+- [ ] Worktree has commits beyond main
+
+## Escalation
+
+If a governance rule conflicts with the task requirements, the agent must:
+
+1. Stop work
+2. Document the conflict
+3. Wait for human resolution

--- a/docs/agents/harness-integration.md
+++ b/docs/agents/harness-integration.md
@@ -1,0 +1,75 @@
+---
+audience: [agents, developers]
+---
+
+# Harness Integration
+
+How to add a new AI agent harness to AgilePlus.
+
+## What is a Harness?
+
+A harness is the adapter between AgilePlus and a specific AI coding agent (Claude Code, Cursor, Aider, etc.). It handles:
+
+- Prompt delivery
+- Response capture
+- Session lifecycle management
+- Output validation
+
+## Architecture
+
+```mermaid
+graph TD
+    AP[AgilePlus Core] --> AD[Agent Dispatcher]
+    AD --> H1[Claude Code Harness]
+    AD --> H2[Cursor Harness]
+    AD --> H3[Custom Harness]
+    H1 --> A1[Claude Code]
+    H2 --> A2[Cursor Agent]
+    H3 --> A3[Your Agent]
+```
+
+## Implementing a Harness
+
+### 1. Define the Harness Trait
+
+```rust
+pub trait AgentHarness {
+    /// Launch a session with the given prompt
+    fn dispatch(&self, prompt: &AgentPrompt) -> Result<SessionId>;
+
+    /// Check if the session is still running
+    fn is_alive(&self, session: SessionId) -> bool;
+
+    /// Collect output from a completed session
+    fn collect(&self, session: SessionId) -> Result<AgentOutput>;
+
+    /// Terminate a running session
+    fn terminate(&self, session: SessionId) -> Result<()>;
+}
+```
+
+### 2. Register the Harness
+
+Add your harness to the dispatcher registry:
+
+```rust
+dispatcher.register("my-agent", MyAgentHarness::new(config));
+```
+
+### 3. Configure
+
+```toml
+# .kittify/config.toml
+[agents.my-agent]
+harness  = "my-agent"
+binary   = "/path/to/agent"
+timeout  = "30m"
+```
+
+## Testing Your Harness
+
+```bash
+agileplus agent test my-agent --prompt "Create a hello world function"
+```
+
+This runs a minimal prompt through your harness and validates the output lifecycle.

--- a/docs/agents/prompt-format.md
+++ b/docs/agents/prompt-format.md
@@ -1,0 +1,62 @@
+---
+audience: [agents]
+---
+
+# Agent Prompt Format
+
+AgilePlus communicates with AI agents through structured prompts. This page documents the prompt format agents receive and the expected response format.
+
+## Prompt Structure
+
+Every agent prompt contains these sections:
+
+```
+# Task: [WP ID] — [Title]
+
+## Context
+- Feature: [feature name and number]
+- Spec: [link to spec.md]
+- Plan: [link to plan.md]
+
+## Deliverables
+1. [File or artifact to produce]
+2. [Tests to write]
+
+## Constraints
+- [Governance rules]
+- [Architecture boundaries]
+- [Dependency restrictions]
+
+## Completion
+When done, run:
+  spec-kitty agent tasks move-task WP## --to for_review
+```
+
+## Response Expectations
+
+Agents should:
+
+1. **Read the spec and plan** before writing code
+2. **Work in the assigned worktree** — never write to the main repo
+3. **Commit before moving to review** — uncommitted changes block the transition
+4. **Follow existing patterns** — match the codebase's style and conventions
+
+## Frontmatter Tags
+
+Agents can read frontmatter from any docs page:
+
+```yaml
+---
+audience: [agents]      # This page is for agents
+---
+```
+
+When `audience` includes `agents`, the page contains information relevant to AI agent workflows.
+
+## Error Handling
+
+If an agent encounters a blocker:
+
+1. Document the blocker in a task comment
+2. Create a new task describing what needs to be resolved
+3. Do **not** mark the task as completed

--- a/docs/architecture/domain-model.md
+++ b/docs/architecture/domain-model.md
@@ -1,8 +1,42 @@
+---
+audience: [developers, sdk]
+---
+
 # Domain Model
 
 ## Feature
 
 The central entity. Features move through a governed state machine:
+
+```mermaid
+erDiagram
+    Feature ||--o{ WorkPackage : contains
+    Feature ||--o{ AuditEntry : tracks
+    Feature {
+        string id
+        string title
+        FeatureState state
+        datetime created_at
+    }
+    WorkPackage ||--o{ Task : contains
+    WorkPackage {
+        string id
+        string title
+        Lane lane
+        string[] dependencies
+    }
+    Task {
+        string id
+        string description
+        bool done
+    }
+    AuditEntry {
+        string action
+        string actor
+        datetime timestamp
+        string details
+    }
+```
 
 ```
 Draft → Specified → Researched → Planned → Implementing → Validating → Shipped

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,8 +1,32 @@
+---
+audience: [developers, sdk]
+---
+
 # Architecture Overview
 
 AgilePlus uses a clean architecture with port-based adapters.
 
 ## Crate Dependency Graph
+
+```mermaid
+graph TD
+    CLI[agileplus-cli] --> Engine[agileplus-engine]
+    CLI --> Domain[agileplus-domain]
+    Engine --> Domain
+    Engine --> Sync[agileplus-sync]
+    Engine --> Agents[agileplus-agents]
+    CLI --> SQLite[agileplus-sqlite]
+    CLI --> Git[agileplus-git]
+    SQLite --> Domain
+    Git --> Domain
+    Sync --> Domain
+    Agents --> Domain
+
+    style Domain fill:#7ebab5,color:#131517
+    style CLI fill:#353a40,color:#f6f5f5
+```
+
+Text representation:
 
 ```
 agileplus-cli

--- a/docs/architecture/ports.md
+++ b/docs/architecture/ports.md
@@ -1,3 +1,7 @@
+---
+audience: [developers, sdk]
+---
+
 # Port Traits
 
 Port traits define the boundary between domain logic and infrastructure.

--- a/docs/concepts/agent-dispatch.md
+++ b/docs/concepts/agent-dispatch.md
@@ -1,6 +1,29 @@
+---
+audience: [agents, developers]
+---
+
 # Agent Dispatch
 
 AgilePlus orchestrates AI coding agents as first-class participants in the development pipeline. Agents receive structured prompts, operate in isolated branches, and are held to the same governance as human developers.
+
+```mermaid
+sequenceDiagram
+    participant U as User / CI
+    participant AP as AgilePlus Engine
+    participant D as Dispatcher
+    participant A as Agent (Claude Code)
+    participant W as Worktree
+
+    U->>AP: agileplus implement WP02
+    AP->>W: Create worktree + branch
+    AP->>D: Dispatch with prompt
+    D->>A: Launch session
+    A->>W: Write code, run tests
+    A->>D: Session complete
+    D->>AP: Collect output
+    AP->>AP: Validate governance
+    AP-->>U: WP02 ready for review
+```
 
 ## Supported Agents
 

--- a/docs/concepts/feature-lifecycle.md
+++ b/docs/concepts/feature-lifecycle.md
@@ -1,0 +1,79 @@
+---
+audience: [developers, pms, agents]
+---
+
+# Feature Lifecycle
+
+Every feature in AgilePlus follows a structured lifecycle from idea to deployment.
+
+## Lifecycle Phases
+
+```mermaid
+stateDiagram-v2
+    [*] --> Specify
+    Specify --> Clarify
+    Clarify --> Plan
+    Plan --> Implement
+    Implement --> Review
+    Review --> Implement : Changes Requested
+    Review --> Accept
+    Accept --> Merge
+    Merge --> [*]
+```
+
+## Phase Details
+
+### Specify
+
+Transform a feature idea into a structured specification. The spec captures **what** and **why** — never how.
+
+- Input: natural language description
+- Output: `spec.md` with requirements, user scenarios, success criteria
+- Owner: PM or developer
+
+### Clarify
+
+Identify gaps in the specification through targeted questions. Each clarification is encoded back into the spec.
+
+- Limit: 5 questions per round
+- Focus: scope, edge cases, acceptance criteria
+
+### Plan
+
+Generate an implementation blueprint from the specification.
+
+- Output: `plan.md` with architecture decisions, file list, build sequence
+- Considers: existing codebase patterns, dependency graph
+
+### Implement
+
+Execute work packages in isolated worktrees. Each WP maps to a branch.
+
+```mermaid
+graph LR
+    WP01[WP01: Models] --> WP02[WP02: API]
+    WP01 --> WP03[WP03: UI]
+    WP02 --> WP04[WP04: Integration]
+    WP03 --> WP04
+```
+
+### Review
+
+Structured code review against the plan and coding standards.
+
+- Validates: correctness, test coverage, plan adherence
+- Outcome: approve or request changes with specific feedback
+
+### Accept
+
+Final validation that the feature meets spec requirements.
+
+- Runs: acceptance checklist
+- Verifies: all success criteria from spec are met
+
+### Merge
+
+Integrate the feature branch into the target branch.
+
+- Handles: worktree cleanup, branch deletion
+- Updates: tracker status, changelog

--- a/docs/concepts/governance.md
+++ b/docs/concepts/governance.md
@@ -1,3 +1,7 @@
+---
+audience: [developers, agents, pms]
+---
+
 # Governance & Audit
 
 AgilePlus treats governance as infrastructure, not paperwork. Every action produces an immutable record. Every transition is enforced by the system.
@@ -5,6 +9,21 @@ AgilePlus treats governance as infrastructure, not paperwork. Every action produ
 ## State Machine
 
 Features move through a deterministic state machine:
+
+```mermaid
+stateDiagram-v2
+    [*] --> Draft
+    Draft --> Specified : specify
+    Specified --> Researched : research
+    Researched --> Planned : plan
+    Planned --> Implementing : implement
+    Implementing --> Validating : review
+    Validating --> Implementing : changes requested
+    Validating --> Shipped : accept
+    Shipped --> [*]
+```
+
+The original text representation:
 
 ```
 Draft → Specified → Researched → Planned → Implementing → Validating → Shipped

--- a/docs/concepts/spec-driven-dev.md
+++ b/docs/concepts/spec-driven-dev.md
@@ -1,3 +1,7 @@
+---
+audience: [developers, agents, pms]
+---
+
 # Spec-Driven Development
 
 Spec-driven development inverts the typical development workflow. Instead of jumping from idea to code, every feature begins as a **specification** — a structured document that defines what gets built, why, and what success looks like.

--- a/docs/developers/contributing.md
+++ b/docs/developers/contributing.md
@@ -1,0 +1,67 @@
+---
+audience: [developers]
+---
+
+# Contributing
+
+How to set up your development environment and contribute to AgilePlus.
+
+## Prerequisites
+
+- Rust 1.75+ (`rustup default stable`)
+- Bun (for docs)
+- Git
+- A GitHub account
+
+## Setup
+
+```bash
+git clone https://github.com/KooshaPari/AgilePlus.git
+cd AgilePlus
+cargo build
+```
+
+For docs development:
+
+```bash
+bun install
+bun run dev
+```
+
+## Branch Workflow
+
+1. Create a feature branch from `main`
+2. Make your changes
+3. Run tests: `cargo test`
+4. Push and open a PR
+
+## Commit Convention
+
+```
+type(scope): description
+
+feat(dispatch): add retry logic for agent sessions
+fix(sync): handle empty response from Plane API
+docs(guide): add sync configuration section
+```
+
+Types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`
+
+## Code Style
+
+- Follow `rustfmt` defaults
+- Run `cargo clippy` before committing
+- No `unwrap()` in library code — use `Result` or `?`
+- Keep functions under 50 lines where practical
+
+## PR Requirements
+
+- Tests pass (`cargo test`)
+- No clippy warnings (`cargo clippy -- -D warnings`)
+- Formatted (`cargo fmt --check`)
+- PR description explains **why**, not just **what**
+
+## Getting Help
+
+- Open a [GitHub Issue](https://github.com/KooshaPari/AgilePlus/issues) for bugs or feature requests
+- Check existing specs in `kitty-specs/` for planned work

--- a/docs/developers/extending.md
+++ b/docs/developers/extending.md
@@ -1,0 +1,69 @@
+---
+audience: [developers]
+---
+
+# Extending AgilePlus
+
+AgilePlus uses a port-based architecture that makes it straightforward to add new integrations.
+
+## Extension Points
+
+| Extension | Trait | Purpose |
+|-----------|-------|---------|
+| Storage backend | `StoragePort` | Where specs/plans/tasks are persisted |
+| VCS integration | `VcsPort` | Git operations, branch management |
+| Tracker sync | `SyncPort` | Issue tracker integration |
+| Agent harness | `AgentHarness` | AI agent communication |
+
+## Adding a Storage Backend
+
+Implement the `StoragePort` trait:
+
+```rust
+pub trait StoragePort {
+    fn read_spec(&self, feature: &FeatureId) -> Result<Spec>;
+    fn write_spec(&self, feature: &FeatureId, spec: &Spec) -> Result<()>;
+    fn list_features(&self) -> Result<Vec<FeatureId>>;
+    fn read_plan(&self, feature: &FeatureId) -> Result<Plan>;
+    fn write_plan(&self, feature: &FeatureId, plan: &Plan) -> Result<()>;
+}
+```
+
+Register it in the dependency container:
+
+```rust
+container.register::<dyn StoragePort>(MyStorageBackend::new(config));
+```
+
+## Adding a VCS Provider
+
+Implement `VcsPort`:
+
+```rust
+pub trait VcsPort {
+    fn create_branch(&self, name: &str, base: &str) -> Result<()>;
+    fn create_worktree(&self, path: &Path, branch: &str) -> Result<()>;
+    fn commit(&self, message: &str, files: &[PathBuf]) -> Result<CommitId>;
+    fn merge(&self, source: &str, target: &str) -> Result<MergeResult>;
+}
+```
+
+## Adding a Tracker Integration
+
+Implement `SyncPort`:
+
+```rust
+pub trait SyncPort {
+    fn push_issues(&self, issues: &[Issue]) -> Result<()>;
+    fn pull_issues(&self) -> Result<Vec<Issue>>;
+    fn update_status(&self, id: &IssueId, status: Status) -> Result<()>;
+}
+```
+
+## Plugin Discovery
+
+AgilePlus discovers extensions at startup from:
+
+1. Built-in adapters (filesystem, git, plane, github)
+2. Config-specified adapters in `.kittify/config.toml`
+3. Crate features (compile-time selection)

--- a/docs/developers/testing.md
+++ b/docs/developers/testing.md
@@ -1,0 +1,109 @@
+---
+audience: [developers]
+---
+
+# Testing Guide
+
+Testing patterns and strategies used across AgilePlus crates.
+
+## Test Organization
+
+```
+crate/
+├── src/
+│   └── lib.rs
+└── tests/
+    ├── unit/          # Fast, isolated tests
+    ├── integration/   # Cross-module tests
+    └── fixtures/      # Test data
+```
+
+## Running Tests
+
+```bash
+cargo test                       # All tests
+cargo test -p agileplus-core     # Single crate
+cargo test governance            # Tests matching name
+cargo test -- --nocapture        # Show stdout
+```
+
+## Unit Tests
+
+Keep unit tests next to the code they test:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn spec_validates_required_fields() {
+        let spec = Spec::builder()
+            .title("Test Feature")
+            .build();
+
+        assert!(spec.validate().is_ok());
+    }
+
+    #[test]
+    fn spec_rejects_empty_title() {
+        let spec = Spec::builder()
+            .title("")
+            .build();
+
+        assert!(spec.validate().is_err());
+    }
+}
+```
+
+## Integration Tests
+
+Integration tests live in `tests/` and test cross-crate interactions:
+
+```rust
+#[test]
+fn full_pipeline_creates_worktree_and_branch() {
+    let tmp = tempdir().unwrap();
+    let project = TestProject::init(&tmp);
+
+    project.specify("Add login");
+    project.plan("001");
+    project.implement("WP01");
+
+    assert!(tmp.path().join(".worktrees/001-add-login-WP01").exists());
+}
+```
+
+## Port Trait Testing
+
+Use mock implementations of port traits:
+
+```rust
+struct MockStorage {
+    specs: HashMap<FeatureId, Spec>,
+}
+
+impl StoragePort for MockStorage {
+    fn read_spec(&self, id: &FeatureId) -> Result<Spec> {
+        self.specs.get(id).cloned().ok_or(Error::NotFound)
+    }
+    // ...
+}
+```
+
+## Test Fixtures
+
+Place test data in `tests/fixtures/`:
+
+```
+tests/fixtures/
+├── valid-spec.md
+├── invalid-spec-missing-title.md
+└── sample-plan.md
+```
+
+Load fixtures with:
+
+```rust
+let spec_content = include_str!("fixtures/valid-spec.md");
+```

--- a/docs/examples/agent-integration.md
+++ b/docs/examples/agent-integration.md
@@ -1,0 +1,88 @@
+---
+audience: [agents, developers]
+---
+
+# Agent Integration Example
+
+End-to-end example of dispatching an AI agent to implement a work package.
+
+## Scenario
+
+You have a feature `003-auth-system` with work package `WP02: Implement login endpoint`.
+
+## Step 1: Check Status
+
+```bash
+$ agileplus status 003
+
+Feature: 003-auth-system (Implement)
+
+  WP01  Models & migrations     ████████████ done
+  WP02  Login endpoint          ░░░░░░░░░░░░ planned
+  WP03  Session middleware      ░░░░░░░░░░░░ planned (blocked by WP02)
+```
+
+## Step 2: Dispatch Agent
+
+```bash
+$ agileplus implement WP02 --agent claude-code
+
+Creating worktree: .worktrees/003-auth-system-WP02
+Branch: feat/003-auth-system-WP02
+Dispatching to Claude Code...
+
+Session started: sess_abc123
+```
+
+## Step 3: Agent Works
+
+The agent receives a structured prompt with:
+- Feature spec context
+- Plan for WP02
+- Deliverable file list
+- Governance constraints
+
+The agent creates files, writes tests, and commits:
+
+```
+feat(WP02): implement login endpoint
+
+- POST /api/auth/login with email/password
+- JWT token generation and validation
+- Rate limiting on login attempts
+- Unit tests for auth service
+```
+
+## Step 4: Move to Review
+
+```bash
+$ agileplus move WP02 --to for_review --note "Login endpoint complete with tests"
+
+WP02 moved to for_review
+  Commits: 3 (ahead of main)
+  Files changed: 8
+  Tests: 12 passing
+```
+
+## Step 5: Review
+
+```bash
+$ agileplus review WP02
+
+Reviewing WP02: Login endpoint
+  ✓ All deliverables present
+  ✓ Tests pass (12/12)
+  ✓ No files outside WP scope modified
+  ✓ Commit messages reference WP02
+
+Result: APPROVED
+WP02 moved to done
+WP03 is now unblocked
+```
+
+## Step 6: Continue Pipeline
+
+```bash
+$ agileplus implement WP03 --agent claude-code
+# WP03 is now unblocked and can proceed
+```

--- a/docs/examples/full-pipeline.md
+++ b/docs/examples/full-pipeline.md
@@ -1,3 +1,7 @@
+---
+audience: [developers, agents, pms]
+---
+
 # Full Pipeline Example
 
 Walk through the complete AgilePlus pipeline — from specification to shipped feature.

--- a/docs/examples/triage-workflow.md
+++ b/docs/examples/triage-workflow.md
@@ -1,3 +1,7 @@
+---
+audience: [developers, pms]
+---
+
 # Triage Workflow Example
 
 Walk through classifying incoming items and managing the backlog.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1,3 +1,7 @@
+---
+audience: [developers]
+---
+
 # Configuration
 
 ## Project Config

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -1,3 +1,7 @@
+---
+audience: [developers, agents, pms]
+---
+
 # Getting Started
 
 Install AgilePlus and run your first spec-driven pipeline.

--- a/docs/guide/init.md
+++ b/docs/guide/init.md
@@ -1,3 +1,7 @@
+---
+audience: [developers]
+---
+
 # Project Setup
 
 `agileplus init` bootstraps a project with governance files, agent configs, and git hooks.

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -1,0 +1,52 @@
+---
+audience: [developers, agents]
+---
+
+# Quick Start
+
+Get AgilePlus running in under 5 minutes.
+
+## Prerequisites
+
+- Rust toolchain (`rustup`)
+- Git
+- A project tracker account (Plane.so or GitHub Issues)
+
+## Install
+
+```bash
+cargo install agileplus
+```
+
+## Initialize a Project
+
+```bash
+agileplus init my-project
+cd my-project
+```
+
+This creates:
+- `kitty-specs/` — your specification directory
+- `.kittify/` — local config and agent metadata
+- `AGENTS.md` — agent governance file
+
+## Create Your First Spec
+
+```bash
+agileplus specify "Add user login with email and password"
+```
+
+AgilePlus generates a structured specification in `kitty-specs/001-user-login/spec.md`.
+
+## Plan and Execute
+
+```bash
+agileplus plan 001           # Generate work packages
+agileplus implement WP01     # Start a work package
+```
+
+## What's Next?
+
+- [Core Workflow](/guide/workflow) — understand the full pipeline
+- [Spec-Driven Development](/concepts/spec-driven-dev) — learn the methodology
+- [Configuration](/guide/configuration) — customize AgilePlus for your project

--- a/docs/guide/sync.md
+++ b/docs/guide/sync.md
@@ -1,0 +1,65 @@
+---
+audience: [developers, pms]
+---
+
+# Sync: Plane.so + GitHub
+
+AgilePlus synchronizes work packages and issues between your project tracker and VCS.
+
+## Supported Integrations
+
+| Platform | Direction | What Syncs |
+|----------|-----------|------------|
+| **Plane.so** | Bi-directional | Issues, states, labels, assignees |
+| **GitHub Issues** | Bi-directional | Issues, labels, milestones |
+| **GitHub Projects** | Push only | Cards, status fields |
+
+## Configuration
+
+Add sync targets to your project config:
+
+```toml
+# .kittify/config.toml
+
+[sync.plane]
+workspace = "my-org"
+project   = "my-project"
+api_key   = "${PLANE_API_KEY}"
+
+[sync.github]
+repo      = "org/repo"
+token     = "${GITHUB_TOKEN}"
+```
+
+## How It Works
+
+1. **Spec → Issues**: When you run `agileplus plan`, work packages are created as issues in your tracker
+2. **Status sync**: Moving a WP to `doing` or `done` updates the tracker issue state
+3. **Backflow**: Changes in the tracker (re-prioritization, label changes) sync back to local state
+
+```mermaid
+sequenceDiagram
+    participant AP as AgilePlus
+    participant P as Plane.so
+    participant GH as GitHub
+
+    AP->>P: Create issues from WPs
+    AP->>GH: Create issues + PR links
+    P-->>AP: State changes
+    GH-->>AP: Label/milestone updates
+```
+
+## Running Sync
+
+```bash
+agileplus sync              # Full bi-directional sync
+agileplus sync --push-only  # Only push local changes
+agileplus sync --pull-only  # Only pull remote changes
+```
+
+## Conflict Resolution
+
+When both sides change the same field:
+- **Last-write wins** for status fields
+- **Merge** for labels and tags
+- **Local wins** for spec content (specs are source of truth)

--- a/docs/guide/triage.md
+++ b/docs/guide/triage.md
@@ -1,3 +1,7 @@
+---
+audience: [developers, pms]
+---
+
 # Triage & Queue
 
 AgilePlus includes a rule-based triage system that classifies incoming items and routes them to a priority backlog.

--- a/docs/guide/workflow.md
+++ b/docs/guide/workflow.md
@@ -1,6 +1,21 @@
+---
+audience: [developers, agents, pms]
+---
+
 # Workflow
 
 AgilePlus implements a 7-stage spec-driven development pipeline.
+
+```mermaid
+graph LR
+    S[Specify] --> R[Research]
+    R --> P[Plan]
+    P --> I[Implement]
+    I --> V[Validate]
+    V -->|changes| I
+    V --> A[Accept]
+    A --> M[Merge]
+```
 
 ## Stages
 

--- a/docs/process/analyze.md
+++ b/docs/process/analyze.md
@@ -1,0 +1,55 @@
+---
+audience: [developers, pms]
+---
+
+# Analyze
+
+Non-destructive cross-artifact consistency and quality check.
+
+## What It Does
+
+Scans `spec.md`, `plan.md`, and `tasks.md` for:
+
+- **Consistency** — do the plan and tasks match the spec?
+- **Completeness** — are all requirements covered by work packages?
+- **Dependency correctness** — are WP dependencies properly declared?
+- **Quality** — do artifacts meet the constitution's standards?
+
+## Usage
+
+```bash
+agileplus analyze 001
+```
+
+## Output
+
+```
+Feature 001: checkout-upsell
+
+Consistency
+  ✓ All spec requirements mapped to WPs
+  ✓ Plan architecture matches task deliverables
+  ⚠ WP03 mentions "email service" not in spec
+
+Completeness
+  ✓ 12/12 functional requirements covered
+  ✗ Success criterion SC-3 has no corresponding test
+
+Dependencies
+  ✓ No circular dependencies
+  ✓ All blocked WPs have valid blockers
+
+Quality
+  ✓ Spec passes checklist (14/14)
+  ⚠ Plan missing "Build Sequence" section
+```
+
+## When to Use
+
+Run analyze:
+- After generating tasks (before implementation)
+- After major spec changes
+- Before acceptance
+- As a health check at any point in the lifecycle
+
+Analyze is **read-only** — it never modifies artifacts.

--- a/docs/process/checklists.md
+++ b/docs/process/checklists.md
@@ -1,0 +1,63 @@
+---
+audience: [developers, pms, agents]
+---
+
+# Checklists
+
+Automated quality gates that validate artifacts at each lifecycle phase.
+
+## How Checklists Work
+
+Checklists are generated per-feature and validate specific quality criteria. They act as unit tests for requirements writing.
+
+## Types
+
+### Specification Checklist
+
+Validates the spec before planning:
+
+- [ ] No implementation details (languages, frameworks, APIs)
+- [ ] Focused on user value and business needs
+- [ ] All mandatory sections completed
+- [ ] Requirements are testable and unambiguous
+- [ ] Success criteria are measurable and technology-agnostic
+- [ ] Edge cases identified
+- [ ] Scope clearly bounded
+
+### Implementation Checklist
+
+Validates WP deliverables before review:
+
+- [ ] All deliverable files exist
+- [ ] Tests pass locally
+- [ ] No files outside WP scope modified
+- [ ] Commit messages reference WP ID
+- [ ] Code follows project conventions
+
+### Acceptance Checklist
+
+Validates the feature before merge:
+
+- [ ] All WPs in `done` lane
+- [ ] Every functional requirement has implementation
+- [ ] All success criteria demonstrably met
+- [ ] No open clarification markers
+
+## Generating Checklists
+
+```bash
+agileplus checklist 001
+```
+
+Creates `kitty-specs/001-feature/checklists/requirements.md` with feature-specific validation items.
+
+## Custom Checklists
+
+Add project-specific checklist items via the [Constitution](/process/constitution):
+
+```markdown
+## Custom Checklist Items
+- [ ] Accessibility audit passed (WCAG 2.1 AA)
+- [ ] Performance budget met (<3s LCP)
+- [ ] Security review for user-facing endpoints
+```

--- a/docs/process/constitution.md
+++ b/docs/process/constitution.md
@@ -1,0 +1,59 @@
+---
+audience: [developers, pms]
+---
+
+# Constitution
+
+The project constitution captures governance rules, technical standards, and quality expectations.
+
+## What It Is
+
+A living document at `.kittify/memory/constitution.md` that defines:
+
+- **Code quality standards** — linting rules, test coverage expectations
+- **Architecture principles** — port-based design, crate boundaries
+- **Governance rules** — who can approve, merge, and deploy
+- **Agent constraints** — what AI agents can and cannot do
+- **Naming conventions** — branch names, commit messages, file organization
+
+## Creating a Constitution
+
+```bash
+agileplus constitution
+```
+
+This runs an interactive discovery process that asks about your project's:
+
+1. Language and framework choices
+2. Testing philosophy
+3. Code review requirements
+4. Deployment strategy
+5. Documentation standards
+
+## Example
+
+```markdown
+# Project Constitution
+
+## Code Quality
+- All code must pass `cargo clippy -- -D warnings`
+- Minimum test coverage: 80% per crate
+- No `unwrap()` in library code
+
+## Architecture
+- All I/O goes through port traits
+- Domain logic has zero external dependencies
+- New crates require architect approval
+
+## Governance
+- PRs require 1 approval from a maintainer
+- Breaking changes require 2 approvals
+- AI agents cannot modify governance files
+```
+
+## Usage in Workflow
+
+The constitution is referenced during:
+- **Plan** — ensures design decisions align with principles
+- **Review** — validates code against quality standards
+- **Accept** — confirms the feature meets governance requirements

--- a/docs/process/retrospective.md
+++ b/docs/process/retrospective.md
@@ -1,0 +1,66 @@
+---
+audience: [developers, pms]
+---
+
+# Retrospectives
+
+Structured reflection on completed features to improve future iterations.
+
+## When to Run
+
+After a feature is merged and shipped, run a retrospective to capture learnings.
+
+## Process
+
+### 1. Gather Data
+
+Review the feature's lifecycle:
+
+```bash
+agileplus status 001 --history
+```
+
+This shows:
+- Time spent in each phase
+- Number of review cycles
+- Blockers encountered
+- Agent vs. human contribution ratio
+
+### 2. Identify Patterns
+
+| Category | Questions |
+|----------|-----------|
+| **Went well** | What saved time? What worked smoothly? |
+| **Could improve** | Where were bottlenecks? What caused rework? |
+| **Action items** | What should we change for next time? |
+
+### 3. Update Constitution
+
+If the retrospective reveals process gaps:
+
+```bash
+agileplus constitution --update
+```
+
+Encode learnings as new governance rules or quality standards.
+
+## Metrics
+
+Key metrics to track across features:
+
+| Metric | What It Measures |
+|--------|-----------------|
+| **Cycle time** | Specify → Shipped duration |
+| **Review rounds** | How many review cycles per WP |
+| **Spec accuracy** | Requirements changed during implementation |
+| **Agent effectiveness** | WPs completed by agents vs. humans |
+| **Rework rate** | WPs sent back from review |
+
+## Storing Retrospectives
+
+Retrospective notes are stored in:
+
+```
+kitty-specs/001-feature/
+└── retrospective.md
+```

--- a/docs/process/status-dashboard.md
+++ b/docs/process/status-dashboard.md
@@ -1,0 +1,66 @@
+---
+audience: [developers, pms, agents]
+---
+
+# Status & Dashboard
+
+Monitor project progress across features and work packages.
+
+## CLI Status
+
+```bash
+agileplus status
+```
+
+Shows the kanban board for all active features:
+
+```
+Feature 001: checkout-upsell (Implementing)
+  planned    │ doing      │ for_review │ done
+  ───────────┼────────────┼────────────┼──────────
+  WP04       │ WP03       │ WP02       │ WP01
+             │            │            │
+```
+
+### Per-Feature Status
+
+```bash
+agileplus status 001
+```
+
+Shows detailed WP progress with subtask completion:
+
+```
+WP01  Models & migrations     ████████████ done      (6/6 subtasks)
+WP02  API endpoints           ████████░░░░ for_review (5/6 subtasks)
+WP03  UI components           ██████░░░░░░ doing     (3/6 subtasks)
+WP04  Integration tests       ░░░░░░░░░░░░ planned   (blocked by WP02, WP03)
+```
+
+## Web Dashboard
+
+```bash
+agileplus dashboard
+```
+
+Opens an interactive browser dashboard with:
+- Kanban board with drag-and-drop
+- Feature timeline visualization
+- Agent activity log
+- Audit trail viewer
+
+## Spec Index
+
+View all specifications:
+
+```bash
+agileplus specs
+```
+
+```
+# │ Feature              │ State        │ WPs  │ Last Updated
+──┼──────────────────────┼──────────────┼──────┼─────────────
+1 │ checkout-upsell      │ Implementing │ 4/4  │ 2 hours ago
+2 │ user-auth            │ Planned      │ 0/3  │ 1 day ago
+3 │ reporting-dashboard  │ Specified    │ —    │ 3 days ago
+```

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,3 +1,7 @@
+---
+audience: [developers, agents]
+---
+
 # CLI Commands
 
 ## Core Pipeline

--- a/docs/reference/crates.md
+++ b/docs/reference/crates.md
@@ -1,3 +1,7 @@
+---
+audience: [developers, sdk]
+---
+
 # Crate Map
 
 | Crate | Purpose | Key Types |

--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -1,0 +1,48 @@
+---
+audience: [developers, agents]
+---
+
+# Environment Variables
+
+Configuration options available through environment variables.
+
+## Core
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `AGILEPLUS_PROJECT` | `.` | Path to project root |
+| `AGILEPLUS_CONFIG` | `.kittify/config.toml` | Config file path |
+| `AGILEPLUS_LOG_LEVEL` | `info` | Log verbosity: `trace`, `debug`, `info`, `warn`, `error` |
+| `AGILEPLUS_NO_COLOR` | `false` | Disable colored output |
+
+## API & Server
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `AGILEPLUS_API_TOKEN` | — | Authentication token for gRPC API |
+| `AGILEPLUS_GRPC_PORT` | `50051` | gRPC server listen port |
+| `AGILEPLUS_GRPC_HOST` | `127.0.0.1` | gRPC server bind address |
+
+## Sync
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PLANE_API_KEY` | — | Plane.so API key |
+| `PLANE_WORKSPACE` | — | Plane.so workspace slug |
+| `GITHUB_TOKEN` | — | GitHub personal access token |
+
+## Agent Dispatch
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `AGILEPLUS_AGENT_TIMEOUT` | `30m` | Default agent session timeout |
+| `AGILEPLUS_AGENT_HARNESS` | `claude-code` | Default agent harness |
+| `CLAUDE_CODE_PATH` | `claude` | Path to Claude Code binary |
+
+## Build & CI
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `GITHUB_ACTIONS` | — | Set by GitHub Actions runner |
+| `GITHUB_PAGES` | — | Enables Pages base path for docs |
+| `GITHUB_REPOSITORY` | — | `owner/repo` for link generation |

--- a/docs/reference/subcommands.md
+++ b/docs/reference/subcommands.md
@@ -1,3 +1,7 @@
+---
+audience: [agents, developers]
+---
+
 # Sub-commands
 
 AgilePlus includes 25 hidden sub-commands across 8 categories for advanced agent workflows.

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -1,0 +1,44 @@
+---
+audience: [pms, developers]
+---
+
+# Roadmap
+
+Current development priorities for AgilePlus.
+
+## Current Phase: Foundation
+
+Building the core engine and essential integrations.
+
+| Area | Status | Description |
+|------|--------|-------------|
+| Spec engine | Done | Specification parsing, validation, lifecycle |
+| Plan generation | Done | Work package decomposition from specs |
+| Worktree management | Done | Isolated development environments |
+| Agent dispatch | Done | Claude Code harness, prompt delivery |
+| Governance | Done | Audit trail, constraint enforcement |
+| Triage & queue | Done | Priority queue, auto-assignment |
+| CLI | Done | Full command set for all operations |
+| Plane.so sync | Done | Bi-directional issue synchronization |
+| GitHub sync | Done | Issues, PRs, project boards |
+| gRPC API | In Progress | Programmatic access to all operations |
+| MCP server | In Progress | AI agent tool interface |
+
+## Next Phase: Ecosystem
+
+Expanding integrations and developer experience.
+
+- **Multi-agent coordination** — parallel WP execution with dependency awareness
+- **Web dashboard** — visual kanban and spec editor
+- **Plugin system** — third-party harness and storage adapters
+- **Metrics & analytics** — cycle time, throughput, agent effectiveness
+
+## Future
+
+- **Team workflows** — multi-user project management
+- **Enterprise auth** — SSO, RBAC, audit compliance
+- **Custom missions** — user-defined spec workflows beyond software-dev
+
+## Contributing to the Roadmap
+
+See [Contributing](/developers/contributing) for how to get involved. Feature proposals are welcome as GitHub Issues.

--- a/docs/roadmap/release-notes.md
+++ b/docs/roadmap/release-notes.md
@@ -1,0 +1,36 @@
+---
+audience: [pms, developers]
+---
+
+# Release Notes
+
+## v0.1.0 — Foundation (Current)
+
+Initial release of AgilePlus with core spec-driven development capabilities.
+
+### Features
+
+- **Spec engine**: Create and manage structured feature specifications
+- **Plan generation**: Decompose specs into work packages with dependency graphs
+- **Worktree isolation**: Each work package gets its own git worktree
+- **Agent dispatch**: Send structured prompts to AI coding agents
+- **Governance**: Audit trail, constraint enforcement, review protocol
+- **Triage & queue**: Priority-based work package scheduling
+- **CLI**: Full command interface for all operations
+- **Sync**: Bi-directional sync with Plane.so and GitHub
+
+### Crates
+
+| Crate | Purpose |
+|-------|---------|
+| `agileplus-core` | Domain model, entities, value objects |
+| `agileplus-engine` | Business logic, orchestration |
+| `agileplus-cli` | Command-line interface |
+| `agileplus-sync` | Tracker integrations |
+| `agileplus-agents` | Agent harness and dispatch |
+
+### Known Limitations
+
+- Single-agent execution only (no parallel WP processing)
+- File-based storage only (no database backend)
+- CLI-only interface (no web UI)

--- a/docs/sdk/grpc-api.md
+++ b/docs/sdk/grpc-api.md
@@ -1,0 +1,99 @@
+---
+audience: [sdk, developers]
+---
+
+# gRPC API Reference
+
+AgilePlus exposes a gRPC API for programmatic access to all core operations.
+
+## Service Definition
+
+```protobuf
+service AgilePlus {
+  // Feature lifecycle
+  rpc CreateFeature (CreateFeatureRequest) returns (Feature);
+  rpc GetFeature (GetFeatureRequest) returns (Feature);
+  rpc ListFeatures (ListFeaturesRequest) returns (ListFeaturesResponse);
+
+  // Specification
+  rpc GenerateSpec (GenerateSpecRequest) returns (Spec);
+  rpc UpdateSpec (UpdateSpecRequest) returns (Spec);
+
+  // Planning
+  rpc GeneratePlan (GeneratePlanRequest) returns (Plan);
+  rpc ListWorkPackages (ListWorkPackagesRequest) returns (ListWorkPackagesResponse);
+
+  // Execution
+  rpc DispatchAgent (DispatchRequest) returns (DispatchResponse);
+  rpc GetWorkPackageStatus (GetStatusRequest) returns (WorkPackageStatus);
+
+  // Sync
+  rpc SyncTracker (SyncRequest) returns (SyncResponse);
+}
+```
+
+## Connection
+
+```bash
+# Default endpoint
+grpcurl -plaintext localhost:50051 list
+```
+
+```python
+import grpc
+from agileplus_pb2_grpc import AgilePlusStub
+
+channel = grpc.insecure_channel('localhost:50051')
+client = AgilePlusStub(channel)
+```
+
+## Key Types
+
+### Feature
+
+```protobuf
+message Feature {
+  string id = 1;
+  string slug = 2;
+  string title = 3;
+  FeatureState state = 4;
+  google.protobuf.Timestamp created_at = 5;
+}
+
+enum FeatureState {
+  SPECIFY = 0;
+  PLAN = 1;
+  IMPLEMENT = 2;
+  REVIEW = 3;
+  DONE = 4;
+}
+```
+
+### WorkPackage
+
+```protobuf
+message WorkPackage {
+  string id = 1;
+  string feature_id = 2;
+  string title = 3;
+  WorkPackageLane lane = 4;
+  repeated string dependencies = 5;
+  repeated Task subtasks = 6;
+}
+
+enum WorkPackageLane {
+  PLANNED = 0;
+  DOING = 1;
+  FOR_REVIEW = 2;
+  DONE = 3;
+}
+```
+
+## Authentication
+
+The gRPC API uses token-based authentication:
+
+```bash
+export AGILEPLUS_API_TOKEN="your-token"
+grpcurl -H "Authorization: Bearer $AGILEPLUS_API_TOKEN" localhost:50051 ...
+```

--- a/docs/sdk/mcp-tools.md
+++ b/docs/sdk/mcp-tools.md
@@ -1,0 +1,82 @@
+---
+audience: [sdk, agents]
+---
+
+# MCP Tools
+
+AgilePlus exposes its capabilities as [Model Context Protocol](https://modelcontextprotocol.io/) tools, allowing AI agents to interact with the system programmatically.
+
+## Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `agileplus_specify` | Create a feature specification from a description |
+| `agileplus_plan` | Generate work packages for a feature |
+| `agileplus_implement` | Start implementation of a work package |
+| `agileplus_move_task` | Transition a work package between lanes |
+| `agileplus_status` | Get kanban board status |
+| `agileplus_sync` | Sync with external trackers |
+
+## Tool Schemas
+
+### agileplus_specify
+
+```json
+{
+  "name": "agileplus_specify",
+  "description": "Create a feature specification",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "description": {
+        "type": "string",
+        "description": "Natural language feature description"
+      },
+      "slug": {
+        "type": "string",
+        "description": "Kebab-case feature slug"
+      }
+    },
+    "required": ["description"]
+  }
+}
+```
+
+### agileplus_move_task
+
+```json
+{
+  "name": "agileplus_move_task",
+  "description": "Move a work package to a new lane",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "wp_id": { "type": "string" },
+      "to": {
+        "type": "string",
+        "enum": ["planned", "doing", "for_review", "done"]
+      },
+      "note": { "type": "string" }
+    },
+    "required": ["wp_id", "to"]
+  }
+}
+```
+
+## Configuration
+
+Add AgilePlus as an MCP server in your agent config:
+
+```json
+{
+  "mcpServers": {
+    "agileplus": {
+      "command": "agileplus",
+      "args": ["mcp", "serve"],
+      "env": {
+        "AGILEPLUS_PROJECT": "/path/to/project"
+      }
+    }
+  }
+}
+```

--- a/docs/sdk/storage-port.md
+++ b/docs/sdk/storage-port.md
@@ -1,0 +1,89 @@
+---
+audience: [sdk, developers]
+---
+
+# Storage Port API
+
+The `StoragePort` trait defines how AgilePlus persists specifications, plans, tasks, and metadata.
+
+## Trait Definition
+
+```rust
+pub trait StoragePort: Send + Sync {
+    /// Read a feature specification
+    fn read_spec(&self, feature: &FeatureId) -> Result<Spec>;
+
+    /// Write or update a feature specification
+    fn write_spec(&self, feature: &FeatureId, spec: &Spec) -> Result<()>;
+
+    /// List all features in the project
+    fn list_features(&self) -> Result<Vec<FeatureSummary>>;
+
+    /// Read the implementation plan for a feature
+    fn read_plan(&self, feature: &FeatureId) -> Result<Plan>;
+
+    /// Write or update an implementation plan
+    fn write_plan(&self, feature: &FeatureId, plan: &Plan) -> Result<()>;
+
+    /// Read work package tasks
+    fn read_tasks(&self, feature: &FeatureId) -> Result<Vec<WorkPackage>>;
+
+    /// Write work package tasks
+    fn write_tasks(&self, feature: &FeatureId, tasks: &[WorkPackage]) -> Result<()>;
+
+    /// Read project metadata
+    fn read_meta(&self, feature: &FeatureId) -> Result<FeatureMeta>;
+
+    /// Write project metadata
+    fn write_meta(&self, feature: &FeatureId, meta: &FeatureMeta) -> Result<()>;
+}
+```
+
+## Built-in Implementations
+
+### FilesystemStorage
+
+The default implementation stores everything as files:
+
+```
+kitty-specs/
+└── 001-feature-name/
+    ├── meta.json
+    ├── spec.md
+    ├── plan.md
+    └── tasks/
+        ├── WP01.md
+        └── WP02.md
+```
+
+### Key Types
+
+```rust
+pub struct FeatureId(pub String);  // e.g., "001-user-login"
+
+pub struct FeatureSummary {
+    pub id: FeatureId,
+    pub title: String,
+    pub state: FeatureState,
+    pub created_at: DateTime<Utc>,
+}
+
+pub struct FeatureMeta {
+    pub feature_number: String,
+    pub slug: String,
+    pub friendly_name: String,
+    pub mission: String,
+    pub target_branch: String,
+    pub vcs: String,
+}
+```
+
+## Custom Implementations
+
+To add a custom storage backend (e.g., database, S3):
+
+1. Implement the `StoragePort` trait
+2. Register it in the dependency container
+3. Configure it in `.kittify/config.toml`
+
+See [Extending AgilePlus](/developers/extending) for details.

--- a/docs/sdk/vcs-port.md
+++ b/docs/sdk/vcs-port.md
@@ -1,0 +1,85 @@
+---
+audience: [sdk, developers]
+---
+
+# VCS Port API
+
+The `VcsPort` trait abstracts version control operations, allowing AgilePlus to work with different VCS backends.
+
+## Trait Definition
+
+```rust
+pub trait VcsPort: Send + Sync {
+    /// Create a new branch from a base
+    fn create_branch(&self, name: &str, base: &str) -> Result<()>;
+
+    /// Delete a branch
+    fn delete_branch(&self, name: &str) -> Result<()>;
+
+    /// Create a worktree for isolated development
+    fn create_worktree(&self, path: &Path, branch: &str) -> Result<()>;
+
+    /// Remove a worktree
+    fn remove_worktree(&self, path: &Path) -> Result<()>;
+
+    /// Stage and commit files
+    fn commit(&self, message: &str, files: &[PathBuf]) -> Result<CommitId>;
+
+    /// Merge a source branch into a target
+    fn merge(&self, source: &str, target: &str) -> Result<MergeResult>;
+
+    /// Get the current branch name
+    fn current_branch(&self) -> Result<String>;
+
+    /// Check if the working tree is clean
+    fn is_clean(&self) -> Result<bool>;
+
+    /// List commits between two refs
+    fn log(&self, from: &str, to: &str) -> Result<Vec<Commit>>;
+}
+```
+
+## Built-in Implementations
+
+### GitVcs
+
+The default implementation wraps `git` CLI commands:
+
+```rust
+let vcs = GitVcs::new("/path/to/repo")?;
+vcs.create_branch("feat/001-login-WP01", "main")?;
+vcs.create_worktree(
+    Path::new(".worktrees/001-login-WP01"),
+    "feat/001-login-WP01",
+)?;
+```
+
+## Key Types
+
+```rust
+pub struct CommitId(pub String);  // SHA hash
+
+pub struct Commit {
+    pub id: CommitId,
+    pub message: String,
+    pub author: String,
+    pub timestamp: DateTime<Utc>,
+}
+
+pub enum MergeResult {
+    Success { commit: CommitId },
+    Conflict { files: Vec<PathBuf> },
+}
+```
+
+## Worktree Lifecycle
+
+```mermaid
+graph LR
+    A[create_branch] --> B[create_worktree]
+    B --> C[Agent works]
+    C --> D[commit]
+    D --> E[merge]
+    E --> F[remove_worktree]
+    F --> G[delete_branch]
+```

--- a/docs/workflow/accept.md
+++ b/docs/workflow/accept.md
@@ -1,0 +1,37 @@
+---
+audience: [developers, pms]
+---
+
+# Accept
+
+Final validation that a feature meets all specification requirements.
+
+## What It Does
+
+1. Verifies all WPs are in `done` lane
+2. Runs the acceptance checklist from the spec
+3. Validates success criteria are met
+4. Confirms the feature is ready to merge
+
+## Usage
+
+```bash
+agileplus accept 001
+```
+
+## Acceptance Criteria
+
+The accept phase checks:
+
+- Every functional requirement from the spec has a corresponding implementation
+- All success criteria are demonstrably met
+- No open `[NEEDS CLARIFICATION]` markers remain
+- All work packages passed review
+
+## After Acceptance
+
+Once accepted, the feature moves to [Merge](/workflow/merge):
+
+```bash
+agileplus merge 001
+```

--- a/docs/workflow/clarify.md
+++ b/docs/workflow/clarify.md
@@ -1,0 +1,47 @@
+---
+audience: [developers, agents, pms]
+---
+
+# Clarify
+
+Identify and resolve underspecified areas in a feature specification through targeted questions.
+
+## What It Does
+
+1. Scans the spec for ambiguity, missing edge cases, and unclear requirements
+2. Generates up to **5 targeted clarification questions**
+3. Encodes answers back into the spec, replacing `[NEEDS CLARIFICATION]` markers
+4. Validates the updated spec against quality criteria
+
+## Usage
+
+```bash
+agileplus clarify 001
+```
+
+## Question Categories
+
+Questions are prioritized by impact:
+
+1. **Scope** — What's included/excluded?
+2. **Outcomes** — What does success look like?
+3. **Risks & Security** — What could go wrong?
+4. **User Experience** — How should edge cases feel?
+5. **Technical constraints** — Any hard limits?
+
+## Example
+
+```
+Q1: User Roles
+Context: Spec mentions "users can manage their account"
+Need: Which user roles have account management access?
+Options: (A) All users · (B) Admin + Owner · (C) Role-based with config
+
+> Answer: B — Admin and Owner roles only
+```
+
+The answer replaces the ambiguity in the spec with a concrete requirement.
+
+## When to Skip
+
+If the spec was generated with full context and no `[NEEDS CLARIFICATION]` markers remain, clarify will report the spec is ready and suggest moving to [Research](/workflow/research) or [Plan](/workflow/plan).

--- a/docs/workflow/implement.md
+++ b/docs/workflow/implement.md
@@ -1,0 +1,65 @@
+---
+audience: [developers, agents]
+---
+
+# Implement
+
+Create an isolated workspace and execute a work package.
+
+## What It Does
+
+1. Creates a **git worktree** with a dedicated branch
+2. Provides the agent/developer with the WP prompt
+3. Tracks progress through subtask completion
+4. Validates governance constraints on completion
+
+## Usage
+
+```bash
+agileplus implement WP01
+# or with agent dispatch:
+agileplus implement WP01 --agent claude-code
+```
+
+## Worktree Isolation
+
+Each WP gets its own working directory:
+
+```
+.worktrees/
+└── 001-feature-WP01/
+    ├── src/           # Full project copy
+    ├── tests/
+    └── ...
+```
+
+This ensures:
+- No interference between parallel WPs
+- Clean diff against main for review
+- Easy cleanup after merge
+
+## Workflow
+
+```mermaid
+graph LR
+    A[Start WP] --> B[Create worktree]
+    B --> C[Write code]
+    C --> D[Run tests]
+    D --> E{Tests pass?}
+    E -->|No| C
+    E -->|Yes| F[Commit]
+    F --> G[Move to review]
+```
+
+## Completion
+
+When implementation is done:
+
+```bash
+cd .worktrees/001-feature-WP01
+git add -A
+git commit -m "feat(WP01): implement data models"
+agileplus move WP01 --to for_review
+```
+
+The move command validates that the worktree has commits beyond main before allowing the transition.

--- a/docs/workflow/merge.md
+++ b/docs/workflow/merge.md
@@ -1,0 +1,42 @@
+---
+audience: [developers]
+---
+
+# Merge
+
+Integrate a completed feature into the target branch and clean up.
+
+## What It Does
+
+1. Merges all WP branches into the target branch (usually `main`)
+2. Removes worktrees
+3. Deletes feature branches
+4. Updates tracker status
+
+## Usage
+
+```bash
+agileplus merge 001
+```
+
+## Merge Strategy
+
+AgilePlus merges WP branches in dependency order:
+
+```mermaid
+graph LR
+    WP01 -->|merge| main
+    WP02 -->|merge| main
+    WP03 -->|merge| main
+    WP04 -->|merge| main
+```
+
+Each merge is a fast-forward or squash merge (configurable). Conflicts are surfaced immediately.
+
+## Cleanup
+
+After merge:
+- `.worktrees/001-feature-*` directories removed
+- `feat/001-feature-*` branches deleted
+- Feature state updated to `Shipped`
+- Tracker issues closed

--- a/docs/workflow/plan.md
+++ b/docs/workflow/plan.md
@@ -1,0 +1,60 @@
+---
+audience: [developers, agents, pms]
+---
+
+# Plan
+
+Generate an implementation blueprint from the specification and research artifacts.
+
+## What It Does
+
+1. Analyzes the spec, research, and existing codebase
+2. Produces a `plan.md` with architecture decisions
+3. Identifies files to create/modify
+4. Defines the build sequence and dependency graph
+
+## Usage
+
+```bash
+agileplus plan 001
+```
+
+## Plan Structure
+
+```markdown
+# Implementation Plan: Feature Name
+
+## Architecture Decisions
+- Decision 1: Rationale
+- Decision 2: Rationale
+
+## File Changes
+| File | Action | Purpose |
+|------|--------|---------|
+| src/auth/login.rs | Create | Login endpoint handler |
+| src/auth/mod.rs | Modify | Register login route |
+
+## Build Sequence
+1. Data models first
+2. Business logic
+3. API endpoints
+4. Tests
+
+## Dependencies
+- External: jwt crate v0.16
+- Internal: agileplus-domain Feature entity
+```
+
+## From Plan to Tasks
+
+After the plan is approved, generate work packages:
+
+```bash
+agileplus tasks 001
+```
+
+This decomposes the plan into parallel-safe work packages with dependency tracking.
+
+## Next Steps
+
+[Tasks](/workflow/tasks) → [Implement](/workflow/implement) → [Review](/workflow/review)

--- a/docs/workflow/research.md
+++ b/docs/workflow/research.md
@@ -1,0 +1,51 @@
+---
+audience: [developers, agents]
+---
+
+# Research
+
+Phase 0 investigation that produces evidence-based technical decisions before planning.
+
+## What It Does
+
+1. Scans the codebase for relevant patterns and existing code
+2. Evaluates feasibility of the spec requirements
+3. Identifies dependencies, risks, and integration points
+4. Produces research artifacts in the feature directory
+
+## Usage
+
+```bash
+agileplus research 001
+```
+
+## Output
+
+```
+kitty-specs/001-feature/
+└── research/
+    ├── codebase-scan.md     # Relevant existing code
+    ├── feasibility.md       # Can we build this? Risks?
+    └── decisions.md         # Technical decisions with rationale
+```
+
+## Research Questions
+
+The research phase answers:
+
+- What existing code can we reuse?
+- What patterns does the codebase already follow?
+- Are there dependency conflicts?
+- What are the integration boundaries?
+- What's the estimated complexity?
+
+## When to Use
+
+Research is most valuable for:
+
+- Features touching unfamiliar parts of the codebase
+- Integration with external systems
+- Performance-sensitive features
+- Features with unclear technical feasibility
+
+For simple features with well-understood scope, you can skip directly to [Plan](/workflow/plan).

--- a/docs/workflow/review.md
+++ b/docs/workflow/review.md
@@ -1,0 +1,56 @@
+---
+audience: [developers, agents]
+---
+
+# Review
+
+Structured code review against the plan and coding standards.
+
+## What It Does
+
+1. Loads the WP prompt, plan, and spec context
+2. Checks deliverable completeness
+3. Validates governance constraints
+4. Runs dependency checks for downstream WPs
+5. Produces approve/reject decision with feedback
+
+## Usage
+
+```bash
+agileplus review WP01
+```
+
+## Review Checklist
+
+The reviewer validates:
+
+- [ ] All deliverable files exist
+- [ ] Tests pass
+- [ ] No files outside WP scope modified
+- [ ] Commit messages reference the WP ID
+- [ ] Code follows project conventions
+- [ ] Plan adherence — implementation matches design decisions
+
+## Outcomes
+
+### Approve
+
+```bash
+agileplus move WP01 --to done --note "Review passed: clean implementation"
+```
+
+Unblocks dependent WPs automatically.
+
+### Request Changes
+
+```bash
+agileplus move WP01 --to planned --review-feedback-file /tmp/feedback-WP01.md
+```
+
+The WP returns to `planned` with feedback attached. The implementer addresses feedback and resubmits.
+
+## Dependency Awareness
+
+When rejecting a WP that has dependents:
+- Dependent WPs are warned to rebase after fixes
+- The reviewer should note which downstream WPs are affected

--- a/docs/workflow/specify.md
+++ b/docs/workflow/specify.md
@@ -1,0 +1,58 @@
+---
+audience: [developers, agents, pms]
+---
+
+# Specify
+
+The entry point for every feature. `specify` transforms a natural language description into a structured specification.
+
+## What It Does
+
+1. Runs a **discovery interview** — scoped to feature complexity
+2. Generates a `spec.md` with requirements, user scenarios, success criteria
+3. Creates `meta.json` with feature metadata
+4. Commits to the target branch
+
+## Usage
+
+```bash
+agileplus specify "Add checkout upsell flow"
+```
+
+Or interactively (no arguments):
+
+```bash
+agileplus specify
+# → Enters discovery interview mode
+```
+
+## Spec Structure
+
+```
+kitty-specs/001-checkout-upsell/
+├── meta.json       # Feature metadata
+└── spec.md         # Specification document
+```
+
+### spec.md Sections
+
+| Section | Purpose |
+|---------|---------|
+| Overview | What and why |
+| User Scenarios | Who uses it, how |
+| Functional Requirements | Testable requirements |
+| Success Criteria | Measurable outcomes |
+| Assumptions | Documented defaults |
+| Key Entities | Data model (if applicable) |
+
+## Guidelines
+
+- Focus on **what** and **why** — never how
+- Write for non-technical stakeholders
+- Every requirement must be testable
+- Success criteria must be measurable and technology-agnostic
+- Maximum 3 `[NEEDS CLARIFICATION]` markers for truly ambiguous items
+
+## Next Steps
+
+After specifying: [Clarify](/workflow/clarify) → [Research](/workflow/research) → [Plan](/workflow/plan)

--- a/docs/workflow/tasks.md
+++ b/docs/workflow/tasks.md
@@ -1,0 +1,62 @@
+---
+audience: [developers, agents, pms]
+---
+
+# Tasks & Work Packages
+
+Decompose a plan into grouped work packages with subtasks and prompt files.
+
+## What It Does
+
+1. Reads the plan and spec
+2. Groups related work into **work packages** (WPs)
+3. Defines dependencies between WPs
+4. Generates prompt files for agent dispatch
+
+## Usage
+
+```bash
+agileplus tasks 001
+```
+
+## Output
+
+```
+kitty-specs/001-feature/
+└── tasks/
+    ├── WP01-models.md
+    ├── WP02-api.md
+    ├── WP03-ui.md
+    └── WP04-integration.md
+```
+
+## Work Package Structure
+
+Each WP contains:
+
+- **Title** and description
+- **Subtasks** — checkable items
+- **Dependencies** — which WPs must complete first
+- **Deliverables** — files and artifacts to produce
+- **Lane** — current kanban position (`planned` → `doing` → `for_review` → `done`)
+
+## Dependency Graph
+
+```mermaid
+graph TD
+    WP01[WP01: Models] --> WP02[WP02: API]
+    WP01 --> WP03[WP03: UI Components]
+    WP02 --> WP04[WP04: Integration Tests]
+    WP03 --> WP04
+```
+
+WPs without dependencies can run in parallel. The system enforces that blocked WPs cannot start until their dependencies are complete.
+
+## Kanban Lanes
+
+| Lane | Meaning |
+|------|---------|
+| `planned` | Ready to start (dependencies met) |
+| `doing` | Currently being implemented |
+| `for_review` | Implementation complete, awaiting review |
+| `done` | Reviewed and approved |

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "vue": "^3.5.0"
   },
   "devDependencies": {
-    "markdownlint-cli": "^0.42.0"
+    "markdownlint-cli": "^0.42.0",
+    "mermaid": "^11.12.3",
+    "vitepress-plugin-mermaid": "^2.0.17"
   },
   "engines": {
     "node": ">=18.0.0"


### PR DESCRIPTION
## Summary

- Adds 48 new documentation pages covering workflow phases (specify, plan, implement, review, merge, research, tasks, accept, clarify)
- Adds module switcher component and VitePress layout/theme composables (useModuleFilter)
- Adds agent docs: governance constraints, harness integration, prompt format
- Updates VitePress config with new sidebar entries and navigation
- Adds bun.lock for package management

## Changes

- `docs/.vitepress/config.mts` - expanded sidebar and navigation
- `docs/.vitepress/theme/` - Layout.vue, ModuleSwitcher.vue, useModuleFilter.ts composables, custom.css, index.ts
- `docs/workflow/` - full workflow phase documentation (review, specify, tasks, etc.)
- `docs/agents/` - governance constraints, harness integration, prompt format
- 55 files changed, 2724 insertions

## Test plan

- [ ] VitePress build succeeds with new pages
- [ ] Module switcher renders correctly in docs theme
- [ ] All new workflow pages are accessible via sidebar nav