### PR TITLE
feat(ui): improve lightbox and media card hover styling

### DIFF
--- a/templates/pages/feature-detail.html
+++ b/templates/pages/feature-detail.html
@@ -17,11 +17,15 @@
       <div class="lightbox-body">
         <img :src="mediaUrl" alt="" />
       </div>
-      <button type="button" class="lightbox-close" @click="closeMedia()" aria-label="Close lightbox">
-        <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
-        </svg>
-      </button>
+      <div class="lightbox-footer">
+        <span class="lightbox-footer-filename" x-text="mediaTitle"></span>
+        <button type="button" class="lightbox-close" @click="closeMedia()" aria-label="Close lightbox">
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+          </svg>
+          Close
+        </button>
+      </div>
     </div>
   </div>
 

--- a/templates/partials/feature-media.html
+++ b/templates/partials/feature-media.html
@@ -6,6 +6,7 @@
               data-media-url="{{ media.url_or_path }}"
               data-media-title="{{ media.name }}"
               @click="openMedia($event)"
+              title="{{ media.name }} ({{ media.kind }})"
               aria-label="Open {{ media.name }}">
         <img src="{{ media.url_or_path }}"
              alt="{{ media.name }}"
@@ -14,7 +15,8 @@
         <div class="media-card-button-overlay">
           <div class="media-card-button-label">
             <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0zM13 10H7"/>
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/>
             </svg>
             View
           </div>

--- a/templates/static/style.css
+++ b/templates/static/style.css
@@ -473,6 +473,11 @@ th, td  { vertical-align: top; }
   align-items: center;
   justify-content: center;
   padding: 0.75rem;
+  transition: opacity 0.2s ease;
+}
+
+.lightbox-overlay[x-cloak] {
+  display: none;
 }
 
 .lightbox-content {
@@ -512,34 +517,54 @@ th, td  { vertical-align: top; }
   object-fit: contain;
 }
 
-.lightbox-close {
-  position: absolute;
-  top: 0.5rem;
-  right: 0.5rem;
-  z-index: 10;
-  width: 2.5rem;
-  height: 2.5rem;
-  border-radius: 50%;
-  background: linear-gradient(135deg, #3f3f46 0%, #27272a 100%);
-  border: 1px solid var(--color-border);
-  color: var(--color-text);
-  cursor: pointer;
+.lightbox-footer {
   display: flex;
   align-items: center;
-  justify-content: center;
-  font-weight: bold;
+  justify-content: space-between;
+  padding: 0.625rem 1rem;
+  border-top: 1px solid var(--color-border);
+  background-color: var(--color-bg);
+  gap: 0.75rem;
+}
+
+.lightbox-footer-filename {
+  font-size: 0.75rem;
+  color: var(--color-text-muted, #a1a1aa);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
+  min-width: 0;
+}
+
+.lightbox-close {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.375rem 0.875rem;
+  border-radius: 9999px;
+  background: rgba(63, 63, 70, 0.7);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  border: 1px solid var(--color-border);
+  color: var(--color-text);
+  font-size: 0.75rem;
+  font-weight: 500;
+  cursor: pointer;
   transition: all 0.2s ease;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
+  white-space: nowrap;
+  flex-shrink: 0;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
 }
 
 .lightbox-close:hover {
-  background: linear-gradient(135deg, #52525b 0%, #3f3f46 100%);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.6);
-  transform: scale(1.1);
+  background: rgba(82, 82, 91, 0.85);
+  border-color: var(--color-accent, #3b82f6);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.5);
 }
 
 .lightbox-close:active {
-  transform: scale(0.95);
+  transform: scale(0.96);
 }
 
 /* ── T084: Hover-to-expand previews ────────────────────────────── */
@@ -609,16 +634,26 @@ th, td  { vertical-align: top; }
 .media-card-button-label {
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.5rem 1rem;
-  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
+  gap: 0.4rem;
+  padding: 0.4rem 1rem;
+  background: rgba(15, 15, 20, 0.65);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
   color: white;
-  border-radius: 0.375rem;
+  border-radius: 9999px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
   font-size: 0.75rem;
   font-weight: 500;
-  box-shadow: 0 2px 8px rgba(59, 130, 246, 0.3);
+  letter-spacing: 0.02em;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(59, 130, 246, 0.2);
   white-space: nowrap;
   z-index: 10;
+  transition: background 0.15s ease, box-shadow 0.15s ease;
+}
+
+.media-card-button:hover .media-card-button-label {
+  background: rgba(30, 30, 40, 0.8);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.5), 0 0 0 1px rgba(59, 130, 246, 0.45);
 }
 
 .media-card-info {


### PR DESCRIPTION
## Summary

- **Lightbox footer bar**: replaced the top-right circle close button with a bottom `lightbox-footer` bar containing the filename/title on the left and a pill-shaped "Close" button (icon + text, backdrop-blur frosted glass) on the right
- **Lightbox overlay transition**: added `transition: opacity 0.2s ease` and `[x-cloak] { display: none }` so Alpine.js `x-transition` works correctly on enter and exit
- **Media card "View" pill**: upgraded from a flat blue rectangle to a frosted-glass pill with `backdrop-filter: blur`, subtle white border ring, blue accent ring glow, and animated shadow on hover
- **View icon**: switched from magnifying-glass to eye (visibility) icon — more accurate for "preview this asset"
- **Tooltip**: added `title="{{ media.name }} ({{ media.kind }})"` on the card button so browsers show filename/type on hover

## Test plan

- [ ] Open a feature detail page with media assets
- [ ] Hover a media card — overlay fades in, frosted-glass "View" pill appears centered
- [ ] Click a card — lightbox opens with fade transition
- [ ] Verify footer bar shows filename on left, Close pill on right
- [ ] Click Close pill or press Escape — lightbox fades out cleanly
- [ ] Hover the Close pill — border brightens to accent blue, no layout shift

🤖 Generated with [Claude Code](https://claude.com/claude-code)