### PR TITLE
fix(dashboard): populate event timeline links from WorkPackage data

### DIFF
--- a/crates/agileplus-dashboard/src/routes.rs
+++ b/crates/agileplus-dashboard/src/routes.rs
@@ -295,31 +295,55 @@ fn build_feature_events(
             ),
         });
 
-        for (i, wp) in workpackages.iter().enumerate() {
+        for wp in workpackages {
+            // agent_link: route to agent detail page when an agent_id is present.
+            let agent_link = wp
+                .agent_id
+                .as_deref()
+                .map(|aid| format!("/api/dashboard/agents/{aid}"));
+
+            // wp_link: slug-based URL to the work package detail anchor.
+            let wp_link = Some(format!(
+                "/features/{}/work-packages/{}",
+                feature.slug, wp.id
+            ));
+
+            // commit_link: GitHub commit URL when a head commit SHA is present.
+            let (commit_sha, commit_link) = match &wp.head_commit {
+                Some(sha) => (
+                    Some(sha.clone()),
+                    Some(format!(
+                        "https://github.com/KooshaPari/AgilePlus/commit/{sha}"
+                    )),
+                ),
+                None => (None, None),
+            };
+
+            // ci_run_link: derive from pr_url when it is a GitHub PR URL by
+            // redirecting to the Actions tab for that repository.
+            let ci_run_link = wp.pr_url.as_deref().and_then(|url| {
+                // pr_url is typically https://github.com/{owner}/{repo}/pull/{n}
+                // Strip the `/pull/{n}` suffix and append `/actions` for the runs view.
+                let prefix = url
+                    .split("/pull/")
+                    .next()
+                    .filter(|p| p.starts_with("https://github.com/"))?;
+                Some(format!("{prefix}/actions"))
+            });
+
             events.push(crate::templates::EventView {
                 id: format!("evt-feature-{}-wp-{}", feature.id, wp.id),
                 kind: "state_change".into(),
                 description: format!("Work-package {} is in state '{}'", wp.title, wp.state),
                 timestamp: now.clone(),
-                agent_name: Some(format!("worker-agent-{}", i % 3)),
-                agent_link: Some(format!("/agents/worker-agent-{}", i % 3)),
+                agent_name: wp.agent_id.clone(),
+                agent_link,
                 wp_id: Some(wp.id.to_string()),
-                wp_link: Some(format!("/features/{}#wp-{}", feature.id, wp.id)),
-                commit_sha: if i % 2 == 0 {
-                    Some(format!("abc{:04}", i))
-                } else {
-                    None
-                },
-                commit_link: if i % 2 == 0 {
-                    Some(format!(
-                        "https://github.com/Phenotype/AgilePlus/commit/abc{:04}",
-                        i
-                    ))
-                } else {
-                    None
-                },
+                wp_link,
+                commit_sha,
+                commit_link,
                 ci_run_id: None,
-                ci_run_link: None,
+                ci_run_link,
             });
         }
     } else {

--- a/crates/agileplus-dashboard/src/templates.rs
+++ b/crates/agileplus-dashboard/src/templates.rs
@@ -39,6 +39,12 @@ pub struct WpView {
     pub agent: String,
     pub progress: u8,
     pub task_count: usize,
+    /// Raw agent identifier, used to build agent deep-links.
+    pub agent_id: Option<String>,
+    /// GitHub PR URL when a PR has been submitted for this work package.
+    pub pr_url: Option<String>,
+    /// Most recent commit SHA on the work package branch.
+    pub head_commit: Option<String>,
 }
 
 impl WpView {
@@ -50,6 +56,9 @@ impl WpView {
             agent: wp.agent_id.clone().unwrap_or_else(|| "—".into()),
             progress: 0,
             task_count: 0,
+            agent_id: wp.agent_id.clone(),
+            pr_url: wp.pr_url.clone(),
+            head_commit: wp.head_commit.clone(),
         }
     }
 }


### PR DESCRIPTION
## Summary
- Adds `agent_id`, `pr_url`, `head_commit` fields to `WpView` struct
- Populates `agent_link`, `wp_link`, `commit_link`, `ci_run_link` in `build_feature_events`
- Timeline events now link to agent endpoint, feature WP page, GitHub commit, and CI runs

## Test plan
- [ ] Build: `cargo check` passes with 0 errors
- [ ] Timeline events show populated links when WP has agent_id / pr_url / head_commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)