### PR TITLE
fix(dashboard): resolve all Rust compiler errors in agileplus-dashboard

### DIFF
--- a/crates/agileplus-dashboard/src/routes.rs
+++ b/crates/agileplus-dashboard/src/routes.rs
@@ -132,6 +132,13 @@ pub struct ServiceSettingsForm {
     pub endpoint_urls: Vec<String>,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct DashboardSettingsForm {
+    pub theme: String,
+    pub log_level: String,
+    pub data_directory: String,
+}
+
 /// Returns `true` if the `HX-Request` header is present and truthy.
 fn is_htmx(headers: &HeaderMap) -> bool {
     headers

--- a/templates/partials/feature-media.html
+++ b/templates/partials/feature-media.html
@@ -11,9 +11,12 @@
     <div class="media-card-image-container aspect-video relative overflow-hidden">
       <button type="button"
               class="w-full h-full block group-hover:scale-105 transition-transform duration-300"
-              @click="openMedia('{{ media.url_or_path }}', '{{ media.name }}', '{{ media.kind == 'video' ? 'video' : 'image' }}')"
+              data-media-src="{{ media.url_or_path }}"
+              data-media-name="{{ media.name }}"
+              data-media-type="{{ media.kind }}"
+              @click="openMedia($el.dataset.mediaSrc, $el.dataset.mediaName, $el.dataset.mediaType)"
               aria-label="Open {{ media.name }}">
-        {% if media.kind == 'video' %}
+        {% if media.kind == "video" %}
           <div class="absolute inset-0 flex items-center justify-center bg-black/40 z-10 group-hover:bg-black/20 transition-colors">
             <svg xmlns="http://www.w3.org/2000/svg" class="w-12 h-12 text-white/80 group-hover:text-white transition-all transform group-hover:scale-110" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z" />
@@ -47,7 +50,7 @@
         <span class="text-zinc-700">•</span>
         <span>
           {% if media.size_bytes > 0 %}
-            {{ (media.size_bytes / 1024) | round(1) }} KB
+            {{ media.size_bytes / 1024 }} KB
           {% else %}
             Size unknown
           {% endif %}


### PR DESCRIPTION
## Summary
- Add missing `DashboardSettingsForm` struct with `theme`, `log_level`, and `data_directory` fields
- Fix Askama template syntax: replace single-quoted string comparisons with double-quoted in `feature-media.html`
- Fix invalid ternary expression `{{ kind == 'video' ? 'video' : 'image' }}` by using Alpine.js `$el.dataset` data-attributes instead
- Fix size display expression: remove unsupported `|round(1)` Askama filter, use integer division

## Test plan
- [x] `cargo check` passes with 0 errors and 0 warnings
- [x] All 4 previous compiler errors resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)