### PR TITLE
fix(dashboard): resolve Askama template syntax and missing type errors

### DIFF
--- a/crates/agileplus-dashboard/src/routes.rs
+++ b/crates/agileplus-dashboard/src/routes.rs
@@ -132,6 +132,13 @@ pub struct ServiceSettingsForm {
     pub endpoint_urls: Vec<String>,
 }
 
+#[derive(serde::Deserialize)]
+pub struct DashboardSettingsForm {
+    pub theme: String,
+    pub log_level: String,
+    pub data_directory: String,
+}
+
 /// Returns `true` if the `HX-Request` header is present and truthy.
 fn is_htmx(headers: &HeaderMap) -> bool {
     headers

--- a/templates/partials/feature-media.html
+++ b/templates/partials/feature-media.html
@@ -11,9 +11,9 @@
     <div class="media-card-image-container aspect-video relative overflow-hidden">
       <button type="button"
               class="w-full h-full block group-hover:scale-105 transition-transform duration-300"
-              @click="openMedia('{{ media.url_or_path }}', '{{ media.name }}', '{{ media.kind == 'video' ? 'video' : 'image' }}')"
+              @click="openMedia('{{ media.url_or_path }}', '{{ media.name }}', '{{ media.kind }}')"
               aria-label="Open {{ media.name }}">
-        {% if media.kind == 'video' %}
+        {% if media.kind == "video" %}
           <div class="absolute inset-0 flex items-center justify-center bg-black/40 z-10 group-hover:bg-black/20 transition-colors">
             <svg xmlns="http://www.w3.org/2000/svg" class="w-12 h-12 text-white/80 group-hover:text-white transition-all transform group-hover:scale-110" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z" />
@@ -47,7 +47,7 @@
         <span class="text-zinc-700">•</span>
         <span>
           {% if media.size_bytes > 0 %}
-            {{ (media.size_bytes / 1024) | round(1) }} KB
+            {{ media.size_bytes / 1024 }} KB
           {% else %}
             Size unknown
           {% endif %}


### PR DESCRIPTION
## Summary

- Fix single-quote string comparison in `templates/partials/feature-media.html` — Askama requires double quotes for string literals in template expressions
- Replace unsupported `| round(1)` filter with integer division (`media.size_bytes / 1024`) for KB display — Askama does not have a `round` filter
- Add missing `DashboardSettingsForm` struct to `crates/agileplus-dashboard/src/routes.rs` with the `theme`, `log_level`, and `data_directory` fields used by the `save_dashboard_settings` handler

## Test plan

- [x] `cargo check -p agileplus-dashboard` passes with 0 errors
- [x] Template syntax verified: double-quoted string comparisons, no unsupported filters
- [x] `DashboardSettingsForm` fields match all `form.*` field accesses in `save_dashboard_settings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)