### PR TITLE
feat(infra): OrbStack Plane.so + Dragonfly integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,3 +52,23 @@ ENVIRONMENT=development
 DEBUG=true
 ENABLE_METRICS=true
 ENABLE_TRACING=true
+
+# ── Plane.so Local Instance ────────────────────────────────────────────────
+# Used by both docker-compose.plane.yml (containerized) and
+# scripts/setup-plane.sh (native Python/Node via process-compose).
+#
+# Generate a production SECRET_KEY with: openssl rand -hex 32
+PLANE_SECRET_KEY=dev-secret-key-change-in-prod
+PLANE_POSTGRES_PASSWORD=agileplus-dev
+POSTGRES_USER=agileplus
+PLANE_WEB_URL=http://localhost:3100
+PLANE_CORS_ALLOWED_ORIGINS=http://localhost:3100,http://localhost:3000
+PLANE_DEBUG=0
+
+# Plane.so API connection (for agileplus sync push/pull)
+PLANE_API_URL=http://localhost:8000
+PLANE_API_KEY=your-plane-api-key-here
+PLANE_WORKSPACE_SLUG=your-workspace-slug
+
+# Next.js (plane-web container)
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8000

--- a/README.md
+++ b/README.md
@@ -71,6 +71,97 @@ All proto changes are checked against `main` using `buf breaking`. Breaking chan
 2. Explicit documentation in the PR description
 3. Coordination with all downstream consumers
 
+## Running Plane.so + Dragonfly (OrbStack)
+
+AgilePlus ships two complementary approaches for running Plane.so and Dragonfly locally.
+Both require [OrbStack](https://orbstack.dev) as the container runtime (macOS).
+
+### Approach A — Native processes + OrbStack containers (default, recommended)
+
+This is the default `process-compose` stack. Dragonfly and PostgreSQL run as OrbStack
+containers; Plane.so API/worker/beat run as native Python processes; Plane web runs
+natively via Node. This gives fast file-watch reloads and easy breakpoint debugging.
+
+```bash
+# 1. One-time: bootstrap Plane sources and Python env
+bash scripts/setup-plane.sh
+
+# 2. Copy env template and fill in secrets
+cp .env.example .env
+# Set PLANE_SECRET_KEY to output of: openssl rand -hex 32
+
+# 3. Start full stack (OrbStack must be running)
+process-compose up
+
+# Services become available at:
+#   AgilePlus API  http://localhost:3000
+#   Plane.so web   http://localhost:3100
+#   Plane.so API   http://localhost:8000
+#   Dragonfly      redis://localhost:6379
+#   PostgreSQL     postgresql://agileplus:agileplus-dev@localhost:5432/plane
+#   NATS           nats://localhost:4222
+#   MinIO          http://localhost:9000 (console: :9001)
+#   Neo4j          bolt://localhost:7687 (browser: :7474)
+```
+
+The `orb-containers` process in `process-compose.yml` calls `scripts/orb-up.sh` which
+starts (or reuses) the `agileplus-dragonfly` and `agileplus-postgres` containers.
+All Plane processes depend on `orb-containers: process_healthy` before starting.
+
+### Approach B — Fully containerized (CI or no Python/Node runtime)
+
+Use `docker-compose.plane.yml` to run the entire Plane.so stack as OrbStack containers.
+This is useful for CI pipelines or environments where native Python/Node setup is not
+feasible.
+
+```bash
+# Start only the backing stores (Dragonfly + Postgres)
+docker compose -f docker-compose.plane.yml up dragonfly plane-db -d
+
+# Start the full containerized Plane stack
+docker compose -f docker-compose.plane.yml up -d
+
+# Health check
+redis-cli -p 6379 ping                              # expected: PONG
+pg_isready -h localhost -p 5432                     # expected: accepting connections
+curl -s http://localhost:8000/api/health | jq .     # expected: {"status":"ok"}
+curl -s -o /dev/null -w "%{http_code}" http://localhost:3100/  # expected: 200
+
+# Tear down
+docker compose -f docker-compose.plane.yml down
+```
+
+### Container names and ports
+
+| Container | Image | Port |
+|-----------|-------|------|
+| `agileplus-dragonfly` | `dragonflydb/dragonfly:latest` | `6379` |
+| `agileplus-postgres` | `postgres:16-alpine` | `5432` |
+| `agileplus-plane-api` | `makeplane/plane-backend:stable` | `8000` |
+| `agileplus-plane-web` | `makeplane/plane-frontend:stable` | `3100` |
+| `agileplus-plane-worker` | `makeplane/plane-backend:stable` | — |
+| `agileplus-plane-beat` | `makeplane/plane-backend:stable` | — |
+
+### Troubleshooting
+
+```bash
+# Check OrbStack status
+orb status
+
+# Inspect running containers
+docker ps --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}"
+
+# Dragonfly memory/stats
+redis-cli -p 6379 info memory | grep used_memory_human
+
+# Follow process-compose logs for a specific service
+process-compose logs -f plane-api
+process-compose logs -f orb-containers
+
+# Restart a single container without disrupting the stack
+docker restart agileplus-dragonfly
+```
+
 ## Contributing
 
 1. Edit code or proto files as needed.

--- a/docker-compose.plane.yml
+++ b/docker-compose.plane.yml
@@ -1,0 +1,126 @@
+# docker-compose.plane.yml — Plane.so + Dragonfly via OrbStack containers
+#
+# Usage (full Plane stack as containers):
+#   docker compose -f docker-compose.plane.yml up -d
+#
+# Usage (Dragonfly only, Plane runs natively via process-compose):
+#   docker compose -f docker-compose.plane.yml up dragonfly plane-db -d
+#
+# The primary dev stack uses process-compose.yml with native Plane processes
+# talking to OrbStack containers for Dragonfly and PostgreSQL (via orb-up.sh).
+# This file provides the fully-containerized alternative for CI or environments
+# without a Python/Node runtime.
+
+services:
+  plane-db:
+    image: postgres:16-alpine
+    container_name: agileplus-postgres
+    environment:
+      POSTGRES_DB: plane
+      POSTGRES_USER: ${POSTGRES_USER:-agileplus}
+      POSTGRES_PASSWORD: ${PLANE_POSTGRES_PASSWORD:-agileplus-dev}
+    volumes:
+      - plane-db-data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-agileplus} -d plane"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+  dragonfly:
+    image: docker.dragonflydb.io/dragonflydb/dragonfly:latest
+    container_name: agileplus-dragonfly
+    ports:
+      - "6379:6379"
+    ulimits:
+      memlock: -1
+    command: ["--maxmemory=4gb", "--bind=0.0.0.0"]
+    healthcheck:
+      test: ["CMD", "redis-cli", "-p", "6379", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+  plane-api:
+    image: makeplane/plane-backend:stable
+    container_name: agileplus-plane-api
+    depends_on:
+      plane-db:
+        condition: service_healthy
+      dragonfly:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgresql://${POSTGRES_USER:-agileplus}:${PLANE_POSTGRES_PASSWORD:-agileplus-dev}@plane-db/plane
+      REDIS_URL: redis://dragonfly:6379
+      SECRET_KEY: ${PLANE_SECRET_KEY:-dev-secret-key-change-in-prod}
+      WEB_URL: ${PLANE_WEB_URL:-http://localhost:3100}
+      CORS_ALLOWED_ORIGINS: ${PLANE_CORS_ALLOWED_ORIGINS:-http://localhost:3100,http://localhost:3000}
+      DEBUG: ${PLANE_DEBUG:-0}
+      PYTHONUNBUFFERED: "1"
+    ports:
+      - "8000:8000"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:8000/api/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 6
+      start_period: 30s
+    restart: unless-stopped
+
+  plane-web:
+    image: makeplane/plane-frontend:stable
+    container_name: agileplus-plane-web
+    depends_on:
+      plane-api:
+        condition: service_healthy
+    environment:
+      NEXT_PUBLIC_API_BASE_URL: ${NEXT_PUBLIC_API_BASE_URL:-http://localhost:8000}
+      NEXT_PUBLIC_WEB_URL: ${PLANE_WEB_URL:-http://localhost:3100}
+    ports:
+      - "3100:3000"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:3000/ || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 6
+      start_period: 30s
+    restart: unless-stopped
+
+  plane-worker:
+    image: makeplane/plane-backend:stable
+    container_name: agileplus-plane-worker
+    command: celery -A plane worker -l info
+    depends_on:
+      plane-db:
+        condition: service_healthy
+      dragonfly:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgresql://${POSTGRES_USER:-agileplus}:${PLANE_POSTGRES_PASSWORD:-agileplus-dev}@plane-db/plane
+      REDIS_URL: redis://dragonfly:6379
+      SECRET_KEY: ${PLANE_SECRET_KEY:-dev-secret-key-change-in-prod}
+      PYTHONUNBUFFERED: "1"
+    restart: unless-stopped
+
+  plane-beat:
+    image: makeplane/plane-backend:stable
+    container_name: agileplus-plane-beat
+    command: celery -A plane beat -l info
+    depends_on:
+      plane-db:
+        condition: service_healthy
+      dragonfly:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgresql://${POSTGRES_USER:-agileplus}:${PLANE_POSTGRES_PASSWORD:-agileplus-dev}@plane-db/plane
+      REDIS_URL: redis://dragonfly:6379
+      SECRET_KEY: ${PLANE_SECRET_KEY:-dev-secret-key-change-in-prod}
+      PYTHONUNBUFFERED: "1"
+    restart: unless-stopped
+
+volumes:
+  plane-db-data:


### PR DESCRIPTION
## Summary

- Add `docker-compose.plane.yml` — fully-containerized Plane.so stack (Dragonfly, PostgreSQL, plane-api, plane-web, plane-worker, plane-beat) as Approach B alternative to the existing native process-compose setup
- Extend `.env.example` with all Plane.so environment variables (secret key, Postgres credentials, web URL, CORS origins, API key, workspace slug, Next.js public vars)
- Add `README.md` section "Running Plane.so + Dragonfly (OrbStack)" documenting both approaches, container/port table, and troubleshooting commands

## Context

The existing `process-compose.yml` already has a mature Approach A integration (OrbStack containers for Dragonfly/Postgres + native Python/Node Plane processes). This PR adds the missing artifacts:
- A compose file for the fully-containerized path (CI, environments without Python/Node)
- Documented env vars so new contributors know what to set
- A README section tying everything together

## OrbStack status at PR time

Both `agileplus-dragonfly` and `agileplus-postgres` containers are running and healthy:
```
agileplus-dragonfly  Up (healthy)  0.0.0.0:6379->6379/tcp
agileplus-postgres   Up            0.0.0.0:5432->5432/tcp
```

## Test plan

- [ ] `docker compose -f docker-compose.plane.yml up dragonfly plane-db -d` starts both backing stores
- [ ] `redis-cli -p 6379 ping` returns `PONG`
- [ ] `pg_isready -h localhost -p 5432` returns `accepting connections`
- [ ] `process-compose up` starts full native stack (Approach A, unchanged behavior)
- [ ] `.env.example` documents all Plane vars correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guide for running Plane locally with process-compose and Docker Compose approaches, including service configurations, health checks, and troubleshooting steps.

* **Chores**
  * Added environment configuration template with required variables.
  * Added Docker Compose configuration for local development setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->