### PR TITLE
chore(specs): migrate kitty-specs to AgilePlus format, archive BMAD refs

### DIFF
--- a/.agileplus/specs/001-spec-driven-development-engine/meta.json
+++ b/.agileplus/specs/001-spec-driven-development-engine/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "001-spec-driven-development-engine",
+  "title": "AgilePlus \u2014 Spec-Driven Development Engine",
+  "status": "active",
+  "created": "2026-02-27"
+}

--- a/.agileplus/specs/001-spec-driven-development-engine/spec.md
+++ b/.agileplus/specs/001-spec-driven-development-engine/spec.md
@@ -1,0 +1,352 @@
+# Feature Specification: AgilePlus — Spec-Driven Development Engine
+
+**Feature Branch**: `001-spec-driven-development-engine`
+**Created**: 2026-02-27
+**Status**: Draft
+**Mission**: software-dev
+
+## Overview
+
+AgilePlus is a local, git+SQLite-backed spec-driven development engine that runs as a CLI sidecar alongside Claude Code and Codex. It harmonizes the best of OpenSpec (simplicity, ~3 commands to plan), spec-kitty (structured granularity, worktree isolation, kanban tracking), bmad (enterprise depth, role-based agents), and GSD (automation, parallel execution) into a streamlined 7-command workflow.
+
+AgilePlus does not build a custom agent engine. It orchestrates existing AI coding agents (Claude Code, Codex) through slash commands, dispatching work to subagents in isolated worktrees. A Plane.so-based (or equivalent OSS) web UI provides visual project management, auditing, and dashboards — not built from scratch.
+
+AgilePlus becomes the canonical governance source for the Phenotype organization, incorporating a thegent-inspired smart contract system for evidence-backed state transitions, hash-chained audit logs, and policy-driven quality gates.
+
+**Interfaces**: MCP server (FastMCP 3.0), CLI, API. Extensible via agent Skills and plugins.
+
+### Multi-Repo Architecture
+
+AgilePlus is decomposed into 5 independent repositories to enforce CLEAN/SOLID/Hexagonal boundaries at the repository level, prevent scope creep, and enable independent scaling/deployment/versioning:
+
+| Repository | Purpose | Language |
+|------------|---------|----------|
+| `agileplus-proto` | Shared contracts (gRPC + MCP schemas) | Protobuf → Rust/Python |
+| `agileplus-core` | Domain + CLI + API + storage | Rust |
+| `agileplus-mcp` | MCP server (FastMCP 3.0) | Python |
+| `agileplus-agents` | Agent dispatch + review loop | Rust |
+| `agileplus-integrations` | Plane.so + GitHub + triage sync | Rust |
+
+All cross-repo communication uses gRPC with contracts defined in `agileplus-proto`. Each repo can be built, tested, versioned, and deployed independently. The proto repo is consumed as a git submodule or dependency by all other repos.
+
+### Agent-First Architecture
+
+AgilePlus leverages Claude Code's SlashCommand tool (v1.0.123+) to enable agents to programmatically invoke slash commands. The user sees 7 commands; behind the scenes, agents orchestrate ~25 hidden sub-commands that provide bmad-level depth without user friction.
+
+**Prompt Router Pattern**: Each project gets a generated `CLAUDE.md` and `AGENTS.md` that act as a prompt router. An agent's first action is to classify/triage the user's intent and route to the appropriate sub-command chain. This enables dynamic, context-aware workflows without requiring the user to know the internal command vocabulary.
+
+**MCP Primitives**: AgilePlus maps all 6 MCP primitives — Tools (CRUD operations), Resources (specs, audit trails, plans), Prompts (slash command templates), Sampling (server-initiated analysis like triage), Roots (workspace boundaries per feature/WP), and Elicitation (discovery interviews during specify/clarify).
+
+### Source of Truth & Sync Architecture
+
+- **SQLite**: Source of truth for all operational state (feature status, WP progress, audit chain, metrics)
+- **Git**: Source of truth for all artifacts (specs, plans, tasks, evidence, governance contracts)
+- **Plane.so**: Synced mirror for features and work packages (visual PM, kanban boards)
+- **GitHub Issues**: Synced mirror for bugs and issues (triage → GitHub issue → agent fix cycle)
+
+Sync is unidirectional from SQLite → mirrors, with conflict detection on mirror-side edits.
+
+## Clarifications
+
+### Session 2026-02-27
+
+- Q: How should AgilePlus handle credentials? → A: Harnesses manage their own LLM credentials; AgilePlus manages integration keys (GitHub, Coderabbit, Plane.so) via its own config. AgilePlus never touches CLI binaries or agent credentials — it operates through MCP, Skills, and slash commands.
+- Q: What is explicitly NOT part of AgilePlus v1? → A: No cloud sync, no mobile. Basic multi-user supported via shared git repo. Local-first.
+- Q: Can planning states be skipped? → A: Default is strict ordering (specify → research → plan → implement → validate → ship). Steps may be skipped only when the user's prompt clearly indicates it's unnecessary (e.g., trivial fix) — system warns and proceeds.
+- Q: What observability should AgilePlus provide? → A: Full — structured logs + metrics + OpenTelemetry traces exportable to external dashboards.
+- Q: How should resource conflicts between parallel WPs be handled? → A: Worktree isolation by default + dependency-aware scheduling when WPs declare shared files.
+
+## Out of Scope (v1)
+
+- Cloud sync / remote state replication
+- Mobile clients or responsive web UI
+- Custom agent engine — uses Claude Code and Codex harnesses exclusively
+- LLM credential management — delegated entirely to harnesses
+- Blockchain or distributed ledger (smart contracts are local process guarantees)
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Greenfield: Idea to Implementation-Ready Plan (Priority: P1)
+
+A developer has a new feature idea. They invoke `specify` to describe it through a guided discovery interview. The system creates a spec backed by SQLite with full audit trail. They then run `research` for technical feasibility analysis, followed by `plan` which generates work packages, dependency graphs, and governance contracts. At the end of these 3 commands, the project is ready for `implement`.
+
+**Why this priority**: This is the core value proposition — reducing the idea-to-implementation gap from 8+ commands (bmad) or manual ceremony to 3 streamlined commands with implicit refinement loops.
+
+**Independent Test**: Can be fully tested by running `specify` → `research` → `plan` on a sample feature and verifying that spec.md, research artifacts, plan.md, tasks/work packages, and governance contracts are all generated with valid cross-references and audit entries.
+
+**Acceptance Scenarios**:
+
+1. **Given** an empty project with AgilePlus initialized, **When** the user runs `specify` and completes the discovery interview, **Then** a spec is created in SQLite + git with all mandatory sections populated, audit log entry recorded, and the system prompts for `research` or `plan` as next step.
+2. **Given** a completed spec, **When** the user runs `plan`, **Then** work packages are generated with dependency ordering, each WP has acceptance criteria traceable to spec FRs, and a governance contract is written for the feature.
+3. **Given** a completed plan with work packages, **When** the user runs `plan` again with modifications, **Then** the system performs a refinement loop — diffing changes, updating affected WPs, and recording the revision in the audit log.
+
+---
+
+### User Story 2 — Automated Implementation Cycle (Priority: P1)
+
+A developer runs `implement` on a planned feature. AgilePlus spawns 1-3 subagents per worktree (using Claude Code/Codex), each working on assigned work packages in isolated git worktrees. Each agent creates a PR with the original goal/prompt in the PR description and detailed commit messages. The system awaits Coderabbit auto-review, then loops agents on review comments and CI fixes until the PR is green. Once a WP's PR passes, the system moves to the next WP.
+
+**Why this priority**: The implementation loop is where the most time is saved — automating the agent → PR → review → fix → merge cycle removes the manual orchestration overhead.
+
+**Independent Test**: Can be tested by running `implement` on a single WP and verifying: worktree created, subagent dispatched, PR created with goal context, Coderabbit review awaited, agent loops on feedback, PR merges when green.
+
+**Acceptance Scenarios**:
+
+1. **Given** a feature with 3 planned WPs, **When** the user runs `implement`, **Then** the system creates isolated worktrees for each WP, spawns subagents (1-3 per worktree), and each agent begins working on its assigned WP.
+2. **Given** an agent has completed its WP work, **When** it creates a PR, **Then** the PR description contains the original goal/prompt from the WP, commit messages are detailed and reference the WP/FR, and the system waits for Coderabbit auto-review.
+3. **Given** Coderabbit has posted review comments, **When** there are actionable findings, **Then** the agent reads the comments, makes fixes, pushes new commits, and re-awaits review until CI is green and review is approved.
+4. **Given** a WP's PR is approved and CI passes, **When** the system detects this, **Then** it records evidence in the audit log, updates the WP state in SQLite, and proceeds to the next WP respecting dependency ordering.
+
+---
+
+### User Story 3 — Brownfield: Existing Codebase Integration (Priority: P2)
+
+A developer initializes AgilePlus in an existing project. The `research` command (in pre-specify mode) scans the codebase to understand architecture, conventions, dependencies, and existing governance patterns. This analysis feeds into `specify` so that new features are context-aware. The existing governance docs (CLAUDE.md, AGENTS.md, quality gates) are imported into AgilePlus's governance system.
+
+**Why this priority**: Most real-world usage will be brownfield. Without codebase awareness, generated plans will conflict with existing patterns.
+
+**Independent Test**: Can be tested by running `research` on an existing Phenotype repo (e.g., bifrost-extensions) and verifying it produces a codebase analysis that correctly identifies languages, frameworks, architecture patterns, and existing governance rules.
+
+**Acceptance Scenarios**:
+
+1. **Given** an existing project with CLAUDE.md and AGENTS.md, **When** the user runs `research` in pre-specify mode, **Then** the system scans the codebase and produces a structured analysis including: languages/frameworks detected, architecture patterns, existing governance rules, and dependency map.
+2. **Given** a brownfield research analysis exists, **When** the user runs `specify` for a new feature, **Then** the discovery interview incorporates codebase context and generated requirements are consistent with existing patterns.
+
+---
+
+### User Story 4 — Validation and Quality Gates (Priority: P2)
+
+After implementation, the developer runs `validate`. The system checks all WP PRs against governance contracts, verifies FR-to-evidence tracing (every functional requirement has test evidence), runs quality gate policies, and produces a validation report. Only when all gates pass can the feature proceed to `ship`.
+
+**Why this priority**: Governance enforcement is what differentiates AgilePlus from ad-hoc agent workflows. Without it, the system is just a fancy task dispatcher.
+
+**Independent Test**: Can be tested by running `validate` on a feature with one passing and one failing WP, verifying that the report correctly identifies the gap, blocks shipping, and provides actionable feedback.
+
+**Acceptance Scenarios**:
+
+1. **Given** all WPs are implemented with merged PRs, **When** the user runs `validate`, **Then** the system checks: all FRs have corresponding test evidence, quality gate policies pass (lint, type-check, test coverage, security), and governance contracts are satisfied.
+2. **Given** a validation failure (e.g., FR-003 has no test evidence), **When** the report is generated, **Then** it identifies the specific gap, references the FR and responsible WP, and suggests remediation steps.
+3. **Given** all validation checks pass, **When** the system completes validation, **Then** the feature state transitions to "validated" in SQLite with a hash-chained audit entry, and the user is prompted to run `ship`.
+
+---
+
+### User Story 5 — Ship and Retrospective (Priority: P2)
+
+The developer runs `ship` to merge the feature into the target branch, clean up worktrees, archive the feature, and record completion in the audit log. Optionally, they run `retrospective` which auto-generates learnings from the feature's history (time per WP, review cycles, common issues) and feeds insights back into the constitution/governance for future features.
+
+**Why this priority**: Clean closure and learning loops prevent governance drift and improve future feature velocity.
+
+**Independent Test**: Can be tested by running `ship` on a validated feature and verifying: feature branch merged, worktrees cleaned, SQLite records updated, audit log finalized. Then `retrospective` generates a summary with actionable learnings.
+
+**Acceptance Scenarios**:
+
+1. **Given** a validated feature, **When** the user runs `ship`, **Then** the feature branch is merged to the target branch, all worktrees are cleaned up, the feature is archived in SQLite, and a final audit entry is recorded.
+2. **Given** a shipped feature, **When** the user runs `retrospective`, **Then** the system analyzes the feature's history and generates: time-per-WP, review cycle counts, common review findings, and suggested governance updates. Learnings are offered as amendments to the constitution.
+
+---
+
+### User Story 6 — Smart Contract Governance (Priority: P3)
+
+AgilePlus enforces a thegent-inspired smart contract system. Every state transition (spec created → researched → planned → implementing → validated → shipped) requires evidence. Governance contracts define what evidence is needed at each gate. The SQLite ledger stores hash-chained audit records. Policy rules (quality, security, cost) are evaluated at each transition. Violations block progression.
+
+**Why this priority**: This is the long-term differentiator but can be incrementally adopted — initial versions can use lightweight policies while the full evidence chain matures.
+
+**Independent Test**: Can be tested by attempting a state transition without required evidence and verifying it is blocked with a clear error message referencing the governance contract.
+
+**Acceptance Scenarios**:
+
+1. **Given** a governance contract requiring test evidence for FR-001, **When** a WP attempts to transition to "validated" without test evidence, **Then** the transition is blocked and the system reports: "FR-001 missing test evidence — required by governance contract GC-001."
+2. **Given** all state transitions for a feature, **When** the audit log is inspected, **Then** each entry is hash-chained (SHA-256), contains the transition type, evidence references, timestamp, and actor, and the chain is tamper-verifiable.
+
+---
+
+### User Story 7 — MCP Server and External Integration (Priority: P3)
+
+AgilePlus exposes its capabilities via a FastMCP 3.0 server, allowing external tools and agents to query project state, read specs, check governance status, and trigger commands programmatically. A CLI interface provides the same capabilities for scripting and CI/CD integration. An API layer enables the Plane.so web UI to read/write project data.
+
+**Why this priority**: Extensibility is critical for ecosystem integration but depends on the core workflow being stable first.
+
+**Independent Test**: Can be tested by starting the MCP server and using an MCP client to list features, read a spec, and check governance status for a feature.
+
+**Acceptance Scenarios**:
+
+1. **Given** AgilePlus is running with the MCP server, **When** an external agent queries for the current feature's status, **Then** it receives structured data including: feature state, WP progress, governance gate status, and next recommended action.
+2. **Given** the CLI interface, **When** a CI/CD script runs `agileplus validate --feature 001`, **Then** it returns exit code 0 on success or non-zero with structured error output on failure.
+
+---
+
+### User Story 8 — Triage, Queue & Bug Reporting (Priority: P2)
+
+A developer or agent encounters an idea, bug, or feature request during any workflow. They invoke `triage` (or the agent auto-triages based on prompt routing). The system classifies the input, creates the appropriate artifact (GitHub issue for bugs, Plane.so item for features, SQLite backlog entry for ideas), and optionally queues it for the next planning cycle. Agents follow this pattern by default — discovered bugs during `implement` are auto-triaged rather than ignored.
+
+**Why this priority**: Good DevOps hygiene requires capturing work items at discovery time. Without triage, bugs found during implementation are lost or manually tracked.
+
+**Independent Test**: Can be tested by submitting a bug report via CLI and verifying: GitHub issue created, SQLite backlog entry written, audit log records the triage event.
+
+**Acceptance Scenarios**:
+
+1. **Given** a developer encounters a bug during implementation, **When** they (or the agent) invoke triage with a bug description, **Then** a GitHub issue is created with structured metadata, a SQLite entry links the bug to the current feature/WP, and the audit log records the triage.
+2. **Given** a feature idea is queued, **When** the developer later runs `specify`, **Then** queued ideas are surfaced as suggestions during the discovery interview.
+3. **Given** an agent is working on a WP and discovers an unrelated bug, **When** the agent auto-triages, **Then** the bug is filed without interrupting the current WP workflow.
+
+---
+
+### User Story 9 — Agent Prompt Routing & Hidden Sub-Commands (Priority: P2)
+
+An agent receives a user request. Before executing, it reads the project's `CLAUDE.md`/`AGENTS.md` (generated by AgilePlus) which acts as a prompt router. The agent classifies the intent (e.g., "fix this bug" → triage → implement, "add a feature" → specify → plan → implement) and invokes the appropriate chain of hidden sub-commands via the SlashCommand tool. The user sees a single high-level command; the agent orchestrates 3-10 sub-commands behind the scenes.
+
+**Why this priority**: This is what makes AgilePlus feel simple while being powerful. Without prompt routing, users must manually orchestrate the full workflow.
+
+**Independent Test**: Can be tested by giving an agent a vague request ("make the login faster") and verifying: agent triages → selects research+implement path → executes sub-commands → produces PR with audit trail.
+
+**Acceptance Scenarios**:
+
+1. **Given** a project with AgilePlus-generated CLAUDE.md, **When** an agent receives "fix the auth bug", **Then** it routes through: triage → research (codebase scan) → implement (targeted fix) → validate.
+2. **Given** the hidden sub-command vocabulary, **When** an agent needs to check governance before proceeding, **Then** it invokes the `governance:check-gates` sub-command programmatically via SlashCommand tool.
+3. **Given** a complex request spanning multiple commands, **When** the agent orchestrates, **Then** each sub-command invocation is logged in the audit trail with the routing decision.
+
+---
+
+### Edge Cases
+
+- What happens when a subagent fails mid-WP (crash, timeout, API limit)? The system must checkpoint progress, allow resumption, and not corrupt the audit trail.
+- What happens when Coderabbit is unavailable? The system should degrade gracefully — allow manual review approval or skip automated review with a governance exception recorded.
+- What happens when two features modify overlapping files? The worktree isolation prevents conflicts during work, but merge conflicts at `ship` time must be detected and surfaced with clear remediation guidance.
+- What happens when the SQLite database is corrupted? Git remains the source of truth — the system must be able to rebuild SQLite state from git history.
+- What happens when governance contracts are updated mid-feature? Features in progress should be evaluated against the contract version at feature creation, with an option to adopt the new contract.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Core Workflow:**
+- **FR-001**: System MUST provide a `specify` command that conducts a guided discovery interview and produces a structured specification stored in both git and SQLite.
+- **FR-002**: System MUST provide a `research` command that supports both pre-specify (domain/market analysis, codebase scanning) and post-specify (technical feasibility) modes.
+- **FR-003**: System MUST provide a `plan` command that generates work packages with dependency ordering, acceptance criteria traced to spec FRs, and governance contracts.
+- **FR-004**: System MUST provide an `implement` command that spawns 1-3 subagents per worktree via Claude Code/Codex harnesses, creating PRs with goal/prompt context and detailed commit messages.
+- **FR-005**: System MUST provide a `validate` command that checks FR-to-evidence tracing, runs quality gate policies, and produces a validation report.
+- **FR-006**: System MUST provide a `ship` command that merges to target branch, cleans up worktrees, archives the feature, and finalizes the audit log.
+- **FR-007**: System MUST provide an optional `retrospective` command that generates learnings and suggests governance amendments.
+
+**Planning Commands — Implicit Refinement:**
+- **FR-008**: Each planning command (`specify`, `research`, `plan`) MUST include implicit refinement/review loops — the user can re-run any command to iterate, with changes tracked as revisions in the audit log.
+- **FR-009**: Planning commands MUST implicitly incorporate relevant governance checks (constitution compliance, consistency with existing specs/plans).
+
+**Implementation Automation:**
+- **FR-010**: The `implement` command MUST create isolated git worktrees per work package.
+- **FR-011**: The `implement` command MUST instruct agents to include the original WP goal/prompt in PR descriptions.
+- **FR-012**: The `implement` command MUST await automated code review (Coderabbit) and loop agents on review comments and CI failures until the PR is green.
+- **FR-013**: The `implement` command MUST respect WP dependency ordering — dependent WPs wait for their prerequisites to complete.
+
+**Storage and Auditability:**
+- **FR-014**: System MUST use git as the primary source of truth for all artifacts (specs, plans, tasks, evidence).
+- **FR-015**: System MUST use SQLite as the operational database for state tracking, querying, and performance.
+- **FR-016**: System MUST maintain a hash-chained (SHA-256) audit log in SQLite for all state transitions.
+- **FR-017**: System MUST be able to rebuild SQLite state from git history if the database is lost or corrupted.
+
+**Governance — Smart Contracts:**
+- **FR-018**: System MUST enforce governance contracts that define required evidence for each state transition.
+- **FR-019**: System MUST block state transitions when required evidence is missing, with clear error messages referencing the specific contract and missing evidence.
+- **FR-020**: System MUST support policy rules across domains: quality (lint, type-check, test coverage), security (vulnerability scanning), and reliability.
+- **FR-021**: System MUST support FR-to-evidence tracing — every functional requirement must map to test evidence before validation passes.
+
+**Interfaces:**
+- **FR-022**: System MUST expose capabilities via a FastMCP 3.0 server for external tool/agent integration.
+- **FR-023**: System MUST provide a CLI interface for scripting and CI/CD integration.
+- **FR-024**: System MUST provide an API layer for web UI integration (Plane.so or equivalent).
+- **FR-025**: System MUST support extensibility via agent Skills and plugins.
+
+**Web UI:**
+- **FR-026**: System MUST integrate with Plane.so (or equivalent OSS) for visual project management — kanban boards, spec browsing, audit trail viewing, dashboard.
+- **FR-027**: The web UI MUST be a sidecar — running alongside the CLI, reading from the same git+SQLite data store, not a separate system.
+
+**Credential Management:**
+- **FR-030**: System MUST manage integration credentials (GitHub, Coderabbit, Plane.so) via its own encrypted local config.
+- **FR-031**: System MUST NOT manage LLM or agent harness credentials — these are delegated entirely to Claude Code/Codex.
+- **FR-032**: System MUST interact with agents exclusively through MCP, Skills, and slash commands — never by touching CLI binaries directly.
+
+**State Machine:**
+- **FR-033**: System MUST enforce strict command ordering by default: specify → research → plan → implement → validate → ship.
+- **FR-034**: System MAY allow skipping steps only when the user's prompt clearly indicates it's unnecessary (e.g., trivial fix, quick prototype), with a warning logged in the audit trail.
+
+**Observability:**
+- **FR-035**: System MUST emit structured logs for all operations.
+- **FR-036**: System MUST collect and store metrics in SQLite (time-per-WP, agent runs, review cycles, command durations).
+- **FR-037**: System MUST support OpenTelemetry trace export to external dashboards.
+
+**Conflict Resolution:**
+- **FR-038**: System MUST use worktree isolation as the default conflict prevention mechanism for parallel WPs.
+- **FR-039**: System MUST support dependency-aware scheduling — when WPs declare shared files, conflicting WPs are serialized rather than parallelized.
+
+**Triage & Queue:**
+- **FR-040**: System MUST provide a `triage` sub-command that classifies input as bug, feature, idea, or task and routes to the appropriate artifact store (GitHub issue, Plane.so item, SQLite backlog).
+- **FR-041**: System MUST auto-triage bugs discovered by agents during `implement` — agents file bugs without interrupting their current WP workflow.
+- **FR-042**: System MUST provide a `queue` sub-command that adds items to a backlog for later processing, surfaced during the next `specify` or `plan` cycle.
+
+**Sync & Integration:**
+- **FR-043**: System MUST sync feature/WP state from SQLite to Plane.so (create/update work items, update kanban board status).
+- **FR-044**: System MUST sync bug reports from SQLite to GitHub Issues (create issues with structured metadata, labels, and feature/WP cross-references).
+- **FR-045**: System MUST detect and warn on mirror-side edits (changes made directly in Plane.so or GitHub that conflict with SQLite state).
+
+**Prompt Routing & Sub-Commands:**
+- **FR-046**: System MUST generate a project-specific `CLAUDE.md` and `AGENTS.md` that acts as a prompt router for agents, classifying user intent and routing to appropriate sub-command chains.
+- **FR-047**: System MUST expose ~25 hidden sub-commands (grouped as triage, governance, PM sync, git/devops, context, quick escapes) invocable by agents via the SlashCommand tool.
+- **FR-048**: System MUST log all agent sub-command invocations in the audit trail, including the routing decision and chain of commands executed.
+
+**MCP Primitives:**
+- **FR-049**: MCP server MUST implement all 6 MCP primitives: Tools (CRUD), Resources (read specs/audit), Prompts (command templates), Sampling (server-initiated triage/analysis), Roots (workspace boundaries), Elicitation (discovery interviews).
+- **FR-050**: MCP server MUST leverage FastMCP 3.0 features: background tasks (via Docket+SQLite), component versioning, per-component auth, Resources-as-Tools/Prompts-as-Tools transforms, native OpenTelemetry.
+
+**Agent DevOps Defaults:**
+- **FR-051**: Agents MUST follow CI/CD best practices by default: conventional commits, PR templates with WP context, branch naming conventions, automated linting before push.
+- **FR-052**: Agents MUST use the project's CLAUDE.md/AGENTS.md as their first-action classifier before executing any work.
+
+**Multi-Repo Architecture:**
+- **FR-053**: System MUST define all inter-service contracts in a shared `agileplus-proto` repository, consumed by all service repos as a git submodule or dependency.
+- **FR-054**: Each service repository (core, mcp, agents, integrations) MUST be independently buildable and testable with only the proto dependency.
+- **FR-055**: Cross-repo communication MUST use gRPC with Protobuf contracts — no direct in-process calls between repos.
+- **FR-056**: The proto repository MUST generate typed stubs for both Rust (tonic/prost) and Python (grpcio) from a single set of `.proto` files.
+- **FR-057**: Each service MUST implement its own gRPC service definition (core.proto, agents.proto, integrations.proto) with shared message types from common.proto.
+
+**Governance Source:**
+- **FR-028**: System MUST serve as the canonical governance source for the Phenotype organization, consolidating worktree discipline, quality gates, and agent workflow rules.
+- **FR-029**: System MUST integrate and extend existing Phenotype governance patterns (from parpour, civ, thegent).
+
+### Key Entities
+
+- **Feature**: A unit of work from idea to shipment. Has a spec, research artifacts, plan, work packages, governance contracts, and audit trail. Stored in git (markdown/YAML) and indexed in SQLite.
+- **Work Package (WP)**: A decomposed unit of implementation within a feature. Has acceptance criteria, dependency links, assigned agents, PR references, and state (planned → doing → review → done).
+- **Governance Contract**: Defines required evidence and policy rules for a feature or WP state transition. Versioned and immutable once bound to a feature.
+- **Audit Entry**: A hash-chained record of a state transition, including: timestamp, actor, transition type, evidence references, and SHA-256 chain link.
+- **Evidence**: Test results, CI output, review approvals, or other artifacts that satisfy governance contract requirements. Linked to FRs and WPs.
+- **Constitution**: Project-wide governance principles (technical standards, quality expectations, conventions). Updated via `retrospective` amendments.
+- **Policy Rule**: A specific quality/security/reliability check evaluated at state transitions. Configurable per project.
+- **Backlog Item**: A triaged bug, feature idea, or task queued for future processing. Classified by type, linked to originating feature/WP if discovered during implementation.
+- **Sub-Command**: A hidden operational command (one of ~25) invocable by agents via SlashCommand tool. Grouped into categories: triage, governance, PM sync, git/devops, context, quick escapes.
+- **Prompt Router**: A generated CLAUDE.md/AGENTS.md file that acts as an agent's first-action classifier, mapping user intent to sub-command chains.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A developer can go from feature idea to implementation-ready plan in 3 commands (`specify` → `research` → `plan`) averaging under 10 minutes of active user input.
+- **SC-002**: The `implement` → Coderabbit review → fix loop completes without manual user intervention for straightforward WPs (user only intervenes for ambiguous review findings).
+- **SC-003**: Every shipped feature has 100% FR-to-evidence traceability — no functional requirement lacks corresponding test evidence.
+- **SC-004**: The audit trail for any feature can be independently verified (hash chain integrity check passes) and reconstructed from git history alone.
+- **SC-005**: Total command count for a full feature lifecycle (idea → shipped) is 7 or fewer commands: `specify`, `research`, `plan`, `implement`, `validate`, `ship`, plus optional `retrospective`.
+- **SC-006**: Brownfield integration (running `research` on an existing codebase) correctly identifies languages, frameworks, architecture patterns, and existing governance in under 5 minutes.
+- **SC-007**: The system supports at least 3 concurrent features with independent worktree isolation, no cross-feature state corruption, and parallel agent execution.
+- **SC-008**: Governance violations are caught and blocked before they reach the target branch — zero governance-violating merges after `validate` + `ship`.
+
+## Assumptions
+
+- Claude Code and Codex remain the primary AI coding agent harnesses and maintain their current subagent/worktree capabilities.
+- Coderabbit (or equivalent automated code review) is available as a GitHub integration for PR review automation.
+- Plane.so Community Edition provides sufficient customizability for the web UI sidecar without forking.
+- SQLite is sufficient for single-developer and small-team workloads (no need for PostgreSQL in the initial version). Basic multi-user is supported via shared git repo; no cloud sync in v1.
+- FastMCP 3.0 is stable and available for MCP server implementation.
+- Existing Phenotype governance patterns (worktree discipline, quality gates, CLAUDE.md/AGENTS.md conventions) are the baseline to extend, not replace.
+- Multi-repo architecture with gRPC boundaries is viable for a local-first tool; the gRPC overhead (<10ms) is acceptable for inter-service communication.
+- Each repo can maintain independent CI/CD pipelines; the proto repo is the only shared build dependency.
+- TypeScript 7, Zig, and Go are available for future components where they outperform Rust/Python. v1 uses Rust + Python exclusively; TS7/Zig/Go adoption requires an ADR.
+- Plane.so Community Edition setup and configuration is handled by the user outside AgilePlus. AgilePlus syncs data to an existing Plane.so instance via API — it does not provision or configure the Plane.so deployment.

--- a/.agileplus/specs/001-spec-driven-development-engine/tasks.md
+++ b/.agileplus/specs/001-spec-driven-development-engine/tasks.md
@@ -1,0 +1,951 @@
+# Work Packages: AgilePlus — Spec-Driven Development Engine
+
+**Inputs**: Design documents from `kitty-specs/001-spec-driven-development-engine/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: BDD acceptance tests and contract tests included per the test strategy (cucumber-rs, behave, Pact).
+
+**Organization**: 159 subtasks → 23 work packages. Average ~7 subtasks per WP, ~370 lines per prompt.
+
+---
+
+## Work Package WP00: Proto Repository Scaffold (Priority: P0)
+
+**Goal**: Create the `agileplus-proto` repository with all 4 proto files, buf config, Rust/Python codegen, and CI skeleton.
+**Repo**: `agileplus-proto`
+**Independent Test**: `buf lint` passes, `buf generate` produces Rust and Python stubs, both compile.
+**Prompt**: `tasks/WP00-proto-scaffold.md`
+**Estimated**: ~350 lines, 8 subtasks
+
+### Included Subtasks
+- [x] T000a Initialize `agileplus-proto` repo with README, LICENSE, .gitignore
+- [x] T000b Create `proto/agileplus/common.proto` with shared message types (Feature, WP, Audit, Governance, Agent events)
+- [x] T000c [P] Create `proto/agileplus/core.proto` with AgilePlusCoreService definition
+- [x] T000d [P] Create `proto/agileplus/agents.proto` with AgentDispatchService definition
+- [x] T000e [P] Create `proto/agileplus/integrations.proto` with IntegrationsService definition
+- [x] T000f Create `buf.yaml`, `buf.gen.yaml` for linting and codegen configuration
+- [x] T000f2 Generate buf breaking change baseline and add buf breaking CI check
+- [x] T000g Create Rust crate in `rust/` (Cargo.toml, build.rs with tonic-build, src/lib.rs re-exporting generated code) and Python package in `python/` (pyproject.toml, codegen script)
+
+### Implementation Notes
+- Proto files are the single source of truth for all inter-service contracts
+- `buf generate` produces Rust code in `rust/src/` and Python code in `python/src/agileplus_proto/`
+- Rust crate is consumed as a git dependency by core, agents, integrations repos
+- Python package is consumed as a git dependency by mcp repo
+- `schemas/mcp-tools.json` and `schemas/mcp-resources.json` define MCP tool/resource schemas
+
+### Parallel Opportunities
+- T000c, T000d, T000e are all independent after T000b
+
+### Dependencies
+- None (starting package)
+
+### Risks & Mitigations
+- Proto design must be stable before other repos build against it; use `buf breaking` in CI
+
+---
+
+## Work Package WP01: Core Rust Workspace & Build Scaffold (Priority: P0)
+
+**Goal**: Create the `agileplus-core` Cargo workspace with all 7 crate stubs, Makefile, Docker Compose, and CI skeleton.
+**Repo**: `agileplus-core`
+**Independent Test**: `cargo build --workspace` succeeds, `cargo test --workspace` runs (0 tests, 0 errors).
+**Prompt**: `tasks/WP01-rust-workspace-scaffold.md`
+**Estimated**: ~300 lines, 9 subtasks
+
+### Included Subtasks
+- [x] T001 Create root `Cargo.toml` workspace manifest with all 7 crate members
+- [x] T002 [P] Scaffold `crates/agileplus-domain/` with `lib.rs`, domain module stubs, port trait stubs
+- [x] T003 [P] Scaffold remaining 6 adapter crates (`cli`, `api`, `grpc`, `sqlite`, `git`, `telemetry`) with `lib.rs` and dependency declarations
+- [x] T004 [P] Create `Makefile` with targets: build, test, lint, format, proto-gen, all; CI matrix must include macOS, Linux, and Windows targets
+- [x] T005 [P] Create `docker-compose.yml` for dev environment (Rust builder, Python MCP, SQLite volume)
+- [x] T006 Add `proto/` git submodule pointing to `agileplus-proto` and wire tonic-build in `agileplus-grpc`
+- [x] T006b Add MSRV CI check (latest stable Rust) to Makefile and CI config
+- [x] T006c Add rustdoc CI generation and FR/WP traceability module header convention
+- [x] T006d Add CI lint step validating agileplus-domain has only serde/sha2/chrono dependencies
+
+### Implementation Notes
+- Use Rust 2024 edition in all crates
+- Domain crate (renamed from `agileplus-core`) has no external deps except serde, sha2, chrono
+- Adapter crates depend on domain crate via workspace path
+- Proto consumed from `agileplus-proto` git submodule; tonic-build in `agileplus-grpc`
+- Agent dispatch and integrations crates are NOT in this repo — they live in `agileplus-agents` and `agileplus-integrations`
+- Configure workspace-level clippy.toml with `must-use-candidate = "warn"` per constitution requirements.
+- CI matrix must include macOS, Linux, and Windows targets
+
+### Parallel Opportunities
+- T002, T003, T004, T005 are all independent after T001
+
+### Dependencies
+- Depends on WP00 (proto repo must exist for git submodule)
+
+### Risks & Mitigations
+- tonic-build requires protoc; pin version in Makefile and Docker
+
+---
+
+## Work Package WP02: Python MCP Service Scaffold (Priority: P0)
+
+**Goal**: Create the `agileplus-mcp` repository with FastMCP 3.0 server skeleton, gRPC client stub, and pyproject.toml.
+**Repo**: `agileplus-mcp`
+**Independent Test**: `uv run python -m agileplus_mcp` starts without error, MCP server responds to health check.
+**Prompt**: `tasks/WP02-python-mcp-scaffold.md`
+**Estimated**: ~250 lines, 6 subtasks
+
+### Included Subtasks
+- [x] T007 Initialize `agileplus-mcp` repo, create `pyproject.toml` with FastMCP 3.0, grpcio, opentelemetry-sdk deps
+- [x] T008 Create `src/agileplus_mcp/__init__.py` and `server.py` (FastMCP entry)
+- [x] T009 [P] Create `src/agileplus_mcp/grpc_client.py` (stub gRPC connection to Rust core)
+- [x] T010 [P] Create `src/agileplus_mcp/tools/`, `resources/`, `prompts/`, `sampling/` directory stubs
+- [x] T011 Add `proto/` git submodule pointing to `agileplus-proto` and create `tests/` directory structure
+- [x] T011b Add sphinx/autodoc CI generation for Python API reference
+
+### Implementation Notes
+- Use `uv` for Python package management
+- FastMCP 3.0 server should register tools from `agileplus-proto/schemas/mcp-tools.json` schema
+- gRPC client connects to `localhost:50051` (Rust core default)
+- Proto consumed from `agileplus-proto` git submodule
+
+### Parallel Opportunities
+- T009, T010 independent after T008
+
+### Dependencies
+- Depends on WP00 (proto repo must exist for git submodule)
+
+### Risks & Mitigations
+- Python 3.13 free-threaded + FastMCP compatibility: test early, fall back to 3.12 if needed
+
+---
+
+## Work Package WP03: Domain Model — Feature & State Machine (Priority: P0)
+
+**Goal**: Implement the Feature aggregate, state machine (FSM), and core domain types in `agileplus-domain` (within `agileplus-core` repo).
+**Independent Test**: Unit tests pass for Feature creation, all valid state transitions, and skip-with-warning behavior.
+**Prompt**: `tasks/WP03-domain-feature-state-machine.md`
+**Estimated**: ~400 lines, 8 subtasks
+
+### Included Subtasks
+- [x] T012 Implement `Feature` struct with all fields from data-model.md in `crates/agileplus-domain/src/domain/feature.rs`
+- [x] T013 Implement `FeatureState` enum and `StateTransition` type with strict ordering (FR-033)
+- [x] T014 Implement state machine logic: `transition()` method enforcing valid transitions, skip-with-warning (FR-034)
+- [x] T015 Implement `WorkPackage` struct with states (planned/doing/review/done/blocked) in `work_package.rs`
+- [x] T016 Implement `WpDependency` and dependency-aware scheduling logic (FR-039)
+- [x] T017 Write unit tests for FSM: all valid transitions, invalid transitions blocked, skip transitions logged
+- [x] T017b Write proptest property-based tests for FSM transitions (all valid/invalid state pairs)
+- [x] T017c Run cargo-mutants on state_machine.rs, verify ≥90% mutation score
+
+### Implementation Notes
+- State machine uses Rust enums with exhaustive match — compiler enforces all transitions handled
+- Skip transitions return `Result<Warning>` not `Result<()>` — caller decides to log or abort
+- WorkPackage.file_scope is `Vec<String>` for overlap detection
+
+### Parallel Opportunities
+- T015-T016 (WP model) parallel with T012-T014 (Feature model) after shared types defined
+
+### Dependencies
+- Depends on WP01 (crate structure must exist)
+
+### Risks & Mitigations
+- Complex state machine edge cases: exhaustive unit tests with property-based testing (proptest)
+
+---
+
+## Work Package WP04: Domain Model — Governance & Audit (Priority: P0)
+
+**Goal**: Implement governance contracts, audit entries with hash chaining, evidence, and policy rules in `agileplus-domain` (within `agileplus-core` repo).
+**Independent Test**: Unit tests pass for hash chain creation, verification, evidence linking, and policy evaluation.
+**Prompt**: `tasks/WP04-domain-governance-audit.md`
+**Estimated**: ~450 lines, 10 subtasks
+
+### Included Subtasks
+- [x] T018 Implement `GovernanceContract` struct with versioned rules (FR-018) in `governance.rs`
+- [x] T019 Implement `AuditEntry` struct with SHA-256 hash chain (FR-016) in `audit.rs`
+- [x] T020 Implement `hash_entry()` function: SHA-256(id ‖ timestamp ‖ actor ‖ transition ‖ evidence_refs ‖ prev_hash)
+- [x] T021 Implement `verify_chain()` function: sequential scan validating prev_hash linkage
+- [x] T022 Implement `Evidence` struct with FR-to-evidence linking (FR-021) in `governance.rs`
+- [x] T023 Implement `PolicyRule` struct with domain-based evaluation (quality/security/reliability) (FR-020)
+- [x] T024 Write unit tests: chain integrity, tamper detection, evidence completeness check, policy pass/fail
+- [x] T024d Import and extend existing Phenotype governance patterns (from parpour, civ, thegent) into governance contract templates (FR-028, FR-029)
+- [x] T024b Write proptest property-based tests for hash chain integrity and governance evaluation
+- [x] T024c Run cargo-mutants on audit.rs and governance.rs, verify ≥90% mutation score
+
+### Implementation Notes
+- Use sha2 crate for SHA-256
+- AuditEntry.hash computed deterministically from concatenated fields
+- verify_chain() returns first invalid entry ID or Ok(count)
+- GovernanceContract.rules stored as serde_json::Value for flexibility
+
+### Parallel Opportunities
+- T018, T022-T023 (governance types) parallel with T019-T021 (audit chain)
+
+### Dependencies
+- Depends on WP03 (Feature and WP types needed for evidence linking)
+
+### Risks & Mitigations
+- Hash chain correctness is critical: extensive property-based tests, comparison with thegent's implementation
+
+---
+
+## Work Package WP05: Port Traits (Priority: P0)
+
+**Goal**: Define all port traits in `agileplus-domain/src/ports/` (within `agileplus-core` repo) that adapter crates will implement.
+**Independent Test**: Core crate compiles with all port traits defined, adapter crates can reference them.
+**Prompt**: `tasks/WP05-port-traits.md`
+**Estimated**: ~350 lines, 6 subtasks
+
+### Included Subtasks
+- [x] T025 Define `StoragePort` trait in `ports/storage.rs`: CRUD for features, WPs, audit, evidence, policies
+- [x] T026 [P] Define `VcsPort` trait in `ports/vcs.rs`: worktree create/cleanup, branch ops, artifact read/write
+- [x] T027 [P] Define `AgentPort` trait in `ports/agent.rs`: dispatch subagent, query status, send instruction
+- [x] T028 [P] Define `ReviewPort` trait in `ports/review.rs`: await review, read comments, check CI status
+- [x] T029 [P] Define `ObservabilityPort` trait in `ports/observability.rs`: emit trace, record metric, write log
+- [x] T030 Define `mod.rs` re-exporting all ports, application service traits using ports
+
+### Implementation Notes
+- All ports are async traits (use `async_trait` or Rust 2024 native async traits)
+- Port methods return `Result<T, DomainError>` — domain error type defined in core
+- StoragePort methods mirror data-model.md entities
+- VcsPort abstracts git2 — tests can use in-memory mock
+
+### Parallel Opportunities
+- T026-T029 all independent
+
+### Dependencies
+- Depends on WP03, WP04 (domain types referenced in port signatures)
+
+### Risks & Mitigations
+- Port design lock-in: keep ports minimal, add methods incrementally
+
+---
+
+## Work Package WP06: SQLite Adapter (Priority: P1)
+
+**Goal**: Implement SQLite storage adapter with migrations, CRUD operations, and rebuild-from-git capability.
+**Independent Test**: Integration tests pass for all CRUD operations, migration up/down, and rebuild from fixtures.
+**Prompt**: `tasks/WP06-sqlite-adapter.md`
+**Estimated**: ~500 lines, 7 subtasks
+
+### Included Subtasks
+- [x] T031 Create SQLite migration system in `crates/agileplus-sqlite/src/migrations/` (all tables from data-model.md)
+- [x] T032 Implement `SqliteStorageAdapter` struct implementing `StoragePort`
+- [x] T033 Implement feature CRUD: create, get_by_slug, update_state, list_by_state
+- [x] T034 Implement work package CRUD: create, get, update_state, list_by_feature, dependency queries
+- [x] T035 Implement audit CRUD: append_entry, get_trail, verify_chain (delegates to domain)
+- [x] T036 Implement evidence + policy + metric CRUD
+- [x] T037 Implement `rebuild_from_git()` (FR-017): parse git artifacts → populate SQLite
+
+### Implementation Notes
+- Use rusqlite with WAL mode for concurrent reads
+- Migrations are embedded SQL files, applied on startup
+- rebuild_from_git reads: meta.json, audit/chain.jsonl, evidence/** from git working tree
+- All queries use parameterized statements (no SQL injection)
+
+### Parallel Opportunities
+- T033, T034, T035, T036 are independent after T031-T032
+
+### Dependencies
+- Depends on WP05 (StoragePort trait)
+
+### Risks & Mitigations
+- WAL mode + single writer: use connection pooling with write serialization
+
+---
+
+## Work Package WP07: Git Adapter (Priority: P1)
+
+**Goal**: Implement git adapter for worktree management, branch ops, and artifact read/write.
+**Independent Test**: Integration tests pass for worktree create/cleanup, artifact read/write, branch merge in a temp repo.
+**Prompt**: `tasks/WP07-git-adapter.md`
+**Estimated**: ~400 lines, 6 subtasks
+
+### Included Subtasks
+- [x] T038 Implement `GitVcsAdapter` struct implementing `VcsPort` in `crates/agileplus-git/src/`
+- [x] T039 Implement worktree operations: create_worktree(feature, wp), list_worktrees, cleanup_worktree
+- [x] T040 Implement branch operations: create_branch, checkout, merge_to_target, detect_conflicts
+- [x] T041 Implement artifact operations: read_spec, read_plan, write_audit_chain, write_evidence
+- [x] T042 Implement git history scanning for `rebuild_from_git()` support
+- [x] T043 Write integration tests using temp git repos (git2::Repository::init)
+
+### Implementation Notes
+- Worktree paths: `.worktrees/<feature-slug>-<WP-id>/`
+- Use git2 for all operations — no shelling out to git CLI
+- Merge conflicts detected via git2 merge analysis, surfaced as structured error
+
+### Parallel Opportunities
+- T039, T040, T041 independent after T038
+
+### Dependencies
+- Depends on WP05 (VcsPort trait)
+
+### Risks & Mitigations
+- git2 worktree API quirks: test on macOS + Linux, handle case-insensitive filesystems
+
+---
+
+## Work Package WP08: Agent Dispatch Service (Priority: P1)
+
+**Goal**: Create `agileplus-agents` repo and implement agent dispatch for Claude Code and Codex, including PR creation, review loop, and gRPC service implementing `agents.proto`.
+**Repo**: `agileplus-agents`
+**Independent Test**: Mock dispatch test passes: agent spawned, PR created with goal context, review loop simulated. gRPC service starts and responds to health check.
+**Prompt**: `tasks/WP08-agent-dispatch-adapter.md`
+**Estimated**: ~550 lines, 8 subtasks
+
+### Included Subtasks
+- [x] T044 Initialize `agileplus-agents` repo with Cargo workspace (3 crates), proto git submodule, Makefile
+- [x] T044b Implement `AgentDispatchAdapter` in `crates/agileplus-agent-dispatch/src/`
+- [x] T045 Implement `claude_code.rs`: spawn Claude Code with `--print` mode, pass WP prompt, collect output
+- [x] T046 Implement `codex.rs`: spawn Codex in batch mode, pass WP prompt, collect output
+- [x] T047 Implement `dispatch.rs`: select agent (from config), create worktree, inject prompt, spawn 1-3 subagents
+- [x] T048 Implement `pr_loop.rs`: create PR (gh CLI), set description with WP goal/prompt (FR-011), poll for review
+- [x] T049 Implement review-fix loop: read Coderabbit comments → feed to agent → re-push → re-poll (FR-012)
+- [x] T049b Implement `agileplus-agent-service` gRPC server implementing `agents.proto` AgentDispatchService
+
+### Implementation Notes
+- This is a separate repo (`agileplus-agents`) with its own Cargo workspace (3 crates)
+- Communicates with `agileplus-core` via gRPC client for state queries/updates
+- Implements `agents.proto` service that core can call
+- Agent invocation via `tokio::process::Command` — capture stdout/stderr
+- PR creation via `gh pr create` with structured body (FR-011)
+- Review loop: poll GitHub API every 30s for review status, Coderabbit comments
+
+### Parallel Opportunities
+- T045, T046 independent (different agent harnesses)
+
+### Dependencies
+- Depends on WP00 (proto repo). Design reference: WP05 (AgentPort trait — not a build dependency, used as interface design guide)
+
+### Risks & Mitigations
+- Agent CLI changes: abstract behind AgentPort, adapter is swappable
+- Coderabbit latency: configurable poll interval with exponential backoff
+
+---
+
+## Work Package WP09: Code Review Adapter (Priority: P1)
+
+**Goal**: Implement Coderabbit integration and manual review fallback in `agileplus-agent-review` crate within `agileplus-agents` repo.
+**Repo**: `agileplus-agents`
+**Independent Test**: Mock test passes: Coderabbit review fetched, comments parsed, fallback to manual works.
+**Prompt**: `tasks/WP09-review-adapter.md`
+**Estimated**: ~300 lines, 5 subtasks
+
+### Included Subtasks
+- [x] T050 Implement `ReviewAdapter` struct in `crates/agileplus-agent-review/src/`
+- [x] T051 Implement `coderabbit.rs`: fetch review via GitHub API, parse comments into structured feedback
+- [x] T052 Implement `fallback.rs`: manual review approval flow (user confirms via CLI prompt)
+- [x] T053 Implement CI status checking: poll GitHub checks API for PR, return pass/fail/pending
+- [x] T054 Write unit tests with mock GitHub API responses
+
+### Implementation Notes
+- Lives in `agileplus-agents` repo, `crates/agileplus-agent-review/` crate
+- GitHub API via `octocrab` or raw `reqwest` — use integration key from credential store
+- Coderabbit comments identified by bot username, parsed for actionable vs informational
+- Fallback triggers when Coderabbit unavailable for >5min (configurable)
+
+### Parallel Opportunities
+- T051, T052, T053 independent after T050
+
+### Dependencies
+- Depends on WP08 (agents repo must exist)
+
+### Risks & Mitigations
+- GitHub API rate limits: cache responses, use conditional requests (ETags)
+
+---
+
+## Work Package WP10: Telemetry Adapter (Priority: P1)
+
+**Goal**: Implement OpenTelemetry traces, metrics, and structured logging.
+**Independent Test**: Traces and metrics exported to OTLP collector, structured logs written to file.
+**Prompt**: `tasks/WP10-telemetry-adapter.md`
+**Estimated**: ~300 lines, 5 subtasks
+
+### Included Subtasks
+- [x] T055 Implement `TelemetryAdapter` struct implementing `ObservabilityPort` in `crates/agileplus-telemetry/src/`
+- [x] T056 Implement `traces.rs`: OpenTelemetry trace spans per command execution, agent dispatch
+- [x] T057 [P] Implement `metrics.rs`: counters (agent_runs, review_cycles), histograms (command_duration_ms)
+- [x] T058 [P] Implement `logs.rs`: structured JSON logging with tracing crate, configurable output (stdout/file)
+- [x] T059 Create `~/.agileplus/otel-config.yaml` schema and loader
+
+### Implementation Notes
+- Use `opentelemetry` + `opentelemetry-otlp` crates
+- Traces: one span per command, child spans for agent dispatch, review loop iterations
+- Metrics stored in SQLite (via StoragePort) AND exported via OTLP
+- Log format: JSON with timestamp, level, span_id, message, fields
+
+### Parallel Opportunities
+- T056, T057, T058 independent after T055
+
+### Dependencies
+- Depends on WP05 (ObservabilityPort trait)
+
+### Risks & Mitigations
+- OTLP collector not running: degrade gracefully, log warning, continue without export
+
+---
+
+## Work Package WP11: CLI — Specify & Research Commands (Priority: P1) 🎯 MVP
+
+**Goal**: Implement `specify` and `research` CLI commands with discovery interview and SQLite persistence.
+**Independent Test**: `agileplus specify` creates a spec interactively, stores in git+SQLite. `agileplus research` produces research artifacts.
+**Prompt**: `tasks/WP11-cli-specify-research.md`
+**Estimated**: ~450 lines, 6 subtasks
+
+### Included Subtasks
+- [x] T060 Create `crates/agileplus-cli/src/main.rs` with clap App, global flags, subcommand routing
+- [x] T061 Implement `commands/specify.rs`: guided discovery interview, spec generation, SQLite+git persistence (FR-001)
+- [x] T062 Implement `commands/research.rs`: pre-specify (codebase scan) and post-specify (feasibility) modes (FR-002)
+- [x] T063 Implement implicit refinement: re-run detection, diffing, revision audit logging (FR-008)
+- [x] T064 Implement governance checks within planning commands (FR-009): constitution loading, consistency validation
+- [x] T065 Wire specify/research to StoragePort, VcsPort, ObservabilityPort via dependency injection
+
+### Implementation Notes
+- CLI uses clap derive macros for arg parsing
+- Discovery interview: structured prompts to stdout, read from stdin
+- Spec written to git (kitty-specs/<feature>/spec.md) AND indexed in SQLite
+- Research modes determined by presence/absence of spec.md in feature dir
+
+### Parallel Opportunities
+- T061, T062 independent after T060
+
+### Dependencies
+- Depends on WP06 (SQLite), WP07 (git), WP10 (telemetry)
+
+### Risks & Mitigations
+- Interactive CLI complexity: use `dialoguer` crate for structured prompts
+
+---
+
+## Work Package WP12: CLI — Plan & Implement Commands (Priority: P1) 🎯 MVP
+
+**Goal**: Implement `plan` and `implement` CLI commands. Plan generates WPs. Implement dispatches agents.
+**Independent Test**: `agileplus plan` generates WPs from spec. `agileplus implement` spawns agents in worktrees.
+**Prompt**: `tasks/WP12-cli-plan-implement.md`
+**Estimated**: ~500 lines, 7 subtasks
+
+### Included Subtasks
+- [x] T066 Implement `commands/plan.rs`: WP generation with dependency ordering, governance contract creation (FR-003)
+- [x] T067 Implement WP file_scope detection: parse plan for file paths, build overlap graph
+- [x] T068 Implement dependency-aware scheduler: parallel WPs for non-overlapping, serial for overlapping (FR-038, FR-039)
+- [x] T069 Implement `commands/implement.rs`: worktree creation, agent dispatch, PR creation (FR-004, FR-010-013)
+- [x] T070 Implement PR description builder: inject WP goal, FR references, acceptance criteria (FR-011)
+- [x] T071 Implement review-fix loop orchestrator: await Coderabbit, loop agent, detect green (FR-012)
+- [x] T072 Wire plan/implement to all ports (storage, VCS, agent, review, telemetry)
+
+### Implementation Notes
+- Plan command reads spec.md + research.md, generates WPs with acceptance criteria traced to FRs
+- Implement command respects dependency ordering (WP.depends_on must all be `done`)
+- Agent dispatch: 1-3 subagents per worktree based on WP complexity (configurable)
+- Review loop: poll every 30s, max 5 cycles, fail after max with governance exception
+
+### Parallel Opportunities
+- T066-T068 (plan) parallel with T069-T071 (implement) — different command files
+
+### Dependencies
+- Depends on WP08 (agent dispatch), WP09 (review), WP11 (CLI scaffold)
+
+### Risks & Mitigations
+- Agent dispatch reliability: implement retry with checkpoint (resume from last commit)
+
+---
+
+## Work Package WP13: CLI — Validate, Ship, Retrospective Commands (Priority: P1)
+
+**Goal**: Implement the final 3 commands to complete the 7-command workflow.
+**Independent Test**: `agileplus validate` checks governance gates. `agileplus ship` merges + archives. `agileplus retrospective` generates learnings.
+**Prompt**: `tasks/WP13-cli-validate-ship-retro.md`
+**Estimated**: ~450 lines, 6 subtasks
+
+### Included Subtasks
+- [x] T073 Implement `commands/validate.rs`: FR-to-evidence tracing, quality gate checks, validation report (FR-005)
+- [x] T074 Implement governance gate evaluator: check all contract rules, collect violations, block if failing (FR-018, FR-019)
+- [x] T075 Implement `commands/ship.rs`: merge to target branch, cleanup worktrees, archive feature, finalize audit (FR-006)
+- [x] T076 Implement `commands/retrospective.rs`: analyze feature history, generate learnings, suggest constitution amendments (FR-007)
+- [x] T077 Implement strict state machine enforcement in all commands: verify current state, transition, log (FR-033, FR-034)
+- [x] T078 Wire validate/ship/retro to all ports
+
+### Implementation Notes
+- Validate: iterate all FRs, for each find evidence records, check policy rules
+- Ship: git merge to target_branch, git worktree prune, update SQLite state, append final audit
+- Retrospective: query metrics table (time-per-WP, review cycles), generate markdown report
+- State enforcement: each command checks feature.state before proceeding
+
+### Parallel Opportunities
+- T073-T074 (validate) parallel with T075 (ship) — different files
+
+### Dependencies
+- Depends on WP12 (implement must exist for validate to have evidence)
+
+### Risks & Mitigations
+- Merge conflicts at ship time: detect via git2, present structured diff, suggest resolution
+
+---
+
+## Work Package WP14: gRPC Server & MCP Integration (Priority: P2)
+
+**Goal**: Implement the tonic gRPC server in `agileplus-core` repo (serving `core.proto` + proxying agents/integrations) and wire the `agileplus-mcp` Python service to call it.
+**Repos**: `agileplus-core` (gRPC server), `agileplus-mcp` (MCP tools + gRPC client)
+**Independent Test**: gRPC server starts serving `core.proto`, Python MCP client connects, tool calls route through to Rust core and return results.
+**Prompt**: `tasks/WP14-grpc-mcp-integration.md`
+**Estimated**: ~450 lines, 7 subtasks
+
+### Included Subtasks
+- [x] T079 Implement tonic gRPC server in `agileplus-core/crates/agileplus-grpc/src/server.rs` implementing `AgilePlusCoreService` from `core.proto`
+- [x] T080 Wire gRPC handlers to domain services (feature queries, governance checks, audit trail, command dispatch)
+- [x] T080b Implement gRPC proxy/routing: core server forwards agent/integration requests to agileplus-agents and agileplus-integrations services (or stubs them when those services are unavailable)
+- [x] T081 Implement Python gRPC client in `agileplus-mcp/src/agileplus_mcp/grpc_client.py` using generated stubs from `agileplus-proto`
+- [x] T082 Implement MCP tool handlers in `agileplus-mcp/src/agileplus_mcp/tools/` — each tool calls gRPC client
+- [x] T083 Implement agent event streaming: bidirectional gRPC stream for real-time agent status
+- [x] T084 Write Pact contract tests for Rust↔Python gRPC boundary
+- [x] T084b Implement MCP Sampling primitive: server-initiated triage analysis and governance pre-checks (FR-049)
+- [x] T084c Implement MCP Roots primitive: workspace boundary declarations per feature/WP (FR-049)
+- [x] T084d Implement MCP Elicitation primitive: discovery interview flows for specify/clarify commands (FR-049)
+
+### Implementation Notes
+- gRPC server in core serves `core.proto` endpoints directly
+- For agents.proto and integrations.proto, core either proxies to those services or returns "service unavailable" stubs
+- MCP tools map 1:1 to `agileplus-proto/schemas/mcp-tools.json` definitions
+- Proto consumed from git submodule in both repos
+- Pact: Rust (core) is provider, Python (mcp) is consumer
+
+### Parallel Opportunities
+- T079-T080b (Rust server) parallel with T081-T082 (Python client)
+
+### Dependencies
+- Depends on WP00 (proto), WP13 (all CLI commands must exist for command dispatch)
+
+### Risks & Mitigations
+- gRPC streaming complexity: start with unary calls, add streaming incrementally
+
+---
+
+## Work Package WP15: API Layer & Credential Management (Priority: P2)
+
+**Goal**: Implement axum HTTP API for web UI integration and credential management system.
+**Independent Test**: API endpoints return feature/WP/audit data as JSON. Credentials stored/retrieved from OS keychain.
+**Prompt**: `tasks/WP15-api-credentials.md`
+**Estimated**: ~400 lines, 6 subtasks
+
+### Included Subtasks
+- [x] T085 Implement axum router in `crates/agileplus-api/src/` with routes for features, WPs, governance, audit
+- [x] T086 Implement API route handlers: delegate to domain services via ports
+- [x] T087 [P] Implement integration key auth middleware: validate API keys from credential store (FR-030)
+- [x] T088 [P] Implement credential management: OS keychain storage (macOS Keychain, Linux secret-service) (FR-030, FR-031)
+- [x] T089 [P] Create `~/.agileplus/config.toml` schema and loader (core config, credential references)
+- [x] T090 Write API integration tests with mock HTTP client
+
+### Implementation Notes
+- axum runs alongside gRPC in the same tokio runtime (shared binary)
+- API designed for Plane.so consumption: JSON responses match Plane.so work item format where possible
+- Credentials: use `keyring` crate, fallback to encrypted file with passphrase
+- Config: TOML with sections for core, credentials, telemetry, api
+
+### Parallel Opportunities
+- T087, T088, T089 independent after T085-T086
+
+### Dependencies
+- Depends on WP14 (gRPC server — shared binary architecture)
+
+### Risks & Mitigations
+- Keychain access permissions on Linux: test with both gnome-keyring and kwallet
+
+---
+
+## Work Package WP16: BDD Acceptance Tests & Integration Suite (Priority: P2)
+
+**Goal**: Write BDD acceptance tests mapping to spec FRs, contract tests, and Docker-based integration tests.
+**Independent Test**: `make test` runs all unit, BDD, contract, and integration tests with >80% coverage.
+**Prompt**: `tasks/WP16-bdd-integration-tests.md`
+**Estimated**: ~450 lines, 7 subtasks
+
+### Included Subtasks
+- [x] T091 Create `.feature` files for core user stories: specify.feature, implement.feature, governance.feature, audit.feature
+- [x] T092 Implement cucumber-rs step definitions for Rust BDD tests in `tests/bdd/`
+- [x] T093 [P] Implement behave step definitions for Python BDD tests in `mcp/tests/bdd/`
+- [x] T094 [P] Create Pact contract test fixtures for gRPC boundary in `tests/contract/`
+- [x] T095 Create `docker-compose.test.yml` for full-stack integration tests (spins up all 4 services: core, mcp, agents, integrations)
+- [x] T096 Implement integration test scenarios: full workflow (specify → ship) on test repo
+- [x] T097 Create test fixtures: sample specs, plans, WPs, evidence artifacts in `tests/fixtures/`
+
+### Implementation Notes
+- BDD .feature files reference FR IDs in scenario names (e.g., "Scenario: FR-001 - Specify creates spec in git+SQLite")
+- cucumber-rs and behave share the same .feature files (copied or symlinked)
+- Pact: Python consumer writes expected interactions, Rust provider verifies
+- Integration tests use a temp git repo created in setUp, torn down in tearDown
+
+### Parallel Opportunities
+- T092, T093, T094 all independent
+
+### Dependencies
+- Depends on WP15 (all components must exist for full integration)
+
+### Risks & Mitigations
+- Docker test environment complexity: use Docker Compose profiles for partial testing
+
+---
+
+## Work Package WP17: Triage & Backlog Service (Priority: P2)
+
+**Goal**: Create `agileplus-integrations` repo and implement the triage classifier, backlog management, and prompt router generation in `agileplus-triage` crate.
+**Repo**: `agileplus-integrations`
+**Independent Test**: Triage classifies input correctly (bug/feature/idea), creates backlog entries, generates a valid CLAUDE.md router. gRPC service responds to ClassifyInput.
+**Prompt**: `tasks/WP17-triage-backlog-adapter.md`
+**Estimated**: ~500 lines, 8 subtasks
+
+### Included Subtasks
+- [x] T098 Initialize `agileplus-integrations` repo with Cargo workspace (4 crates), proto git submodule, Makefile
+- [ ] T098b Implement `TriageAdapter` struct with `classify()` method in `crates/agileplus-triage/src/`
+- [x] T099 Implement `BacklogItem` CRUD: create, list_by_type, list_by_feature, promote_to_feature
+- [x] T100 Implement `classifier.rs`: rule-based + keyword intent classification (extensible for LLM-based later)
+- [x] T101 Implement `router.rs`: generate project-specific CLAUDE.md with prompt routing rules (FR-046)
+- [x] T102 Implement `router.rs`: generate project-specific AGENTS.md with sub-command vocabulary (FR-047)
+- [ ] T102b Implement `agileplus-integrations-service` gRPC server implementing `integrations.proto` IntegrationsService (triage endpoints)
+- [x] T103 Write unit tests for classification accuracy, backlog operations, router generation
+
+### Implementation Notes
+- This is a separate repo (`agileplus-integrations`) with its own Cargo workspace (4 crates)
+- Communicates with `agileplus-core` via gRPC client for state reads
+- Implements triage portion of `integrations.proto` service
+
+### Dependencies
+- Depends on WP00 (proto repo)
+
+---
+
+## Work Package WP18: Plane.so Sync Adapter (Priority: P2)
+
+**Goal**: Implement bidirectional-aware sync from core to Plane.so for features and work packages in `agileplus-plane` crate within `agileplus-integrations` repo.
+**Repo**: `agileplus-integrations`
+**Independent Test**: Feature state change triggers Plane.so work item creation/update via gRPC. Conflict detection works.
+**Prompt**: `tasks/WP18-plane-sync-adapter.md`
+**Estimated**: ~350 lines, 5 subtasks
+
+### Included Subtasks
+- [x] T104 Implement `PlaneSyncAdapter` struct with Plane.so REST API client in `crates/agileplus-plane/src/` (FR-043)
+- [x] T105 Implement feature sync: gRPC request from core → Plane.so work item (create/update on state change)
+- [x] T106 Implement WP sync: gRPC request from core → Plane.so sub-item (status, assignee, PR link)
+- [x] T107 Implement conflict detection: poll Plane.so for mirror-side edits, warn on conflicts (FR-045)
+- [x] T108 Write integration tests with mock Plane.so API
+
+### Implementation Notes
+- Lives in `agileplus-integrations` repo, `crates/agileplus-plane/` crate
+- Receives sync requests via gRPC (integrations.proto SyncFeatureToPlane, SyncWPToPlane, DetectPlaneConflicts)
+- Credential management delegated to the integrations service config
+
+### Dependencies
+- Depends on WP17 (integrations repo must exist)
+
+---
+
+## Work Package WP19: GitHub Sync Adapter (Priority: P2)
+
+**Goal**: Implement bug-to-issue sync to GitHub Issues with structured metadata in `agileplus-github` crate within `agileplus-integrations` repo.
+**Repo**: `agileplus-integrations`
+**Independent Test**: Bug triage via gRPC creates a GitHub issue with labels, cross-references, and metadata.
+**Prompt**: `tasks/WP19-github-sync-adapter.md`
+**Estimated**: ~350 lines, 5 subtasks
+
+### Included Subtasks
+- [x] T109 Implement `GitHubSyncAdapter` struct with octocrab GitHub API client in `crates/agileplus-github/src/` (FR-044)
+- [x] T110 Implement bug sync: gRPC request from core → GitHub issue (title, body, labels, feature/WP refs)
+- [x] T111 Implement issue status sync: GitHub issue closed → notify core via gRPC
+- [x] T112 Implement conflict detection: warn on GitHub-side edits that conflict with core state (FR-045)
+- [x] T113 Write integration tests with mock GitHub API (wiremock)
+
+### Implementation Notes
+- Lives in `agileplus-integrations` repo, `crates/agileplus-github/` crate
+- Receives sync requests via gRPC (integrations.proto SyncBugToGitHub, SyncIssueStatus, DetectGitHubConflicts)
+- Credential management delegated to the integrations service config
+
+### Dependencies
+- Depends on WP17 (integrations repo must exist)
+
+---
+
+## Work Package WP20: Hidden Sub-Commands & SlashCommand Integration (Priority: P2)
+
+**Goal**: Implement the ~25 hidden sub-commands and wire them for invocation via Claude Code's SlashCommand tool.
+**Independent Test**: Each sub-command executes correctly when invoked programmatically; audit log captures all invocations.
+**Prompt**: `tasks/WP20-hidden-subcommands.md`
+**Estimated**: ~500 lines, 7 subtasks
+
+### Included Subtasks
+- [x] T114 Define sub-command registry: enum of all ~25 sub-commands with metadata (category, description, required args)
+- [x] T115 Implement triage sub-commands: `triage:classify`, `triage:file-bug`, `triage:queue-idea` (FR-040, FR-041, FR-042)
+- [x] T116 Implement governance sub-commands: `governance:check-gates`, `governance:evaluate-policy`, `governance:verify-chain`
+- [x] T117 Implement sync sub-commands: `sync:push-plane`, `sync:push-github`, `sync:pull-status` (FR-043, FR-044)
+- [x] T118 Implement git/devops sub-commands: `git:create-worktree`, `git:branch-from-wp`, `devops:lint-and-format`, `devops:conventional-commit` (FR-051)
+- [x] T119 Implement context + escape sub-commands: `context:load-spec`, `context:scan-codebase`, `escape:quick-fix`, `escape:hotfix`, `meta:generate-router`
+- [x] T120 Implement audit logging for all sub-command invocations (FR-048) and write integration tests
+
+### Dependencies
+- Depends on WP13 (CLI commands), WP17 (triage), WP18 (Plane sync), WP19 (GitHub sync)
+
+---
+
+## Work Package WP21: CLI Triage & Queue Commands + Agent Defaults (Priority: P2)
+
+**Goal**: Add `triage` and `queue` as user-facing CLI commands, implement agent DevOps defaults, and auto-triage during implement.
+**Independent Test**: `agileplus triage "login is broken"` classifies as bug and creates GitHub issue. Agent auto-triages during implement.
+**Prompt**: `tasks/WP21-cli-triage-queue.md`
+**Estimated**: ~400 lines, 6 subtasks
+
+### Included Subtasks
+- [x] T121 Implement `commands/triage.rs`: accept input, classify, route to appropriate store (FR-040)
+- [x] T122 Implement `commands/queue.rs`: add to backlog, surface during next specify/plan cycle (FR-042)
+- [x] T123 Implement agent auto-triage hook: during implement, agents auto-file discovered bugs (FR-041)
+- [x] T124 Implement agent DevOps defaults: conventional commits, branch naming, lint-before-push (FR-051)
+- [x] T125 Implement CLAUDE.md/AGENTS.md first-action classifier integration (FR-052)
+- [x] T126 Wire triage/queue to StoragePort, sync adapters, telemetry; write CLI integration tests
+- [x] T127 Seed sub-command prompt files from hybridized reference commands (spec-kitty, bmad, gsd, openspec superset)
+
+### Dependencies
+- Depends on WP17 (triage adapter), WP20 (sub-commands)
+
+---
+
+## Work Package WP22: Modern Task Runner & DX Tooling Migration (Priority: P1)
+
+**Goal**: Replace Make with a modern task runner (evaluate just/task/mise as of 2026) across all 5 repos. Migrate all Makefile targets, ensure cross-platform compatibility (Windows), and update CI/pre-commit to use the new runner.
+**Repos**: All (agileplus-proto, agileplus-core, agileplus-mcp, agileplus-agents, agileplus-integrations)
+**Independent Test**: `<runner> check` runs full local quality suite on all platforms. CI uses same runner. Windows works without WSL.
+**Prompt**: `tasks/WP22-task-runner-dx-migration.md`
+**Estimated**: ~400 lines, 7 subtasks
+
+### Included Subtasks
+- [ ] T128 Research and evaluate modern task runners (just, task, mise, moon, nx) — select best for Rust+Python polyglot, cross-platform, CI integration
+- [ ] T129 [P] Migrate agileplus-proto Makefile to chosen runner with all targets (lint, generate, breaking, rust-*, python-*, check, pre-commit)
+- [ ] T130 [P] Create agileplus-core task config with all quality gates (build, test, fmt, clippy, audit, deny, coverage, mutants, docs)
+- [ ] T131 [P] Create agileplus-mcp task config (install, test, fmt, lint, audit, docs, coverage)
+- [ ] T132 [P] Create agileplus-agents task config (mirroring core pattern)
+- [ ] T133 [P] Create agileplus-integrations task config (mirroring core pattern)
+- [ ] T134 Update CI workflows and pre-commit hooks across all repos to use new runner
+
+### Implementation Notes
+- Must work natively on macOS, Linux, and Windows (no WSL dependency)
+- Must support task dependencies, parallelism, and environment variables
+- Should integrate with pre-commit hooks and CI runners
+- Consider mise for unified toolchain management (Rust, Python, Node, buf versions)
+
+### Parallel Opportunities
+- T129-T133 all independent after T128 decision
+
+### Dependencies
+- Depends on WP00 (proto repo exists), WP01 (core repo exists)
+
+### Risks & Mitigations
+- Runner not available on all CI images: use install step or container with runner pre-installed
+
+---
+
+## Dependency & Execution Summary
+
+```
+Phase 0 (Foundation — parallel across repos):
+  WP00 (Proto scaffold) ─────── first, no deps
+  WP01 (Core Rust scaffold) ─── depends on WP00
+  WP02 (MCP Python scaffold) ── depends on WP00
+  WP08 (Agents repo scaffold) ─ depends on WP00 (can start repo init in parallel with WP01)
+  WP17 (Integrations repo scaffold) ── depends on WP00 (can start repo init in parallel with WP01)
+
+Phase 1 (Domain — in agileplus-core, after WP01):
+  WP03 (Feature/FSM) ────┐
+  WP04 (Governance/Audit) ┤── parallel, both depend on WP01
+  WP05 (Port traits) ─────┘── depends on WP03, WP04
+
+Phase 2 (Core Adapters — parallel after WP05):
+  WP06 (SQLite) ──────────┐
+  WP07 (Git) ─────────────┤── all in agileplus-core, depend on WP05
+  WP10 (Telemetry) ───────┘
+
+Phase 2b (External Repo Adapters — parallel, in their own repos):
+  WP09 (Review) ──────────── in agileplus-agents, depends on WP08
+  WP18 (Plane.so Sync) ───── in agileplus-integrations, depends on WP17
+  WP19 (GitHub Sync) ─────── in agileplus-integrations, depends on WP17
+
+Phase 3 (CLI — in agileplus-core, after core adapters):
+  WP11 (Specify/Research) ─── depends on WP06, WP07, WP10
+  WP12 (Plan/Implement) ──── depends on WP11 (agent dispatch via gRPC to WP08)
+  WP13 (Validate/Ship/Retro) ── depends on WP12
+
+Phase 4 (Cross-repo Integration — after CLI):
+  WP14 (gRPC Server + MCP) ── depends on WP00, WP13 (core gRPC + mcp tools)
+  WP15 (API + Creds) ──────── depends on WP14
+  WP16 (BDD + Integration) ── depends on WP15 (Docker Compose with all 4 services)
+
+Phase 5 (Sub-Commands & CLI Triage):
+  WP20 (Hidden Sub-Cmds) ─── depends on WP13, WP17, WP18, WP19
+  WP21 (CLI Triage/Queue) ── depends on WP17, WP20
+
+Phase 0b (DX Tooling — after repo scaffolds):
+  WP22 (Task Runner Migration) ── depends on WP00, WP01
+```
+
+**Parallelization**: WP00 is the only sequential bottleneck. After WP00, up to 4 repos can be scaffolded in parallel (WP01, WP02, WP08, WP17). Phase 2 has 3 core adapter WPs in parallel + 3 external adapter WPs in parallel across repos.
+
+**MVP Scope**: WP00 → WP01 → WP03 → WP05 → WP06 → WP07 → WP11 → WP12 → WP13 = 9 WPs for core CLI workflow (specify → ship). External services (agents, integrations, MCP) are additive.
+
+---
+
+## Subtask Index (Reference)
+
+| Subtask | Summary | WP | Priority | Parallel? |
+|---------|---------|-----|----------|-----------|
+| T000a | Init proto repo | WP00 | P0 | No |
+| T000b | common.proto shared types | WP00 | P0 | No |
+| T000c | core.proto service | WP00 | P0 | Yes |
+| T000d | agents.proto service | WP00 | P0 | Yes |
+| T000e | integrations.proto service | WP00 | P0 | Yes |
+| T000f | buf.yaml + buf.gen.yaml | WP00 | P0 | No |
+| T000f2 | buf breaking change baseline + CI check | WP00 | P0 | No |
+| T000g | Rust/Python codegen crates | WP00 | P0 | No |
+| T001 | Cargo workspace manifest (7 crates) | WP01 | P0 | No |
+| T002 | Scaffold agileplus-domain | WP01 | P0 | Yes |
+| T003 | Scaffold 6 adapter crates | WP01 | P0 | Yes |
+| T004 | Makefile | WP01 | P0 | Yes |
+| T005 | Docker Compose | WP01 | P0 | Yes |
+| T006 | Proto generation | WP01 | P0 | No |
+| T006b | MSRV CI check (latest stable Rust) | WP01 | P0 | No |
+| T006c | rustdoc CI generation + FR/WP traceability headers | WP01 | P0 | No |
+| T006d | CI lint: agileplus-domain zero-dep validation | WP01 | P0 | No |
+| T007 | Python pyproject.toml | WP02 | P0 | No |
+| T008 | FastMCP server entry | WP02 | P0 | No |
+| T009 | gRPC client stub | WP02 | P0 | Yes |
+| T010 | MCP tool stubs | WP02 | P0 | Yes |
+| T011 | Python test structure | WP02 | P0 | No |
+| T011b | sphinx/autodoc CI generation for Python API ref | WP02 | P0 | No |
+| T012 | Feature struct | WP03 | P0 | No |
+| T013 | FeatureState enum | WP03 | P0 | No |
+| T014 | State machine logic | WP03 | P0 | No |
+| T015 | WorkPackage struct | WP03 | P0 | Yes |
+| T016 | WP dependency logic | WP03 | P0 | Yes |
+| T017 | FSM unit tests | WP03 | P0 | No |
+| T017b | proptest property-based tests for FSM transitions | WP03 | P0 | No |
+| T017c | cargo-mutants on state_machine.rs (≥90% score) | WP03 | P0 | No |
+| T018 | GovernanceContract | WP04 | P0 | Yes |
+| T019 | AuditEntry struct | WP04 | P0 | Yes |
+| T020 | hash_entry() | WP04 | P0 | No |
+| T021 | verify_chain() | WP04 | P0 | No |
+| T022 | Evidence struct | WP04 | P0 | Yes |
+| T023 | PolicyRule struct | WP04 | P0 | Yes |
+| T024 | Governance unit tests | WP04 | P0 | No |
+| T024b | proptest property-based tests for hash chain + governance | WP04 | P0 | No |
+| T024c | cargo-mutants on audit.rs + governance.rs (≥90% score) | WP04 | P0 | No |
+| T024d | Import/extend Phenotype governance patterns (FR-028, FR-029) | WP04 | P0 | No |
+| T025 | StoragePort trait | WP05 | P0 | No |
+| T026 | VcsPort trait | WP05 | P0 | Yes |
+| T027 | AgentPort trait | WP05 | P0 | Yes |
+| T028 | ReviewPort trait | WP05 | P0 | Yes |
+| T029 | ObservabilityPort trait | WP05 | P0 | Yes |
+| T030 | Port module re-exports | WP05 | P0 | No |
+| T031 | SQLite migrations | WP06 | P1 | No |
+| T032 | SqliteStorageAdapter | WP06 | P1 | No |
+| T033 | Feature CRUD | WP06 | P1 | Yes |
+| T034 | WP CRUD | WP06 | P1 | Yes |
+| T035 | Audit CRUD | WP06 | P1 | Yes |
+| T036 | Evidence+policy+metric CRUD | WP06 | P1 | Yes |
+| T037 | rebuild_from_git | WP06 | P1 | No |
+| T038 | GitVcsAdapter | WP07 | P1 | No |
+| T039 | Worktree ops | WP07 | P1 | Yes |
+| T040 | Branch ops | WP07 | P1 | Yes |
+| T041 | Artifact ops | WP07 | P1 | Yes |
+| T042 | Git history scanning | WP07 | P1 | No |
+| T043 | Git integration tests | WP07 | P1 | No |
+| T044 | Init agents repo + workspace | WP08 | P1 | No |
+| T044b | AgentDispatchAdapter | WP08 | P1 | No |
+| T045 | Claude Code harness | WP08 | P1 | Yes |
+| T046 | Codex harness | WP08 | P1 | Yes |
+| T047 | Agent dispatch logic | WP08 | P1 | No |
+| T048 | PR creation + description | WP08 | P1 | No |
+| T049 | Review-fix loop | WP08 | P1 | No |
+| T049b | Agent gRPC service (agents.proto) | WP08 | P1 | No |
+| T050 | ReviewAdapter | WP09 | P1 | No |
+| T051 | Coderabbit integration | WP09 | P1 | Yes |
+| T052 | Manual review fallback | WP09 | P1 | Yes |
+| T053 | CI status checking | WP09 | P1 | Yes |
+| T054 | Review unit tests | WP09 | P1 | No |
+| T055 | TelemetryAdapter | WP10 | P1 | No |
+| T056 | OTel traces | WP10 | P1 | Yes |
+| T057 | OTel metrics | WP10 | P1 | Yes |
+| T058 | Structured logging | WP10 | P1 | Yes |
+| T059 | OTel config schema | WP10 | P1 | No |
+| T060 | CLI main + clap | WP11 | P1 | No |
+| T061 | specify command | WP11 | P1 | Yes |
+| T062 | research command | WP11 | P1 | Yes |
+| T063 | Refinement loop logic | WP11 | P1 | No |
+| T064 | Governance checks in planning | WP11 | P1 | No |
+| T065 | DI wiring for specify/research | WP11 | P1 | No |
+| T066 | plan command | WP12 | P1 | Yes |
+| T067 | File scope detection | WP12 | P1 | No |
+| T068 | Dependency-aware scheduler | WP12 | P1 | No |
+| T069 | implement command | WP12 | P1 | Yes |
+| T070 | PR description builder | WP12 | P1 | No |
+| T071 | Review-fix orchestrator | WP12 | P1 | No |
+| T072 | DI wiring for plan/implement | WP12 | P1 | No |
+| T073 | validate command | WP13 | P1 | Yes |
+| T074 | Governance gate evaluator | WP13 | P1 | No |
+| T075 | ship command | WP13 | P1 | Yes |
+| T076 | retrospective command | WP13 | P1 | No |
+| T077 | State machine enforcement | WP13 | P1 | No |
+| T078 | DI wiring for validate/ship/retro | WP13 | P1 | No |
+| T079 | tonic gRPC server | WP14 | P2 | Yes |
+| T080 | gRPC handler wiring | WP14 | P2 | No |
+| T080b | gRPC proxy to agents/integrations | WP14 | P2 | No |
+| T081 | Python gRPC client | WP14 | P2 | Yes |
+| T082 | MCP tool handlers | WP14 | P2 | No |
+| T083 | Agent event streaming | WP14 | P2 | No |
+| T084 | Pact contract tests | WP14 | P2 | No |
+| T084b | MCP Sampling primitive (server-initiated triage/governance) | WP14 | P2 | No |
+| T084c | MCP Roots primitive (workspace boundaries per feature/WP) | WP14 | P2 | No |
+| T084d | MCP Elicitation primitive (discovery interview flows) | WP14 | P2 | No |
+| T085 | axum router | WP15 | P2 | No |
+| T086 | API route handlers | WP15 | P2 | No |
+| T087 | Auth middleware | WP15 | P2 | Yes |
+| T088 | Credential management | WP15 | P2 | Yes |
+| T089 | Config schema + loader | WP15 | P2 | Yes |
+| T090 | API integration tests | WP15 | P2 | No |
+| T091 | BDD .feature files | WP16 | P2 | No |
+| T092 | Rust BDD step defs | WP16 | P2 | Yes |
+| T093 | Python BDD step defs | WP16 | P2 | Yes |
+| T094 | Pact contract fixtures | WP16 | P2 | Yes |
+| T095 | Docker Compose test env | WP16 | P2 | No |
+| T096 | Full workflow integration test | WP16 | P2 | No |
+| T097 | Test fixtures | WP16 | P2 | No |
+| T098 | Init integrations repo + workspace | WP17 | P2 | No |
+| T098b | TriageAdapter + classify | WP17 | P2 | No |
+| T099 | BacklogItem CRUD | WP17 | P2 | No |
+| T100 | Intent classifier | WP17 | P2 | No |
+| T101 | CLAUDE.md router gen | WP17 | P2 | No |
+| T102 | AGENTS.md gen | WP17 | P2 | No |
+| T102b | Integrations gRPC service (integrations.proto) | WP17 | P2 | No |
+| T103 | Triage unit tests | WP17 | P2 | No |
+| T104 | PlaneSyncAdapter | WP18 | P2 | No |
+| T105 | Feature → Plane.so sync | WP18 | P2 | Yes |
+| T106 | WP → Plane.so sync | WP18 | P2 | Yes |
+| T107 | Plane.so conflict detection | WP18 | P2 | No |
+| T108 | Plane.so mock tests | WP18 | P2 | No |
+| T109 | GitHubSyncAdapter | WP19 | P2 | No |
+| T110 | Bug → GitHub issue sync | WP19 | P2 | Yes |
+| T111 | Issue status sync | WP19 | P2 | Yes |
+| T112 | GitHub conflict detection | WP19 | P2 | No |
+| T113 | GitHub mock tests | WP19 | P2 | No |
+| T114 | Sub-command registry | WP20 | P2 | No |
+| T115 | Triage sub-commands | WP20 | P2 | Yes |
+| T116 | Governance sub-commands | WP20 | P2 | Yes |
+| T117 | Sync sub-commands | WP20 | P2 | Yes |
+| T118 | Git/devops sub-commands | WP20 | P2 | Yes |
+| T119 | Context/escape sub-commands | WP20 | P2 | Yes |
+| T120 | Sub-command audit logging | WP20 | P2 | No |
+| T121 | triage CLI command | WP21 | P2 | No |
+| T122 | queue CLI command | WP21 | P2 | No |
+| T123 | Agent auto-triage hook | WP21 | P2 | No |
+| T124 | Agent DevOps defaults | WP21 | P2 | No |
+| T125 | CLAUDE.md first-action classifier | WP21 | P2 | No |
+| T126 | Triage/queue DI wiring | WP21 | P2 | No |
+| T127 | Seed sub-command prompts | WP21 | P2 | No |
+| T128 | Research/evaluate task runners (just, task, mise, moon, nx) | WP22 | P1 | No |
+| T129 | Migrate agileplus-proto Makefile | WP22 | P1 | Yes |
+| T130 | Create agileplus-core task config | WP22 | P1 | Yes |
+| T131 | Create agileplus-mcp task config | WP22 | P1 | Yes |
+| T132 | Create agileplus-agents task config | WP22 | P1 | Yes |
+| T133 | Create agileplus-integrations task config | WP22 | P1 | Yes |
+| T134 | Update CI workflows + pre-commit for new runner | WP22 | P1 | No |

--- a/.agileplus/specs/002-org-wide-release-governance-dx-automation/meta.json
+++ b/.agileplus/specs/002-org-wide-release-governance-dx-automation/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "002-org-wide-release-governance-dx-automation",
+  "title": "Org-Wide Release Governance & DX Automation",
+  "status": "active",
+  "created": "2026-03-01"
+}

--- a/.agileplus/specs/002-org-wide-release-governance-dx-automation/spec.md
+++ b/.agileplus/specs/002-org-wide-release-governance-dx-automation/spec.md
@@ -1,0 +1,215 @@
+# Feature Specification: Org-Wide Release Governance & DX Automation
+
+**Feature Branch**: `002-org-wide-release-governance-dx-automation`
+**Created**: 2026-03-01
+**Status**: Draft
+**Input**: User description: "Org-wide DX infrastructure and release governance automation: GitHub Actions publishing workflows (npm, PyPI, crates.io), pre-commit/pre-push hooks, Taskfile or CLI DX commands, experimental/dev/alpha package variants and release channels following the existing 5-tier release channel governance (alpha → canary → beta → rc → prod) as defined in STACKED_PRS_AND_RELEASE_CHANNELS.md. Should cover all repos in the Phenotype org."
+
+---
+
+## Context
+
+The Phenotype organization maintains ~47 repositories spanning Rust, Python, TypeScript, Go, and Elixir. A comprehensive 5-tier release channel governance model (alpha → canary → beta → rc → prod) already exists as documentation but is only implemented in 3 of 47 repos. Publishing to package registries (npm, PyPI, crates.io) is currently manual. Only 9/47 repos have pre-commit hooks. 31/47 have task runners (Taskfile.yml) but with no standardized target set. There is no cross-repo orchestration CLI and no automated channel promotion workflow.
+
+This feature evolves the existing governance model — keeping all 5 tiers but adapting how repos engage based on risk profile — and codifies it into reusable CI workflows, DX tooling, and automated publishing pipelines across the entire org.
+
+---
+
+## User Scenarios & Testing
+
+### User Story 1 — Developer Publishes a Pre-Release Package (Priority: P1)
+
+A developer working on a Rust crate, Python package, or npm module wants to publish a pre-release variant (e.g., `0.2.0-alpha.1`) to the appropriate registry when their feature reaches the alpha channel. The system automatically versions, builds, and publishes the pre-release artifact when the developer promotes their work to a release channel.
+
+**Why this priority**: Publishing is the core value — every other feature builds on the ability to get packages to registries with correct versioning tied to release channels.
+
+**Independent Test**: A developer tags or promotes a branch to `alpha` and the corresponding package appears on the registry within minutes with the correct pre-release version suffix.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Rust crate at version `0.2.0` on the `alpha` channel, **When** the developer triggers a channel promotion to alpha, **Then** version `0.2.0-alpha.1` is published to crates.io automatically.
+2. **Given** a Python package at version `0.3.0` promoted to `beta`, **When** the CI pipeline runs, **Then** version `0.3.0b1` is published to PyPI with the correct PEP 440 pre-release suffix.
+3. **Given** an npm package promoted to `canary`, **When** CI completes, **Then** version `0.1.5-canary.1` is published to npm with the `canary` dist-tag.
+4. **Given** a package promoted to `prod`, **When** CI completes, **Then** the stable version (no suffix) is published to the registry.
+5. **Given** a package marked as private, **When** any promotion occurs, **Then** the publishing step is skipped and no registry upload is attempted.
+
+---
+
+### User Story 2 — Developer Runs Standardized Local DX Commands (Priority: P1)
+
+A developer clones any Phenotype repo and immediately has access to consistent task runner commands for building, testing, linting, and promoting releases — regardless of the repo's language or build system.
+
+**Why this priority**: Tied with publishing — local DX is the daily driver. Without consistent commands, developers waste time learning per-repo idiosyncrasies.
+
+**Independent Test**: Clone any Phenotype repo, run the standard lint/test/build commands, and get correct results without reading repo-specific documentation.
+
+**Acceptance Scenarios**:
+
+1. **Given** a freshly cloned Phenotype repo with the task runner installed, **When** the developer runs the `lint` task, **Then** the appropriate language-specific linter executes and reports results.
+2. **Given** any repo, **When** the developer runs the `test` task, **Then** the repo's test suite runs with correct environment setup.
+3. **Given** any repo, **When** the developer runs the `build` task, **Then** the project compiles/builds successfully.
+4. **Given** a publishable repo, **When** the developer runs the `release:promote <channel>` task, **Then** the promotion workflow initiates with appropriate gate checks.
+5. **Given** a repo without a specific task (e.g., Rust repo has no `docs:build`), **When** the developer runs that task, **Then** a clear message indicates the task is not applicable to this repo.
+
+---
+
+### User Story 3 — CI Enforces Channel Promotion Gates (Priority: P2)
+
+When a developer or automation promotes a package from one release channel to the next (e.g., canary → beta), CI automatically validates that all gate requirements for the target channel are met before allowing the promotion.
+
+**Why this priority**: Gates prevent broken or incomplete packages from reaching higher-stability channels. Critical for quality but depends on publishing (P1) working first.
+
+**Independent Test**: Attempt to promote a package that fails a gate requirement and verify it is blocked with clear feedback.
+
+**Acceptance Scenarios**:
+
+1. **Given** a package on the `canary` channel being promoted to `beta`, **When** unit tests pass but integration tests fail, **Then** the promotion is blocked with a report identifying the failing gate.
+2. **Given** a package promoted to `rc`, **When** all tests pass but no rollback runbook is attached, **Then** the promotion is blocked until the runbook requirement is satisfied.
+3. **Given** a high-risk feature (as classified in the risk matrix), **When** attempting to skip from `alpha` directly to `prod`, **Then** the system rejects the promotion and requires traversal through intermediate channels.
+4. **Given** a low-risk utility package, **When** promoted from `alpha` to `prod`, **Then** the system allows the promotion (low-risk packages may skip intermediate channels).
+5. **Given** any promotion attempt, **When** the gate check completes, **Then** a structured report is generated showing pass/fail status for each gate criterion.
+
+---
+
+### User Story 4 — Pre-Commit and Pre-Push Hooks Guard Quality (Priority: P2)
+
+Developers have standardized git hooks across all repos that enforce conventional commit messages, run fast lint checks before commit, and validate channel-appropriate constraints before push.
+
+**Why this priority**: Prevents bad commits from entering the pipeline. Dependent on the task runner (P1) for the actual lint/check commands.
+
+**Independent Test**: Make a commit with a non-conventional message and verify it is rejected.
+
+**Acceptance Scenarios**:
+
+1. **Given** a developer staging changes, **When** they commit with a message not following conventional commit format, **Then** the pre-commit hook rejects the commit with a helpful error message showing the expected format.
+2. **Given** a developer committing code, **When** the pre-commit hook runs, **Then** fast lint checks (formatting, encoding validation) execute in under 5 seconds.
+3. **Given** a developer pushing to a `beta/*` branch, **When** the pre-push hook runs, **Then** the full test suite executes and the push is blocked if tests fail.
+4. **Given** a developer pushing to a `feature/*` branch, **When** the pre-push hook runs, **Then** only fast checks run (not the full test suite) to keep the feedback loop quick.
+
+---
+
+### User Story 5 — Phenotype CLI Orchestrates Cross-Repo Operations (Priority: P3)
+
+An org maintainer or release manager uses a dedicated CLI tool to audit release status across all repos, promote packages in bulk, and manage the org-wide release matrix.
+
+**Why this priority**: Cross-repo orchestration is high-value but depends on per-repo publishing and gate infrastructure being in place first.
+
+**Independent Test**: Run the CLI's status audit command and get a complete view of all packages, their current channels, and any blocked promotions.
+
+**Acceptance Scenarios**:
+
+1. **Given** the Phenotype CLI installed, **When** the maintainer runs the release status command, **Then** a table shows every publishable package, its current channel, version, and registry status.
+2. **Given** multiple repos with packages ready for promotion, **When** the maintainer runs a bulk promote command for a specific channel, **Then** each package is promoted individually with its own gate checks, and a summary report is generated.
+3. **Given** a package with a failed gate check, **When** the maintainer runs the audit command, **Then** the blocked package is highlighted with the specific failing gate and remediation guidance.
+4. **Given** the release matrix template, **When** the maintainer runs the matrix generation command, **Then** a current-state release matrix is generated matching the format defined in the governance documentation.
+
+---
+
+### User Story 6 — Repo Adopts Governance via Single Command (Priority: P3)
+
+A developer or agent onboarding a new repo (or upgrading an existing one) runs a single bootstrap command that installs the task runner config, pre-commit hooks, CI workflows, and release channel configuration appropriate to the repo's language and risk profile.
+
+**Why this priority**: Adoption at scale requires frictionless onboarding. Without this, the 47-repo rollout would be manual and error-prone.
+
+**Independent Test**: Run the bootstrap command on a bare repo and verify all governance artifacts are created correctly.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Rust repo with no governance artifacts, **When** the developer runs the bootstrap command, **Then** the task runner config, pre-commit hooks, CI workflows, and release channel config are generated for Rust conventions.
+2. **Given** a Python repo, **When** bootstrapped, **Then** the generated artifacts use Python-appropriate tooling (PyPI publishing, Python linters, PEP 440 versioning).
+3. **Given** a multi-language repo (e.g., Rust + Python FFI), **When** bootstrapped, **Then** artifacts for all detected languages are generated with appropriate per-language publishing targets.
+4. **Given** a private repo (not published to any registry), **When** bootstrapped, **Then** publishing workflows are omitted but lint/test/hook infrastructure is still installed.
+
+---
+
+### Edge Cases
+
+- What happens when a registry is unreachable during automated publishing? The workflow retries with exponential backoff and alerts the maintainer after 3 failures.
+- What happens when crates.io rate-limits publishing? The workflow queues remaining publishes with appropriate delays and resumes automatically.
+- What happens when a workspace has interdependent packages? Publishing follows topological dependency order (leaf crates first).
+- What happens when a pre-release version already exists on the registry? The version number auto-increments the pre-release suffix (e.g., `alpha.1` → `alpha.2`).
+- What happens when a repo has no `main` branch? The bootstrap command detects the default branch and adapts accordingly.
+- What happens when two developers promote the same package concurrently? The CI pipeline uses locking/serialization to prevent race conditions.
+
+---
+
+## Requirements
+
+### Functional Requirements
+
+**Automated Publishing**
+
+- **FR-001**: System MUST publish packages to their respective registries (npm, PyPI, crates.io) when a release channel promotion occurs.
+- **FR-002**: System MUST apply correct pre-release version suffixes per registry convention: SemVer pre-release for npm/crates.io (`-alpha.N`), PEP 440 for PyPI (`aN`, `bN`, `rcN`).
+- **FR-003**: System MUST support all public packages for pre-release variant publishing from day one, regardless of maturity level.
+- **FR-004**: System MUST skip publishing for packages marked as private.
+- **FR-005**: System MUST publish workspace/monorepo packages in topological dependency order.
+- **FR-006**: System MUST handle registry rate limits with automatic retry and backoff.
+- **FR-007**: System MUST prevent publishing from dirty working trees — all automation publishes from clean, committed state only.
+
+**Release Channel Governance**
+
+- **FR-008**: System MUST implement the 5-tier release channel model: alpha → canary → beta → rc → prod.
+- **FR-009**: System MUST enforce risk-based channel traversal: high-risk features traverse canary → beta → rc minimum; low-risk features may skip intermediate channels.
+- **FR-010**: System MUST enforce per-channel gate criteria before allowing promotion (lint, tests, security, docs, rollback plan as applicable per channel).
+- **FR-011**: System MUST generate structured promotion reports showing pass/fail status for each gate criterion.
+- **FR-012**: System MUST support the stacked PR model with dependency-ordered merge chains.
+
+**DX Tooling — Per-Repo Task Runner**
+
+- **FR-013**: System MUST provide standardized task runner targets across all repos: `lint`, `test`, `build`, `format`, `release:promote`, `release:status`.
+- **FR-014**: System MUST evaluate and adopt the best modern task runner for a polyglot org (candidates: mise, just, or alternatives based on 2026 ecosystem evaluation), replacing current fragmented usage.
+- **FR-015**: System MUST auto-detect the repo's language(s) and configure language-appropriate tooling behind the standard task names.
+
+**DX Tooling — Phenotype CLI**
+
+- **FR-016**: System MUST provide a CLI tool for cross-repo operations: audit release status, bulk promote, generate release matrix, bootstrap repos.
+- **FR-017**: System MUST support a bootstrap command that installs all governance artifacts (task runner config, hooks, CI workflows, release config) for a given repo based on detected language and risk profile.
+
+**Git Hooks**
+
+- **FR-018**: System MUST provide pre-commit hooks that enforce conventional commit message format and run fast lint/format checks.
+- **FR-019**: System MUST provide pre-push hooks that run channel-appropriate validation (fast checks for feature branches, full test suite for beta+ branches).
+- **FR-020**: Pre-commit hooks MUST complete in under 5 seconds for typical commits.
+
+**CI/CD Workflows**
+
+- **FR-021**: System MUST provide reusable CI workflow templates that repos can adopt via the bootstrap command.
+- **FR-022**: System MUST run the complete gate checklist (lint, format, unit tests, integration tests, dependency checks, docs build, security checks) as defined in the existing governance documentation.
+- **FR-023**: System MUST support both automatic (tag/branch-based) and manual (workflow dispatch) promotion triggers.
+
+### Key Entities
+
+- **Package**: A publishable unit (crate, Python package, or npm module) with a name, version, registry target, and privacy flag.
+- **Release Channel**: One of the 5 tiers (alpha, canary, beta, rc, prod) with associated gate criteria and version suffix conventions.
+- **Risk Profile**: Classification of a package or feature as low, medium, or high risk, determining minimum channel traversal requirements.
+- **Gate Criterion**: A specific check (lint, test, security, rollback plan, etc.) required for promotion to a given channel.
+- **Promotion**: The act of advancing a package from one release channel to the next, subject to gate validation.
+- **Release Matrix**: An org-wide view of all packages, their current channels, versions, and promotion status.
+
+---
+
+## Assumptions
+
+- All repos will eventually adopt the standardized tooling; rollout may be phased but the target is 100% coverage.
+- The existing governance documentation (STACKED_PRS_AND_RELEASE_CHANNELS.md) is the authoritative source for channel definitions and gate criteria.
+- Registry credentials (npm tokens, PyPI tokens, crates.io tokens) will be stored as GitHub organization secrets, not per-repo.
+- The Phenotype CLI will be a standalone tool distributed via one of the supported registries.
+- Repos currently using Taskfile.yml will be migrated to the chosen task runner; backward compatibility is not required.
+- The task runner evaluation will be finalized during the design phase based on 2026 ecosystem state.
+- git-cliff will remain the changelog generation tool (already proven in 3 repos).
+
+---
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of public packages can be published to their respective registries via automated CI workflow within 10 minutes of a channel promotion trigger.
+- **SC-002**: Pre-release versions for all 5 channels are correctly formatted and accepted by their respective registries on first attempt.
+- **SC-003**: Any developer can clone a Phenotype repo and run `lint`, `test`, `build` successfully within 2 minutes of setup, across all 47 repos.
+- **SC-004**: Channel promotion gate checks block 100% of promotions that fail mandatory criteria, with zero false negatives.
+- **SC-005**: Pre-commit hooks reject non-conventional commit messages 100% of the time and complete in under 5 seconds.
+- **SC-006**: A new repo can be fully bootstrapped with all governance artifacts in under 1 minute via a single command.
+- **SC-007**: The org-wide release status audit provides a complete view of all publishable packages and their channel status in under 30 seconds.
+- **SC-008**: Reduction in manual publishing errors to zero — no more dirty-tree publishes, no more rate-limit surprises, no more missed dependency ordering.

--- a/.agileplus/specs/002-org-wide-release-governance-dx-automation/tasks.md
+++ b/.agileplus/specs/002-org-wide-release-governance-dx-automation/tasks.md
@@ -1,0 +1,637 @@
+# Work Packages: Org-Wide Release Governance & DX Automation
+
+**Inputs**: Design documents from `kitty-specs/002-org-wide-release-governance-dx-automation/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/registry-adapter.md
+
+**Tests**: Include testing in each WP where appropriate (adapter tests, CLI tests, workflow validation).
+
+**Organization**: Fine-grained subtasks (`Txxx`) roll up into work packages (`WPxx`). Each work package is independently deliverable and testable.
+
+**Prompt Files**: Each WP references a prompt file in `tasks/`. Lane status in YAML frontmatter.
+
+---
+
+## Work Package WP01: CLI Scaffold & Adapter Interface (Priority: P0)
+
+**Goal**: Create the `pheno-cli` Go project with Cobra skeleton, adapter interface, and version calculation logic.
+**Independent Test**: `pheno --help` shows all subcommands; adapter interface compiles; version calculation unit tests pass.
+**Prompt**: `tasks/WP01-cli-scaffold-adapter-interface.md`
+**Estimated Size**: ~450 lines
+
+### Included Subtasks
+- [x] T001 Initialize Go module (`pheno-cli`) with Cobra + Viper + Lipgloss deps
+- [x] T002 Create Cobra root command with subcommand stubs (publish, promote, audit, bootstrap, matrix, config)
+- [x] T003 Define `RegistryAdapter` interface in `internal/adapters/adapter.go`
+- [x] T004 Implement `internal/version/calculator.go` — version suffix logic per registry per channel
+- [x] T005 [P] Implement `internal/detect/detector.go` — language/manifest auto-detection
+- [x] T006 Unit tests for version calculator (all 7 registries × 5 channels)
+
+### Implementation Notes
+- Go 1.23+, use `go mod init github.com/KooshaPari/pheno-cli`
+- Adapter interface: `Detect()`, `Version()`, `Build()`, `Publish()`, `Verify()`
+- Version calculator is pure logic, no I/O — easy to test exhaustively
+
+### Parallel Opportunities
+- T005 (detector) can proceed in parallel with T004 (version calculator)
+
+### Dependencies
+- None (starting package)
+
+### Risks & Mitigations
+- PyPI PEP 440 edge cases (dev vs alpha ordering) → comprehensive test matrix
+
+---
+
+## Work Package WP02: npm Adapter (Priority: P0)
+
+**Goal**: Implement the npm registry adapter — detect, version, build, publish, verify.
+**Independent Test**: Adapter detects package.json, calculates correct npm pre-release versions, publishes with dist-tags.
+**Prompt**: `tasks/WP02-npm-adapter.md`
+**Estimated Size**: ~350 lines
+
+### Included Subtasks
+- [x] T007 Implement `internal/adapters/npm.go` — Detect (parse package.json, check private field)
+- [x] T008 Implement npm Version (SemVer pre-release + dist-tag mapping)
+- [x] T009 Implement npm Build (`npm pack`)
+- [x] T010 Implement npm Publish (`npm publish --tag <channel>`) with retry/backoff
+- [x] T011 Implement npm Verify (check registry API for published version)
+- [x] T012 Unit + integration tests for npm adapter
+
+### Implementation Notes
+- Dist-tag mapping: alpha→alpha, canary→canary, beta→beta, rc→rc, prod→latest
+- Handle scoped packages (`@org/name`)
+- Private detection: `"private": true` in package.json
+
+### Parallel Opportunities
+- All of WP02 can proceed in parallel with WP03 and WP04
+
+### Dependencies
+- Depends on WP01 (adapter interface)
+
+### Risks & Mitigations
+- npm 2FA/OTP — document that CI uses granular access tokens with 2FA bypass
+
+---
+
+## Work Package WP03: PyPI Adapter (Priority: P0)
+
+**Goal**: Implement the PyPI registry adapter with PEP 440 versioning.
+**Independent Test**: Adapter detects pyproject.toml, applies correct PEP 440 suffixes, publishes via twine.
+**Prompt**: `tasks/WP03-pypi-adapter.md`
+**Estimated Size**: ~350 lines
+
+### Included Subtasks
+- [x] T013 Implement `internal/adapters/pypi.go` — Detect (parse pyproject.toml, check classifiers)
+- [x] T014 Implement PyPI Version (PEP 440: alpha→aN, canary→devN, beta→bN, rc→rcN)
+- [x] T015 Implement PyPI Build (`python -m build`)
+- [x] T016 Implement PyPI Publish (`twine upload`) with retry/backoff
+- [x] T017 Implement PyPI Verify (check PyPI JSON API for version)
+- [x] T018 Unit + integration tests for PyPI adapter
+
+### Implementation Notes
+- PEP 440 normalization: `0.2.0a1` not `0.2.0-alpha.1`
+- Canary maps to `devN` (sorts before alpha in PEP 440)
+- Private detection: `Private :: Do Not Upload` classifier
+- Support both hatchling and setuptools backends
+
+### Parallel Opportunities
+- All of WP03 can proceed in parallel with WP02 and WP04
+
+### Dependencies
+- Depends on WP01 (adapter interface)
+
+### Risks & Mitigations
+- Multiple Python build backends (hatchling, setuptools, uv_build) — adapter calls `python -m build` generically
+
+---
+
+## Work Package WP04: crates.io Adapter (Priority: P0)
+
+**Goal**: Implement the crates.io registry adapter with workspace dependency ordering.
+**Independent Test**: Adapter detects Cargo.toml (including workspaces), publishes crates in topological order.
+**Prompt**: `tasks/WP04-crates-adapter.md`
+**Estimated Size**: ~400 lines
+
+### Included Subtasks
+- [x] T019 Implement `internal/adapters/crates.go` — Detect (parse Cargo.toml, workspace members, publish field)
+- [x] T020 Implement crates.io Version (SemVer pre-release: `-alpha.N`, `-beta.N`, etc.)
+- [x] T021 Implement topological dependency sorting for workspace crates
+- [x] T022 Implement crates.io Build (`cargo package`) and Publish (`cargo publish`) with rate-limit retry
+- [x] T023 Implement crates.io Verify (check crates.io API for version availability)
+- [x] T024 Unit + integration tests (including workspace ordering tests)
+
+### Implementation Notes
+- Rate limiting: crates.io returns 429 with Retry-After header — parse and honor it
+- Workspace detection: parse `[workspace] members = [...]`, resolve paths
+- Topological sort: build dependency graph from `[dependencies]` path deps, publish leaves first
+- Never `--allow-dirty` — fail if working tree is dirty
+
+### Parallel Opportunities
+- All of WP04 can proceed in parallel with WP02 and WP03
+
+### Dependencies
+- Depends on WP01 (adapter interface)
+
+### Risks & Mitigations
+- crates.io rate limits (experienced firsthand) — retry with exponential backoff + Retry-After header
+
+---
+
+## Work Package WP05: Go Proxy + Pre-Wired Adapters (Priority: P1)
+
+**Goal**: Implement the Go module proxy adapter and stub adapters for Hex.pm, Zig, and Mojo.
+**Independent Test**: Go adapter detects go.mod, publishes via git tag. Stub adapters return "not yet supported" gracefully.
+**Prompt**: `tasks/WP05-go-proxy-prewired-adapters.md`
+**Estimated Size**: ~400 lines
+
+### Included Subtasks
+- [x] T025 Implement `internal/adapters/goproxy.go` — Detect (parse go.mod), Version (v-prefix SemVer)
+- [x] T026 Implement Go Publish (git tag + push — Go proxy pulls from VCS, no upload needed)
+- [x] T027 Implement Go Verify (check proxy.golang.org for module version)
+- [x] T028 [P] Implement `internal/adapters/hex.go` — Pre-wired stub (Detect from mix.exs, Version from SemVer, Publish/Verify return "not yet supported")
+- [x] T029 [P] Implement `internal/adapters/zig.go` — Pre-wired stub (Detect from build.zig.zon, git-tag-based versioning)
+- [x] T030 [P] Implement `internal/adapters/mojo.go` — Pre-wired stub (Detect from mojoproject.toml, returns "no registry available")
+- [x] T031 Unit tests for Go adapter + stub adapter behavior
+
+### Implementation Notes
+- Go proxy is unique: no "upload" step. Publishing = creating a git tag and pushing. Proxy discovers automatically.
+- Stubs implement the full adapter interface but return `ErrNotSupported` for Build/Publish/Verify
+- Hex adapter should parse mix.exs minimally (version, package name) even as a stub
+
+### Parallel Opportunities
+- T028, T029, T030 are fully parallel (independent stubs)
+
+### Dependencies
+- Depends on WP01 (adapter interface)
+
+### Risks & Mitigations
+- Go proxy caching delays — Verify should poll with 5-min timeout
+
+---
+
+## Work Package WP06: Gate Evaluation Engine (Priority: P1)
+
+**Goal**: Build the channel promotion gate evaluation system — define criteria per channel, evaluate, generate structured reports.
+**Independent Test**: Given a package and target channel, engine evaluates all gate criteria and returns pass/fail report.
+**Prompt**: `tasks/WP06-gate-evaluation-engine.md`
+**Estimated Size**: ~400 lines
+
+### Included Subtasks
+- [x] T032 Define gate criteria data model in `internal/gate/criteria.go` (per-channel requirements)
+- [x] T033 Implement gate evaluator in `internal/gate/evaluator.go` (run criteria, collect results)
+- [x] T034 Implement risk-based channel skip logic (low-risk can skip intermediates, high-risk must traverse all)
+- [x] T035 Implement structured report generation (pass/fail per criterion, stdout/stderr capture, duration)
+- [x] T036 Implement gate criteria: lint, unit_tests, integration_tests, security_audit, docs_build, rollback_plan
+- [x] T037 Unit tests for evaluator (mock task runner commands, test risk-based skipping)
+
+### Implementation Notes
+- Gate criteria execute task runner commands (e.g., `mise run lint`, `mise run test`)
+- Channel gates (from governance doc):
+  - canary: lint + unit tests + security pass, flags documented
+  - beta: user flows validated, default behavior unaffected
+  - rc: API contract freeze, migration/rollback runbook attached, docs synced
+  - prod: monitoring dashboards configured, rollback RTO met
+- Risk profile read from package config or inferred from manifest
+
+### Parallel Opportunities
+- T032-T033 (data model + evaluator) sequential; T034-T036 parallel after
+
+### Dependencies
+- Depends on WP01 (adapter interface for package detection)
+
+### Risks & Mitigations
+- Gate criteria may vary per repo — make criteria configurable via repo-level config file
+
+---
+
+## Work Package WP07: CLI Publish & Promote Commands (Priority: P1)
+
+**Goal**: Wire up `pheno publish` and `pheno promote` commands using adapters and gate engine.
+**Independent Test**: `pheno publish` detects packages and publishes to registries. `pheno promote` runs gates then publishes.
+**Prompt**: `tasks/WP07-cli-publish-promote.md`
+**Estimated Size**: ~400 lines
+
+### Included Subtasks
+- [x] T038 Implement `cmd/publish.go` — detect packages, select adapter, build, publish
+- [x] T039 Implement `cmd/promote.go` — validate channel transition, run gate evaluation, publish on pass
+- [x] T040 Implement workspace publishing orchestration (topological order, verify between publishes)
+- [x] T041 Add Lipgloss-styled progress output (publish progress, gate results table)
+- [x] T042 Add Viper config loading (registry credentials, default risk profile, org settings)
+- [x] T043 Integration tests (mock registries, test full publish and promote flows)
+
+### Implementation Notes
+- `pheno publish` is a direct publish (skip gates) — useful for manual intervention
+- `pheno promote` is gate-guarded — validates criteria before publishing
+- Config: `~/.config/pheno/config.toml` for global settings, `.pheno.toml` per repo
+- Credentials: read from env vars first, then config file, then GitHub secrets
+
+### Parallel Opportunities
+- T041 (UI output) can proceed in parallel with T038-T040 (logic)
+
+### Dependencies
+- Depends on WP01 (scaffold), WP02-WP05 (adapters), WP06 (gate engine)
+
+### Risks & Mitigations
+- Credential management complexity — provide clear error messages when creds missing
+
+---
+
+## Work Package WP08: CLI Audit & Matrix Commands (Priority: P2)
+
+**Goal**: Implement `pheno audit` (org-wide release status) and `pheno matrix` (release matrix generation).
+**Independent Test**: `pheno audit` scans all repos and shows package/channel/version table. `pheno matrix` generates governance-formatted matrix.
+**Prompt**: `tasks/WP08-cli-audit-matrix.md`
+**Estimated Size**: ~350 lines
+
+### Included Subtasks
+- [x] T044 Implement `cmd/audit.go` — scan configured repos, detect packages, query registries for current versions
+- [x] T045 Implement Lipgloss-styled audit table output (package, channel, version, registry URL, blocked-by)
+- [x] T046 Implement `cmd/matrix.go` — generate release matrix matching RELEASE_MATRIX_TEMPLATE.md format
+- [x] T047 Add repo discovery (scan directory for repos, or read from config file)
+- [x] T048 Unit + integration tests for audit and matrix commands
+
+### Implementation Notes
+- Repo discovery: by default scan parent directory for repos with supported manifests
+- Configurable via `~/.config/pheno/config.toml` → `repos_dir` or explicit repo list
+- Audit queries registries in parallel (one goroutine per repo)
+- Matrix output: markdown table matching governance template format
+
+### Parallel Opportunities
+- T044-T045 (audit) parallel with T046 (matrix)
+
+### Dependencies
+- Depends on WP01 (scaffold), WP02-WP05 (adapters for registry queries)
+
+### Risks & Mitigations
+- Registry API rate limits during audit — throttle parallel queries
+
+---
+
+## Work Package WP09: CLI Bootstrap Command (Priority: P2)
+
+**Goal**: Implement `pheno bootstrap` — one-command governance onboarding for any repo.
+**Independent Test**: Running `pheno bootstrap` on a bare repo creates all governance artifacts (task runner config, hooks, CI workflows, release config).
+**Prompt**: `tasks/WP09-cli-bootstrap.md`
+**Estimated Size**: ~450 lines
+
+### Included Subtasks
+- [x] T049 Implement `cmd/bootstrap.go` — orchestrate artifact generation based on detected languages
+- [x] T050 Create Go template files in `internal/templates/` for all generated artifacts
+- [x] T051 Implement mise.toml template generation (standardized tasks: lint, test, build, format, release:promote, release:status)
+- [x] T052 Implement pre-commit hook template generation (conventional commits, fast lint)
+- [x] T053 Implement pre-push hook template generation (channel-aware validation)
+- [x] T054 Implement CI workflow wrapper templates (ci.yml, release.yml calling phenotypeActions)
+- [x] T055 Implement cliff.toml template generation (git-cliff changelog config)
+- [x] T056 Integration test: bootstrap a mock repo and validate all artifacts
+
+### Implementation Notes
+- Language detection from WP01's detector → determines which templates to generate
+- Templates use Go `text/template` with repo-specific variables (name, language, registry, risk profile)
+- Multi-language repos get merged configs (e.g., mise.toml with both Rust and Python tasks)
+- Private repos: skip publishing templates but include lint/test/hook infrastructure
+- Generated CI workflows reference `KooshaPari/phenotypeActions/.github/workflows/<name>.yml@v1`
+
+### Parallel Opportunities
+- T051-T055 are all parallel (independent template files)
+
+### Dependencies
+- Depends on WP01 (scaffold, detector), WP10 (centralized CI workflows to reference)
+
+### Risks & Mitigations
+- Template drift between bootstrap-generated and centralized workflows — version-pin references
+
+---
+
+## Work Package WP10: Centralized CI Workflows (Priority: P1)
+
+**Goal**: Create reusable GitHub Actions workflows in `phenotypeActions` repo for publishing, gate-checking, and promotion.
+**Independent Test**: Reusable workflows can be called from any repo's CI with correct inputs.
+**Prompt**: `tasks/WP10-centralized-ci-workflows.md`
+**Estimated Size**: ~500 lines
+
+### Included Subtasks
+- [x] T057 Create `publish.yml` reusable workflow (registry-specific publish with retry/backoff)
+- [x] T058 Create `gate-check.yml` reusable workflow (run channel-specific gate criteria)
+- [x] T059 Create `promote.yml` reusable workflow (orchestrate gate-check → publish)
+- [x] T060 Create `changelog.yml` reusable workflow (git-cliff changelog generation on release)
+- [x] T061 Create `audit.yml` scheduled workflow (org-wide release status report)
+- [x] T062 Add workflow inputs/outputs schema (language, registry, channel, risk_profile, credentials)
+- [x] T063 Test workflows with `act` or dry-run mode
+
+### Implementation Notes
+- All workflows use `workflow_call` trigger for reusability
+- Inputs: language (rust|python|typescript|go), registry, channel, risk_profile, version
+- Secrets: `NPM_TOKEN`, `PYPI_TOKEN`, `CRATES_TOKEN` from org-level secrets
+- publish.yml: retry on 429 with exponential backoff (parse Retry-After header)
+- gate-check.yml: run `mise run lint`, `mise run test`, etc. — fail if any gate fails
+- promote.yml: composite — calls gate-check, then publish on success
+
+### Parallel Opportunities
+- T057-T061 are all parallel (independent workflow files)
+
+### Dependencies
+- None (can proceed independently; WP09 references these)
+
+### Risks & Mitigations
+- GitHub Actions reusable workflow limitations (max 4 levels of nesting) — keep flat
+
+---
+
+## Work Package WP11: Task Runner Evaluation & Standardization (Priority: P1)
+
+**Goal**: Finalize task runner choice (mise recommended), create standardized task definitions for all 4 active languages.
+**Independent Test**: Standard tasks (lint, test, build, format) work correctly for Rust, Python, TypeScript, and Go repos.
+**Prompt**: `tasks/WP11-task-runner-standardization.md`
+**Estimated Size**: ~400 lines
+
+### Included Subtasks
+- [x] T064 Final evaluation: validate mise monorepo tasks feature stability (or select alternative)
+- [x] T065 Create reference mise.toml for Rust projects (cargo clippy, cargo test, cargo build, rustfmt)
+- [x] T066 [P] Create reference mise.toml for Python projects (ruff check, pytest, build, ruff format)
+- [x] T067 [P] Create reference mise.toml for TypeScript projects (eslint, vitest/jest, tsc, prettier)
+- [x] T068 [P] Create reference mise.toml for Go projects (golangci-lint, go test, go build, gofmt)
+- [x] T069 Create reference mise.toml with release:promote and release:status tasks (calls pheno CLI)
+- [x] T070 Validate all reference configs on sample repos from the org
+
+### Implementation Notes
+- If mise monorepo tasks not stable by implementation time, fall back to moon or per-repo mise.toml
+- Each reference config includes: lint, test, build, format, release:promote, release:status
+- release:promote calls `pheno promote <channel>`; release:status calls `pheno audit --repo .`
+- Tool version pinning in each mise.toml (rust, python, node, go versions)
+
+### Parallel Opportunities
+- T065-T068 are fully parallel (per-language configs)
+
+### Dependencies
+- Depends on WP07 (pheno CLI publish/promote for release tasks)
+
+### Risks & Mitigations
+- mise experimental features may be unstable — have moon fallback plan documented
+
+---
+
+## Work Package WP12: Pre-Commit & Pre-Push Hooks (Priority: P2)
+
+**Goal**: Create standardized git hook infrastructure — conventional commit enforcement, fast lint, channel-aware pre-push validation.
+**Independent Test**: Non-conventional commit messages are rejected in <5s. Pre-push runs channel-appropriate checks.
+**Prompt**: `tasks/WP12-pre-commit-pre-push-hooks.md`
+**Estimated Size**: ~350 lines
+
+### Included Subtasks
+- [x] T071 Create pre-commit hook script (conventional commit message validation)
+- [x] T072 Add fast lint check to pre-commit (format check, encoding validation — <5s target)
+- [x] T073 Create pre-push hook script with channel-aware logic (feature/* → fast, beta/* → full suite)
+- [x] T074 Create `.pre-commit-config.yaml` template (for repos using pre-commit framework)
+- [x] T075 Create standalone hook installer script (for repos not using pre-commit framework)
+- [x] T076 Test hooks: conventional commit rejection, timing validation, channel branching logic
+
+### Implementation Notes
+- Pre-commit: validate `^(feat|fix|chore|docs|refactor|test|perf|ci|build|style|revert)(\(.+\))?!?: .+`
+- Fast lint: call `mise run format -- --check` (should complete in <5s for most repos)
+- Pre-push channel detection: parse branch name (`feature/*` → fast, `beta/*` → full, `rc/*` → full + rollback check)
+- Support both pre-commit framework (`.pre-commit-config.yaml`) and standalone scripts
+- Hooks are shell scripts (POSIX sh for portability)
+
+### Parallel Opportunities
+- T071-T072 (pre-commit) parallel with T073 (pre-push)
+
+### Dependencies
+- Depends on WP11 (task runner for lint/test commands)
+
+### Risks & Mitigations
+- Pre-commit hook performance — keep under 5s; defer expensive checks to pre-push
+
+---
+
+## Work Package WP13: Pilot Rollout — AgilePlus + 3 Repos (Priority: P2)
+
+**Goal**: Run `pheno bootstrap` on AgilePlus and 3 diverse repos (1 Rust, 1 Python, 1 Go) to validate end-to-end workflow.
+**Independent Test**: All 4 repos have governance artifacts, hooks work, CI workflows trigger, a test publish succeeds.
+**Prompt**: `tasks/WP13-pilot-rollout.md`
+**Estimated Size**: ~350 lines
+
+### Included Subtasks
+- [x] T077 Bootstrap AgilePlus (TypeScript/VitePress) — validate mise.toml, hooks, CI workflows
+- [x] T078 [P] Bootstrap tokenledger (Rust) — validate Rust-specific artifacts, crates.io publish test
+- [x] T079 [P] Bootstrap thegent (Python) — validate Python-specific artifacts, PyPI publish test
+- [x] T080 [P] Bootstrap agentapi-plusplus (Go) — validate Go-specific artifacts, Go proxy publish test
+- [x] T081 Run `pheno audit` across all 4 repos — validate org-wide view
+- [x] T082 Document findings and adjust templates based on pilot feedback
+
+### Implementation Notes
+- AgilePlus: private (no publish), only hooks + lint/test infrastructure
+- tokenledger: already published to crates.io — test pre-release publish
+- thegent: already published to PyPI — test pre-release publish
+- agentapi-plusplus: Go module — test git tag-based publishing
+
+### Parallel Opportunities
+- T077-T080 are fully parallel (independent repos)
+
+### Dependencies
+- Depends on WP09 (bootstrap), WP10 (CI workflows), WP11 (task runner), WP12 (hooks)
+
+### Risks & Mitigations
+- Repos may have conflicting existing configs — bootstrap should detect and warn, not overwrite without confirmation
+
+---
+
+## Work Package WP14: Org-Wide Rollout Automation (Priority: P3)
+
+**Goal**: Script the remaining ~43 repo rollout and create the bulk bootstrap tooling.
+**Independent Test**: Bulk bootstrap script processes all remaining repos, generating appropriate artifacts per language.
+**Prompt**: `tasks/WP14-org-wide-rollout.md`
+**Estimated Size**: ~300 lines
+
+### Included Subtasks
+- [x] T083 Create bulk bootstrap script (`pheno bootstrap --all` or directory-scanning mode)
+- [x] T084 Generate repo manifest (CSV/TOML listing all repos, languages, risk profiles, publish targets)
+- [x] T085 Run bulk bootstrap on remaining repos (with dry-run first)
+- [x] T086 Create PRs for each bootstrapped repo (automated via `gh pr create`)
+- [x] T087 Validate org-wide `pheno audit` after rollout
+
+### Implementation Notes
+- `pheno bootstrap --all --repos-dir ~/CodeProjects/Phenotype/repos/` scans all subdirs
+- Dry-run mode: `--dry-run` shows what would be generated without writing files
+- PR creation: one PR per repo, titled "chore: add release governance infrastructure"
+- Risk profiles: default to `low` unless repo manifest overrides
+
+### Parallel Opportunities
+- T085-T086 can be batched (bootstrap + PR creation per repo)
+
+### Dependencies
+- Depends on WP13 (pilot validation)
+
+### Risks & Mitigations
+- Bulk operations may hit GitHub API rate limits for PR creation — batch with delays
+
+---
+
+## Work Package WP15: Documentation & Polish (Priority: P3)
+
+**Goal**: Write user-facing documentation for the pheno CLI, governance model, and contributor onboarding.
+**Independent Test**: A new contributor can read the docs and successfully bootstrap a repo, run standard tasks, and publish a pre-release.
+**Prompt**: `tasks/WP15-documentation-polish.md`
+**Estimated Size**: ~300 lines
+
+### Included Subtasks
+- [x] T088 Write pheno CLI README.md (installation, commands, configuration)
+- [x] T089 Write governance model overview (evolving the 5-tier model, risk profiles, gate criteria)
+- [x] T090 Write contributor quickstart (bootstrap → develop → promote → publish)
+- [x] T091 Create ADR: task runner selection rationale
+- [x] T092 Create ADR: registry adapter architecture rationale
+- [x] T093 Final cleanup: ensure all error messages are clear, help text is complete
+
+### Implementation Notes
+- README goes in pheno-cli repo root
+- Governance overview and contributor quickstart can go in AgilePlus docs or pheno-cli docs
+- ADRs go in pheno-cli `docs/adr/` per constitution requirements
+
+### Parallel Opportunities
+- T088-T092 are all parallel (independent docs)
+
+### Dependencies
+- Depends on WP07 (CLI finalized), WP11 (task runner chosen), WP13 (pilot feedback)
+
+### Risks & Mitigations
+- Docs get stale quickly — link to CLI help text rather than duplicating
+
+---
+
+## Dependency & Execution Summary
+
+```
+Phase 0 (Foundation):
+  WP01 (CLI scaffold + adapter interface) ←── no deps
+  WP10 (Centralized CI workflows) ←── no deps
+
+Phase 1 (Adapters — all parallel after WP01):
+  WP02 (npm adapter) ←── WP01
+  WP03 (PyPI adapter) ←── WP01
+  WP04 (crates.io adapter) ←── WP01
+  WP05 (Go proxy + stubs) ←── WP01
+  WP06 (Gate engine) ←── WP01
+
+Phase 2 (CLI Commands):
+  WP07 (publish + promote) ←── WP01, WP02-WP05, WP06
+  WP08 (audit + matrix) ←── WP01, WP02-WP05
+
+Phase 3 (DX Tooling):
+  WP11 (Task runner) ←── WP07
+  WP12 (Hooks) ←── WP11
+
+Phase 4 (Bootstrap + Rollout):
+  WP09 (Bootstrap command) ←── WP01, WP10
+  WP13 (Pilot rollout) ←── WP09, WP10, WP11, WP12
+  WP14 (Org-wide rollout) ←── WP13
+
+Phase 5 (Polish):
+  WP15 (Documentation) ←── WP07, WP11, WP13
+```
+
+**Parallelization highlights**:
+- WP01 + WP10 can run simultaneously (Phase 0)
+- WP02, WP03, WP04, WP05, WP06 can ALL run simultaneously (Phase 1)
+- WP08 can start as soon as adapters are done (doesn't need gate engine)
+- WP09 can start once WP01 + WP10 are done (doesn't need adapters yet — uses templates)
+
+**MVP Scope**: WP01 → WP02-WP04 → WP07 → WP10 (CLI can publish to 3 main registries with CI workflows)
+
+---
+
+## Subtask Index
+
+| ID | Summary | WP | Priority | Parallel |
+|----|---------|-----|----------|----------|
+| T001 | Init Go module with deps | WP01 | P0 | No |
+| T002 | Cobra root + subcommand stubs | WP01 | P0 | No |
+| T003 | RegistryAdapter interface | WP01 | P0 | No |
+| T004 | Version calculator | WP01 | P0 | No |
+| T005 | Language/manifest detector | WP01 | P0 | Yes |
+| T006 | Version calculator tests | WP01 | P0 | No |
+| T007 | npm Detect | WP02 | P0 | No |
+| T008 | npm Version | WP02 | P0 | No |
+| T009 | npm Build | WP02 | P0 | No |
+| T010 | npm Publish + retry | WP02 | P0 | No |
+| T011 | npm Verify | WP02 | P0 | No |
+| T012 | npm tests | WP02 | P0 | No |
+| T013 | PyPI Detect | WP03 | P0 | No |
+| T014 | PyPI Version (PEP 440) | WP03 | P0 | No |
+| T015 | PyPI Build | WP03 | P0 | No |
+| T016 | PyPI Publish + retry | WP03 | P0 | No |
+| T017 | PyPI Verify | WP03 | P0 | No |
+| T018 | PyPI tests | WP03 | P0 | No |
+| T019 | crates.io Detect (workspaces) | WP04 | P0 | No |
+| T020 | crates.io Version | WP04 | P0 | No |
+| T021 | Topological dependency sort | WP04 | P0 | No |
+| T022 | crates.io Build + Publish | WP04 | P0 | No |
+| T023 | crates.io Verify | WP04 | P0 | No |
+| T024 | crates.io tests | WP04 | P0 | No |
+| T025 | Go proxy Detect + Version | WP05 | P1 | No |
+| T026 | Go Publish (git tag) | WP05 | P1 | No |
+| T027 | Go Verify | WP05 | P1 | No |
+| T028 | Hex.pm stub | WP05 | P1 | Yes |
+| T029 | Zig stub | WP05 | P1 | Yes |
+| T030 | Mojo stub | WP05 | P1 | Yes |
+| T031 | Go + stub tests | WP05 | P1 | No |
+| T032 | Gate criteria data model | WP06 | P1 | No |
+| T033 | Gate evaluator | WP06 | P1 | No |
+| T034 | Risk-based skip logic | WP06 | P1 | No |
+| T035 | Structured report gen | WP06 | P1 | No |
+| T036 | Gate criteria impls | WP06 | P1 | No |
+| T037 | Gate evaluator tests | WP06 | P1 | No |
+| T038 | pheno publish command | WP07 | P1 | No |
+| T039 | pheno promote command | WP07 | P1 | No |
+| T040 | Workspace publish orchestration | WP07 | P1 | No |
+| T041 | Lipgloss progress output | WP07 | P1 | Yes |
+| T042 | Viper config loading | WP07 | P1 | Yes |
+| T043 | publish/promote integration tests | WP07 | P1 | No |
+| T044 | pheno audit command | WP08 | P2 | No |
+| T045 | Audit table output | WP08 | P2 | No |
+| T046 | pheno matrix command | WP08 | P2 | Yes |
+| T047 | Repo discovery | WP08 | P2 | No |
+| T048 | audit/matrix tests | WP08 | P2 | No |
+| T049 | pheno bootstrap command | WP09 | P2 | No |
+| T050 | Go template files | WP09 | P2 | No |
+| T051 | mise.toml template | WP09 | P2 | Yes |
+| T052 | pre-commit template | WP09 | P2 | Yes |
+| T053 | pre-push template | WP09 | P2 | Yes |
+| T054 | CI workflow templates | WP09 | P2 | Yes |
+| T055 | cliff.toml template | WP09 | P2 | Yes |
+| T056 | Bootstrap integration test | WP09 | P2 | No |
+| T057 | publish.yml reusable workflow | WP10 | P1 | Yes |
+| T058 | gate-check.yml workflow | WP10 | P1 | Yes |
+| T059 | promote.yml workflow | WP10 | P1 | Yes |
+| T060 | changelog.yml workflow | WP10 | P1 | Yes |
+| T061 | audit.yml scheduled workflow | WP10 | P1 | Yes |
+| T062 | Workflow inputs/outputs schema | WP10 | P1 | No |
+| T063 | Workflow testing | WP10 | P1 | No |
+| T064 | Task runner final eval | WP11 | P1 | No |
+| T065 | Rust reference mise.toml | WP11 | P1 | No |
+| T066 | Python reference mise.toml | WP11 | P1 | Yes |
+| T067 | TypeScript reference mise.toml | WP11 | P1 | Yes |
+| T068 | Go reference mise.toml | WP11 | P1 | Yes |
+| T069 | Release tasks mise.toml | WP11 | P1 | No |
+| T070 | Validate on sample repos | WP11 | P1 | No |
+| T071 | Pre-commit hook (conventional commits) | WP12 | P2 | No |
+| T072 | Pre-commit fast lint | WP12 | P2 | No |
+| T073 | Pre-push channel-aware hooks | WP12 | P2 | Yes |
+| T074 | .pre-commit-config.yaml template | WP12 | P2 | Yes |
+| T075 | Standalone hook installer | WP12 | P2 | Yes |
+| T076 | Hook tests | WP12 | P2 | No |
+| T077 | Bootstrap AgilePlus | WP13 | P2 | No |
+| T078 | Bootstrap tokenledger | WP13 | P2 | Yes |
+| T079 | Bootstrap thegent | WP13 | P2 | Yes |
+| T080 | Bootstrap agentapi-plusplus | WP13 | P2 | Yes |
+| T081 | Org-wide audit validation | WP13 | P2 | No |
+| T082 | Pilot findings doc | WP13 | P2 | No |
+| T083 | Bulk bootstrap script | WP14 | P3 | No |
+| T084 | Repo manifest | WP14 | P3 | No |
+| T085 | Bulk bootstrap execution | WP14 | P3 | No |
+| T086 | Automated PR creation | WP14 | P3 | No |
+| T087 | Org-wide audit post-rollout | WP14 | P3 | No |
+| T088 | pheno CLI README | WP15 | P3 | Yes |
+| T089 | Governance model docs | WP15 | P3 | Yes |
+| T090 | Contributor quickstart | WP15 | P3 | Yes |
+| T091 | ADR: task runner selection | WP15 | P3 | Yes |
+| T092 | ADR: adapter architecture | WP15 | P3 | Yes |
+| T093 | Error message cleanup | WP15 | P3 | No |

--- a/.agileplus/specs/003-agileplus-platform-completion/meta.json
+++ b/.agileplus/specs/003-agileplus-platform-completion/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "003-agileplus-platform-completion",
+  "title": "AgilePlus Platform Completion",
+  "status": "active",
+  "created": "2026-03-02"
+}

--- a/.agileplus/specs/003-agileplus-platform-completion/spec.md
+++ b/.agileplus/specs/003-agileplus-platform-completion/spec.md
@@ -1,0 +1,278 @@
+# Feature Specification: AgilePlus Platform Completion
+
+**Feature Branch**: `003-agileplus-platform-completion`
+**Created**: 2026-03-02
+**Status**: Draft
+**Input**: End-to-end completion of AgilePlus as a production-ready, local-first spec-driven development platform with bidirectional Plane.so sync, platform service infrastructure, event-sourced persistence, web dashboard, and multi-device sync.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Bidirectional Plane.so Sync (Priority: P1)
+
+A developer using AgilePlus creates a feature via the CLI. The feature automatically appears as an issue in their Plane.so project. When a teammate moves that issue to "In Progress" in Plane.so's board, the AgilePlus feature state transitions to `implementing` within seconds. When the developer marks a work package done in AgilePlus, the corresponding Plane sub-issue updates in real time. If both sides edit the same field simultaneously, the system detects the conflict, presents both versions, and lets the user choose.
+
+**Why this priority**: Plane.so is the external-facing project management layer. Without bidirectional sync, AgilePlus is an isolated tool rather than an integration layer.
+
+**Independent Test**: Create a feature in AgilePlus CLI, verify it appears in Plane.so. Update the Plane issue, verify AgilePlus reflects the change. Create a simultaneous edit on both sides and verify conflict resolution flow.
+
+**Acceptance Scenarios**:
+
+1. **Given** a feature created in AgilePlus, **When** the CLI runs `agileplus sync push`, **Then** a Plane.so issue is created with matching title, description, state, and labels within 5 seconds
+2. **Given** a Plane.so issue whose state changes, **When** the webhook fires, **Then** the AgilePlus feature state updates to the mapped state within 3 seconds
+3. **Given** a feature edited in both AgilePlus and Plane.so since last sync, **When** sync runs, **Then** the system detects the conflict, presents both versions to the user, and applies the chosen resolution
+4. **Given** a feature with 5 work packages, **When** synced to Plane.so, **Then** each WP appears as a sub-issue under the parent feature issue with correct parent-child relationship
+5. **Given** a Plane.so issue with labels "agileplus", "P1", "backend", **When** synced to AgilePlus, **Then** labels are mapped to AgilePlus metadata (priority, tags)
+
+---
+
+### User Story 2 — Platform Service Infrastructure (Priority: P1)
+
+An operator starts the AgilePlus platform with a single `process-compose up` command. All services start in dependency order: NATS (event bus), Dragonfly/Valkey (cache), Neo4j (graph), MinIO (object store), the Rust core service, and the Python MCP service. Health checks confirm all services are running. The developer can then use AgilePlus CLI and web dashboard backed by the full service stack.
+
+**Why this priority**: The platform services are the foundation for every other feature — sync needs NATS for events, audit needs the event store, the dashboard needs the API, and multi-device sync needs the persistence layer.
+
+**Independent Test**: Run `process-compose up` from a fresh clone. Verify all services start, health checks pass, and the CLI can connect. Run `process-compose down` and verify clean shutdown.
+
+**Acceptance Scenarios**:
+
+1. **Given** a fresh AgilePlus checkout with Process Compose installed, **When** the user runs `process-compose up`, **Then** all services start in dependency order within 30 seconds
+2. **Given** all services running, **When** the user runs `agileplus status`, **Then** a health report shows each service's status, uptime, and connection state
+3. **Given** a service crashes, **When** Process Compose detects the failure, **Then** it restarts the service automatically with exponential backoff
+4. **Given** the user runs `process-compose down`, **Then** all services shut down gracefully in reverse dependency order
+
+---
+
+### User Story 3 — Event-Sourced Persistence with Audit Trail (Priority: P1)
+
+Every state change in AgilePlus — feature transitions, WP updates, governance decisions, agent dispatches — is recorded as an immutable event in the event store. The current state of any entity can be rebuilt by replaying its events. A snapshot is taken periodically for fast reads. The audit trail is queryable: "show me every state change for feature X" returns a complete, hash-chained history.
+
+**Why this priority**: Auditability and versioning are core to spec-driven development. The governance model requires provable history. The existing audit chain (hash-linked) needs to be backed by persistent storage.
+
+**Independent Test**: Create a feature, transition it through 5 states, query the event store, and verify all 5 events are present with correct ordering and hash chain integrity. Rebuild state from events and verify it matches the snapshot.
+
+**Acceptance Scenarios**:
+
+1. **Given** a feature that transitions from Created to Specified, **When** the event store is queried, **Then** a StateTransitioned event with `from: created, to: specified` is found with a valid SHA-256 hash chain
+2. **Given** 1000 events for a feature, **When** the current state is requested, **Then** it is served from the latest snapshot within 10ms rather than replaying all events
+3. **Given** an event store with 100K events, **When** a snapshot is corrupted, **Then** the system detects the corruption and rebuilds from events automatically
+4. **Given** a query for "all events for feature X between dates A and B", **When** executed, **Then** results are returned in chronological order with full provenance metadata
+
+---
+
+### User Story 4 — Web Dashboard (Priority: P2)
+
+A developer opens `http://localhost:PORT` in their browser and sees a real-time dashboard showing: feature kanban board (synced with Plane.so), work package progress, agent activity, governance status, and audit timeline. The dashboard updates live via WebSocket/SSE as events flow through NATS. The developer can trigger actions from the dashboard (transition states, dispatch agents, approve governance gates).
+
+**Why this priority**: Visual overview of the entire spec-driven pipeline. While CLI is primary, a dashboard dramatically improves observability and reduces context-switching.
+
+**Independent Test**: Start platform services, create features via CLI, open dashboard in browser, and verify all features appear in the kanban board. Trigger a state transition from the dashboard and verify it propagates to CLI state and Plane.so.
+
+**Acceptance Scenarios**:
+
+1. **Given** the platform is running, **When** a user navigates to `localhost:PORT`, **Then** the dashboard loads with current feature/WP state within 2 seconds
+2. **Given** a feature state changes via CLI, **When** the dashboard is open, **Then** the kanban board updates within 1 second without page refresh
+3. **Given** a user clicks "Transition to Implementing" on a feature card, **When** the action is confirmed, **Then** the feature state updates in AgilePlus, Plane.so, and the dashboard simultaneously
+4. **Given** 3 agents are actively implementing WPs, **When** the dashboard is viewed, **Then** agent activity (current task, progress, logs) is visible in real time
+
+---
+
+### User Story 5 — CLI Integration (Priority: P2)
+
+The AgilePlus CLI gains new commands for sync, platform management, and dashboard control. Commands include: `agileplus sync` (bidirectional sync), `agileplus platform up/down/status` (service management), `agileplus events` (event store queries), `agileplus dashboard` (open web UI). Existing commands (`agileplus feature`, `agileplus wp`) are enhanced to emit events and sync automatically.
+
+**Why this priority**: CLI is the primary interface. All platform capabilities must be accessible via CLI for automation, scripting, and agent integration.
+
+**Independent Test**: Run each new CLI command and verify output format, error handling, and side effects (events emitted, sync triggered, services managed).
+
+**Acceptance Scenarios**:
+
+1. **Given** Plane.so credentials configured, **When** the user runs `agileplus sync`, **Then** bidirectional sync completes and reports created/updated/skipped/conflicted counts
+2. **Given** a running platform, **When** the user runs `agileplus events --feature my-feature --since 1h`, **Then** all events for that feature in the last hour are displayed in chronological order
+3. **Given** no platform running, **When** the user runs `agileplus platform up`, **Then** all services start via Process Compose and the CLI reports health status
+4. **Given** a feature created via CLI, **When** auto-sync is enabled, **Then** the feature appears in Plane.so without manual `sync` invocation
+
+---
+
+### User Story 6 — Multi-Device Sync (Priority: P3)
+
+A developer works on AgilePlus on their laptop, commits and pushes. On their desktop (connected via Tailscale), they pull and have the identical project state — features, WPs, events, audit chain. For real-time collaboration without git round-trips, devices on the same Tailscale network can discover each other and sync state directly via a P2P protocol.
+
+**Why this priority**: Multi-device is important for teams and individual developers with multiple machines, but the core platform works on a single device first.
+
+**Independent Test**: Set up two devices on a Tailscale network, create a feature on device A, verify it appears on device B within 10 seconds via P2P sync. Disconnect network, make changes on both, reconnect, and verify conflict resolution.
+
+**Acceptance Scenarios**:
+
+1. **Given** two devices with AgilePlus on the same Tailscale network, **When** a feature is created on device A, **Then** it appears on device B within 10 seconds
+2. **Given** device A goes offline and both devices make changes, **When** device A reconnects, **Then** changes are merged with conflict detection matching the Plane.so conflict resolution model
+3. **Given** git-backed sync is configured, **When** the user pushes, **Then** SQLite state, event log, and snapshots are serialized into the git repo in a deterministic format
+4. **Given** a fresh clone of the repo on a new device, **When** `agileplus platform up` runs, **Then** the full state is rebuilt from the git-backed artifacts
+
+---
+
+### Edge Cases
+
+- What happens when Plane.so API is unreachable during sync? → Queue events locally, retry with exponential backoff, surface sync lag in dashboard
+- What happens when NATS goes down while events are being emitted? → Buffer events in-process (bounded queue), replay on reconnection, alert via health check
+- What happens when two users resolve the same conflict differently on different devices? → Last-write-wins with full audit trail of both resolutions; user can revert
+- What happens when the event store grows beyond local disk capacity? → Configurable event retention policy; old events archived to MinIO, snapshots retained
+- What happens when Neo4j is unavailable? → Graph queries degrade gracefully; core feature/WP operations continue via SQLite; graph rebuilds on reconnection
+- What happens when a webhook arrives for a Plane.so issue not tracked by AgilePlus? → Log and ignore; optionally auto-import if configured
+- What happens when Process Compose is not installed? → CLI detects absence, provides installation instructions, offers degraded single-process mode
+
+## Clarifications
+
+### Session 2026-03-02
+
+- Q: Security/AuthN model for web dashboard and API? → A: API key generated on first run, stored in config. Localhost-only by default; API key required for all API calls from dashboard and CLI. Establishes secure pattern for future remote deployments.
+- Q: Dashboard frontend framework? → A: htmx + Alpine.js (server-rendered HTML from Rust axum, minimal JS). Tooling-focused dashboard does not need SPA complexity; keeps bundle small and avoids separate frontend build pipeline.
+- Q: Data volume assumptions for event store? → A: Medium scale — up to 100K events and 500 features per project. Queryable in-process without distributed store overhead; sufficient for multi-month, multi-feature lifecycles.
+- Q: Observability stack for platform services? → A: OpenTelemetry (extending existing agileplus-telemetry crate) for traces and metrics, plus structured JSON logs. No separate Prometheus/Grafana/Loki infrastructure required.
+- Q: NATS deployment mode? → A: Standalone NATS server with JetStream for persistent messaging, managed by Process Compose. Decouples messaging from Rust binary; JetStream adds durable queuing for event replay and audit.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Plane.so Sync Engine**
+
+- **FR-001**: System MUST support bidirectional real-time sync between AgilePlus features/WPs and Plane.so issues/sub-issues
+- **FR-002**: System MUST map AgilePlus FeatureState (created, specified, researched, planned, implementing, validated, shipped, retrospected) to configurable Plane.so issue states
+- **FR-003**: System MUST ingest Plane.so webhooks via an HTTP endpoint to receive real-time updates
+- **FR-004**: System MUST detect conflicts when both sides modify the same entity since last sync, and present resolution options to the user
+- **FR-005**: System MUST sync labels bidirectionally, mapping Plane.so labels to AgilePlus metadata (priority, tags, categories)
+- **FR-006**: System MUST maintain a sync state store (entity ID mappings, content hashes, timestamps) persisted to SQLite
+- **FR-007**: System MUST queue sync operations when Plane.so is unreachable and replay on reconnection
+
+**Platform Services**
+
+- **FR-010**: System MUST orchestrate all services via Process Compose with dependency ordering and health checks
+- **FR-011**: System MUST use NATS with JetStream (standalone server managed by Process Compose) as the event bus for inter-service communication, real-time streaming, and durable message replay
+- **FR-012**: System MUST use Dragonfly (or Valkey as fallback) for caching frequently-accessed state and rate limiting
+- **FR-013**: System MUST use Neo4j for modeling relationships (feature→WP, WP→agent, feature→feature dependencies, cross-project links)
+- **FR-014**: System MUST use MinIO for storing artifacts (specs, plans, evidence, build outputs, archived events)
+- **FR-015**: System MUST use SQLite as the local-first persistence layer for feature state, sync state, and event store
+- **FR-016**: System MUST provide health check endpoints for every service, aggregated into a platform health report
+
+**Event-Sourced Persistence**
+
+- **FR-020**: System MUST record every state mutation as an immutable event with: entity ID, event type, payload, timestamp, actor, SHA-256 hash linking to previous event
+- **FR-021**: System MUST support rebuilding any entity's current state by replaying its event stream
+- **FR-022**: System MUST periodically snapshot entity state for fast reads (configurable interval, default every 100 events or 5 minutes)
+- **FR-023**: System MUST validate event chain integrity on startup and on-demand (detect corruption, offer rebuild)
+- **FR-024**: System MUST support event retention policies (configurable TTL, archive to MinIO, retain snapshots)
+- **FR-025**: System MUST expose event queries: by entity, by time range, by event type, by actor
+
+**Security & Authentication**
+
+- **FR-028**: System MUST generate an API key on first platform startup and store it in the local config directory
+- **FR-029**: All API endpoints (REST and WebSocket) MUST require a valid API key via header or query parameter
+
+**Web Dashboard**
+
+- **FR-030**: System MUST serve a web dashboard on a configurable localhost port via the Rust API server using htmx + Alpine.js (server-rendered HTML)
+- **FR-031**: Dashboard MUST display a feature kanban board with real-time updates via WebSocket/SSE
+- **FR-032**: Dashboard MUST display work package progress, agent activity, and governance status
+- **FR-033**: Dashboard MUST allow users to trigger state transitions, dispatch agents, and approve governance gates
+- **FR-034**: Dashboard MUST display the audit timeline for any feature with drill-down to individual events
+- **FR-035**: Dashboard MUST NOT require a separate frontend build pipeline; HTML templates are served directly by the Rust API
+
+**CLI Commands**
+
+- **FR-040**: CLI MUST provide `agileplus sync [push|pull|auto]` for bidirectional Plane.so sync
+- **FR-041**: CLI MUST provide `agileplus platform [up|down|status|logs]` for service management
+- **FR-042**: CLI MUST provide `agileplus events [--feature X] [--since T] [--type Y]` for event store queries
+- **FR-043**: CLI MUST provide `agileplus dashboard [open|port]` for web UI management
+- **FR-044**: Existing CLI commands MUST emit events to NATS and trigger auto-sync when configured
+
+**Multi-Device Sync**
+
+- **FR-050**: System MUST support git-backed state sync by serializing SQLite state and events into deterministic, mergeable files in the repository
+- **FR-051**: System MUST support P2P device discovery and state sync via Tailscale (or Cloudflare WARP) network
+- **FR-052**: System MUST handle offline operation with local-first semantics and merge on reconnection
+- **FR-053**: System MUST use the same conflict resolution model for device sync as for Plane.so sync
+
+### Key Entities
+
+- **Feature**: Central entity representing a spec-driven feature. Has state (lifecycle), spec hash, target branch, sync mappings to Plane.so issue ID. Related to WorkPackages, AuditEntries, Events.
+- **WorkPackage**: Scoped implementation unit under a Feature. Has state, assignee, subtasks. Maps to Plane.so sub-issue.
+- **Event**: Immutable record of a state mutation. Has entity reference, event type, payload, timestamp, actor, hash chain link. Stored in SQLite event store.
+- **Snapshot**: Point-in-time materialized state of an entity. Built from event replay. Cached in Dragonfly/Valkey for fast reads.
+- **SyncState**: Per-entity mapping between AgilePlus IDs and Plane.so IDs. Tracks content hashes, last sync timestamp, conflict history.
+- **ServiceHealth**: Runtime status of each platform service. Aggregated for health reports.
+- **DeviceNode**: Representation of a device in the P2P mesh. Has Tailscale IP, last seen, sync state vector.
+- **AuditEntry**: Hash-chained audit log entry (existing). Enhanced with event store backing and MinIO archival.
+- **Graph Relationships** (Neo4j): Feature→WP ownership, WP→Agent assignment, Feature→Feature dependencies, Cross-project links, Label→Entity associations.
+
+## Architecture Patterns
+
+This project implements:
+
+### Hexagonal Architecture (Ports & Adapters)
+- **Domain**: Core business logic (entities, value objects, services, events, ports)
+- **Application**: Use cases (commands, queries, handlers)
+- **Adapters**: Primary (REST, CLI) and Secondary (persistence, cache, messaging)
+
+### Clean Architecture Layers
+- **Enterprise Rules**: Domain entities, services, value objects
+- **Application**: Use cases, interactors, DTOs
+- **Interface Adapters**: Controllers, presenters, gateways
+- **Frameworks & Drivers**: Database, web, external interfaces
+
+### xDD Methodologies
+- **TDD**: Test-Driven Development - red/green/refactor cycle
+- **BDD**: Behavior-Driven Development - Gherkin scenarios
+- **SDD**: Specification-Driven Development - executable specs
+- **DDD**: Domain-Driven Design - bounded contexts, aggregates
+- **ADD**: Anxiety-Driven Development - addressing technical debt
+- **CQRS**: Command Query Responsibility Segregation
+- **Event Sourcing**: Complete audit trail via events
+- **Specification by Example**: Living documentation from examples
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Bidirectional sync between AgilePlus and Plane.so completes within 5 seconds for single-entity changes and within 30 seconds for full project sync (50+ features)
+- **SC-002**: Platform services start from cold in under 30 seconds and pass all health checks
+- **SC-003**: Event store supports 100K+ events per project with query response times under 100ms for time-range and entity-filtered queries
+- **SC-004**: Web dashboard loads initial state in under 2 seconds and reflects real-time changes within 1 second
+- **SC-005**: Multi-device P2P sync propagates changes within 10 seconds on a Tailscale network
+- **SC-006**: Git-backed sync produces deterministic, diff-friendly serialization that survives git merge without manual conflict resolution in 95%+ of cases
+- **SC-007**: System operates fully offline with local-first semantics; sync catches up automatically on reconnection without data loss
+- **SC-008**: All state mutations are recorded in the event store with valid hash chains; 100% audit coverage
+- **SC-009**: Platform runs on macOS (primary), Linux, and WSL2 without Docker dependency
+- **SC-010**: Full BDD test suite covers all user stories with 16+ scenarios and 80+ step definitions
+
+## Assumptions
+
+- Plane.so API v1 remains stable and webhook support is available on the user's Plane.so plan
+- Tailscale is the primary P2P transport; Cloudflare WARP is a fallback option evaluated during research
+- Process Compose is the orchestrator; no Docker/Podman/container runtime dependency
+- Neo4j Community Edition is sufficient (no enterprise features required)
+- MinIO runs locally in standalone mode (single-node) for development; S3-compatible cloud for production
+- Dragonfly is preferred over Valkey/Redis for its single-binary, multi-threaded performance; Valkey as fallback if Dragonfly has issues
+- NATS runs as a standalone server with JetStream enabled, managed by Process Compose (not embedded, not clustered)
+- The web dashboard uses htmx + Alpine.js for interactivity, served as server-rendered HTML by the Rust axum API (no separate frontend build pipeline)
+- API authentication uses a locally-generated API key; no external auth provider needed
+- Electrobun desktop wrapper is a future spec, not in scope here
+- The existing agileplus-plane crate, agileplus-sqlite crate, and gRPC infrastructure are extended rather than rewritten
+
+## Dependencies
+
+- Existing: `agileplus-domain`, `agileplus-plane`, `agileplus-sqlite`, `agileplus-grpc`, `agileplus-api`, `agileplus-agents`, `agileplus-mcp`
+- External services: Plane.so account with API key and webhook capability
+- External tools: Process Compose, NATS, Dragonfly (or Valkey), Neo4j, MinIO, Tailscale
+- Rust crates: nats (async-nats), neo4rs, minio-rs or rust-s3, axum (existing), tower, tokio-tungstenite (WebSocket)
+- Go: pheno-cli gains `platform` and `sync` command groups
+- Python: agileplus-mcp gains event store and sync tools
+- Frontend: htmx + Alpine.js (served by Rust axum, no build pipeline)
+
+## Risks
+
+- **Plane.so API rate limits**: Mitigated by existing token bucket rate limiter; enhanced with queue-and-retry
+- **Neo4j operational complexity**: Mitigated by using embedded mode or simple standalone; graph is optional (graceful degradation)
+- **Event store growth**: Mitigated by retention policies and MinIO archival
+- **P2P sync conflict resolution complexity**: Mitigated by reusing the same resolution model as Plane.so sync; CRDT exploration during research phase
+- **Process Compose maturity**: Mitigated by keeping service configs simple; fallback to manual startup scripts
+- **Multi-language coordination**: Mitigated by gRPC contracts between Rust/Go/Python; NATS as language-agnostic event bus

--- a/.agileplus/specs/003-agileplus-platform-completion/tasks.md
+++ b/.agileplus/specs/003-agileplus-platform-completion/tasks.md
@@ -1,0 +1,343 @@
+# Work Packages — AgilePlus Platform Completion (spec 003)
+
+**Feature**: 003-agileplus-platform-completion
+**Generated**: 2026-03-02
+**Total WPs**: 21 | **Total Subtasks**: 105
+
+## Overview
+
+| Phase | WPs | Priority | Parallelizable |
+|-------|-----|----------|----------------|
+| Group 1: Foundation | WP01-WP03 | P1 | Sequential |
+| Group 2: Infrastructure | WP04-WP07 | P1 | All parallel (after G1) |
+| Group 3: Sync Engine | WP08-WP10 | P1 | WP08∥WP09, then WP10 |
+| Group 4: API & Dashboard | WP11-WP14 | P2 | WP11→WP12→WP13, WP14∥ |
+| Group 5: Observability | WP15 | P2 | Parallel with G4 |
+| Group 6: Multi-Device | WP16-WP18 | P3 | WP16→WP17→WP18 |
+| Group 7: Integration | WP19-WP21 | P3 | Sequential |
+
+## Dependency Graph
+
+```
+WP01 → WP02 → WP03
+                  ↓
+         ┌───────┼───────┬───────┐
+        WP04   WP05   WP06   WP07
+         └───────┼───────┴───────┘
+                 ↓
+         ┌───────┼───────┐
+        WP08   WP09   WP15
+         └───┬───┘
+            WP10
+              ↓
+         ┌───┼───┐
+        WP11 WP14
+         ↓
+        WP12
+         ↓
+        WP13
+              ↓
+         ┌───┼───┐
+        WP16  │
+         ↓    │
+        WP17  │
+         ↓    │
+        WP18  │
+              ↓
+        WP19 → WP20 → WP21
+```
+
+---
+
+## Group 1: Foundation (P1, Sequential)
+
+### WP01 — Domain Model Extensions
+**File**: `tasks/WP01-domain-model-extensions.md`
+**Dependencies**: none
+**Priority**: P1 | **Est. lines**: ~400
+**Goal**: Add Event, Snapshot, SyncMapping, ServiceHealth, DeviceNode, ApiKey entities to `agileplus-domain` crate.
+
+- [x] T001: Define Event entity struct with hash chain fields
+- [x] T002: Define Snapshot entity struct
+- [x] T003: Define SyncMapping entity struct
+- [x] T004: Define ServiceHealth and HealthStatus enum
+- [x] T005: Define DeviceNode entity struct
+- [x] T006: Define ApiKey entity struct with key_hash
+- [x] T007: Add Serialize/Deserialize, validation, and builder patterns for all new entities
+
+### WP02 — Event Sourcing Engine
+**File**: `tasks/WP02-event-sourcing-engine.md`
+**Dependencies**: WP01
+**Priority**: P1 | **Est. lines**: ~500
+**Goal**: Create `agileplus-events` crate implementing append-only event store with hash chains, replay, and snapshots.
+
+- [x] T008: Scaffold `agileplus-events` crate with Cargo.toml and module structure
+- [x] T009: Implement EventStore trait (append, get_events, get_by_entity, get_by_range)
+- [x] T010: Implement SHA-256 hash chain computation and verification
+- [x] T011: Implement event replay to rebuild entity state
+- [x] T012: Implement snapshot creation (every N events or time interval)
+- [x] T013: Implement snapshot-based fast state loading with event replay from snapshot
+- [x] T014: Implement event queries (by entity, time range, event type, actor)
+
+### WP03 — SQLite Schema Extensions
+**File**: `tasks/WP03-sqlite-schema-extensions.md`
+**Dependencies**: WP02
+**Priority**: P1 | **Est. lines**: ~450
+**Goal**: Extend `agileplus-sqlite` with event store tables, WAL mode, and new entity persistence.
+
+- [x] T015: Add events table DDL with indexes (entity, timestamp, type)
+- [x] T016: Add snapshots table DDL with unique constraint
+- [x] T017: Add sync_mappings table DDL
+- [x] T018: Add api_keys table DDL
+- [x] T019: Add device_nodes table DDL
+- [x] T020: Implement SqliteEventStore (EventStore trait) with sqlx async queries
+- [x] T021: Enable WAL mode and configure pragmas (synchronous=NORMAL, wal_autocheckpoint)
+
+---
+
+## Group 2: Infrastructure (P1, Parallel after Group 1)
+
+### WP04 — Cache Layer (Dragonfly)
+**File**: `tasks/WP04-cache-layer-dragonfly.md`
+**Dependencies**: WP03
+**Priority**: P1 | **Est. lines**: ~350
+**Goal**: Create `agileplus-cache` crate with Dragonfly/Redis connection pool and typed cache operations.
+
+- [x] T022: Scaffold `agileplus-cache` crate
+- [x] T023: Implement connection pool with bb8-redis (config: host, port, pool size)
+- [x] T024: Implement typed get/set/delete with TTL support
+- [x] T025: Implement projection cache (feature state, WP state) with invalidation
+- [x] T026: Implement rate limiter (sliding window via INCR+EXPIRE)
+- [x] T027: Add health check (PING command)
+
+### WP05 — Graph Layer (Neo4j)
+**File**: `tasks/WP05-graph-layer-neo4j.md`
+**Dependencies**: WP03
+**Priority**: P1 | **Est. lines**: ~400
+**Goal**: Create `agileplus-graph` crate with Neo4j node/relationship CRUD and queries.
+
+- [x] T028: Scaffold `agileplus-graph` crate with neo4rs
+- [x] T029: Implement connection management (Bolt protocol, connection pool)
+- [x] T030: Create node types with constraints (Feature, WorkPackage, Agent, Label, Project)
+- [x] T031: Implement relationship CRUD (owns, assigned_to, depends_on, blocks, tagged, in_project)
+- [x] T032: Implement graph queries (dependency chains, blocking paths, cross-project links)
+- [x] T033: Add health check and index management
+
+### WP06 — Artifact Storage (MinIO)
+**File**: `tasks/WP06-artifact-storage-minio.md`
+**Dependencies**: WP03
+**Priority**: P1 | **Est. lines**: ~350
+**Goal**: Create `agileplus-artifacts` crate with MinIO/S3 operations.
+
+- [x] T034: Scaffold `agileplus-artifacts` crate with aws-sdk-s3
+- [x] T035: Implement bucket management (create, list, exists check for 4 buckets)
+- [x] T036: Implement object upload/download (multipart for large files)
+- [x] T037: Implement event archival (move old events to MinIO, configurable retention)
+- [x] T038: Implement audit entry archival
+- [x] T039: Add health check (list buckets)
+
+### WP07 — Process Compose Configuration
+**File**: `tasks/WP07-process-compose-config.md`
+**Dependencies**: WP03
+**Priority**: P1 | **Est. lines**: ~300
+**Goal**: Create `process-compose.yml` orchestrating all platform services.
+
+- [x] T040: Define NATS server process with JetStream, health check on :8222
+- [x] T041: Define Dragonfly process with health check (redis-cli ping)
+- [x] T042: Define Neo4j process with health check (bolt port)
+- [x] T043: Define MinIO process with health check (api port)
+- [x] T044: Define agileplus-api process (depends on all services, readiness probe)
+- [x] T045: Add environment variable configuration (.env support)
+
+---
+
+## Group 3: Sync Engine (P1, after Groups 1-2)
+
+### WP08 — Plane.so Bidirectional Sync
+**File**: `tasks/WP08-plane-bidirectional-sync.md`
+**Dependencies**: WP03
+**Priority**: P1 | **Est. lines**: ~500
+**Goal**: Extend `agileplus-plane` crate with bidirectional sync, webhook ingestion, state mapping, labels.
+
+- [x] T046: Add Plane.so state group mapping (5 groups → 8 AgilePlus states, configurable)
+- [x] T047: Implement webhook HTTP endpoint (HMAC-SHA256 verification, event parsing)
+- [x] T048: Implement outbound sync (push feature/WP changes to Plane.so issues/sub-issues)
+- [x] T049: Implement inbound sync (process webhook events, update local state)
+- [x] T050: Implement label bidirectional sync (CRUD via Plane API)
+- [x] T051: Implement content hash tracking for change detection
+- [x] T052: Implement sync queue with retry (exponential backoff, bounded buffer)
+
+### WP09 — Sync Orchestrator
+**File**: `tasks/WP09-sync-orchestrator.md`
+**Dependencies**: WP03
+**Priority**: P1 | **Est. lines**: ~400
+**Goal**: Create `agileplus-sync` crate coordinating Plane.so and device sync with conflict resolution.
+
+- [x] T053: Scaffold `agileplus-sync` crate
+- [x] T054: Implement conflict detection (content hash comparison, timestamp ordering)
+- [x] T055: Implement conflict resolution strategies (last-write-wins, manual merge, field-level merge)
+- [x] T056: Implement SyncMapping persistence (create, update, query by entity)
+- [x] T057: Implement sync status reporting (created/updated/skipped/conflicted counts)
+- [x] T058: Wire sync engine to NATS (publish sync events, subscribe to inbound)
+
+### WP10 — CLI Sync Commands
+**File**: `tasks/WP10-cli-sync-commands.md`
+**Dependencies**: WP08, WP09
+**Priority**: P1 | **Est. lines**: ~350
+**Goal**: Add `agileplus sync [push|pull|auto]` CLI commands to `agileplus-subcmds`.
+
+- [x] T059: Add `sync push` subcommand (push all local changes to Plane.so)
+- [x] T060: Add `sync pull` subcommand (pull all Plane.so changes locally)
+- [x] T061: Add `sync auto` subcommand (enable auto-sync on feature/WP mutations)
+- [x] T062: Add sync status display (table of entity mappings, last sync time, conflicts)
+- [x] T063: Add `sync resolve` subcommand (interactive conflict resolution)
+
+---
+
+## Group 4: API & Dashboard (P2, after Group 3)
+
+### WP11 — API Extensions
+**File**: `tasks/WP11-api-extensions.md`
+**Dependencies**: WP03, WP08, WP09
+**Priority**: P2 | **Est. lines**: ~450
+**Goal**: Extend `agileplus-api` with REST endpoints, SSE streams, and API key authentication.
+
+- [x] T064: Implement API key generation (SHA-256 hash, store in SQLite, write plaintext to config)
+- [x] T065: Implement API key auth middleware (extract from header/query, validate against DB)
+- [x] T066: Add REST endpoints for features (CRUD, state transition, list with filters)
+- [x] T067: Add REST endpoints for work packages (CRUD, state transition, list by feature)
+- [x] T068: Add REST endpoints for events (query by entity, time, type, actor)
+- [x] T069: Implement SSE endpoint for real-time dashboard updates (feature/WP state changes)
+- [x] T070: Add health/status endpoint aggregating all service health checks
+
+### WP12 — Dashboard Templates
+**File**: `tasks/WP12-dashboard-templates.md`
+**Dependencies**: WP11
+**Priority**: P2 | **Est. lines**: ~500
+**Goal**: Create `agileplus-dashboard` crate and Askama HTML templates with htmx integration.
+
+- [x] T071: Scaffold `agileplus-dashboard` crate with Askama template registration
+- [x] T072: Create base layout template (navigation, sidebar, keycap palette CSS)
+- [x] T073: Create kanban board template (columns per FeatureState, feature cards)
+- [x] T074: Create feature detail page (state, WPs, events, audit timeline)
+- [x] T075: Create WP list component (progress bars, assignee, state badges)
+- [x] T076: Create health panel component (service status cards)
+- [x] T077: Wire htmx partial swap endpoints (hx-get for each component)
+
+### WP13 — Dashboard Interactivity
+**File**: `tasks/WP13-dashboard-interactivity.md`
+**Dependencies**: WP12
+**Priority**: P2 | **Est. lines**: ~400
+**Goal**: Add Alpine.js interactivity, SSE live updates, and action triggers to dashboard.
+
+- [x] T078: Implement SSE connection with htmx sse-connect for live board updates
+- [x] T079: Implement Alpine.js kanban drag-drop (move features between state columns)
+- [x] T080: Implement state transition actions (button click → htmx POST → state change)
+- [x] T081: Implement agent activity panel (real-time agent status via SSE)
+- [x] T082: Implement audit timeline drill-down (expandable event details)
+- [x] T083: Implement settings page (API key display, sync config, service URLs)
+
+### WP14 — CLI Platform Commands
+**File**: `tasks/WP14-cli-platform-commands.md`
+**Dependencies**: WP07, WP10
+**Priority**: P2 | **Est. lines**: ~400
+**Goal**: Add `agileplus platform`, `events`, and `dashboard` CLI commands.
+
+- [x] T084: Add `platform up` subcommand (invoke process-compose up, wait for health)
+- [x] T085: Add `platform down` subcommand (invoke process-compose down)
+- [x] T086: Add `platform status` subcommand (query health endpoints, display table)
+- [x] T087: Add `platform logs` subcommand (tail process-compose logs with filters)
+- [x] T088: Add `events` subcommand (query event store with --feature, --since, --type filters)
+- [x] T089: Add `dashboard` subcommand (open browser to localhost:PORT, configure port)
+
+---
+
+## Group 5: Observability (P2, Parallel)
+
+### WP15 — OpenTelemetry Integration
+**File**: `tasks/WP15-opentelemetry-integration.md`
+**Dependencies**: WP03
+**Priority**: P2 | **Est. lines**: ~350
+**Goal**: Extend `agileplus-telemetry` with OTLP traces, metrics, and axum middleware.
+
+- [x] T090: Add OTLP exporter setup (HTTP binary protocol, configurable endpoint)
+- [x] T091: Add tracing-opentelemetry layer integration with existing tracing subscriber
+- [x] T092: Add axum-tracing-opentelemetry middleware for automatic trace propagation
+- [x] T093: Define custom metrics (events.processed, sync.duration, cache.hit_rate, api.request_duration)
+- [x] T094: Add structured JSON log formatting with trace context injection
+
+---
+
+## Group 6: Multi-Device Sync (P3, after Group 3)
+
+### WP16 — P2P Sync via Tailscale
+**File**: `tasks/WP16-p2p-sync-tailscale.md`
+**Dependencies**: WP09
+**Priority**: P3 | **Est. lines**: ~400
+**Goal**: Create `agileplus-p2p` crate for Tailscale peer discovery and event replication.
+
+- [x] T095: Scaffold `agileplus-p2p` crate with tailscale-localapi
+- [x] T096: Implement peer discovery (query Tailscale local API for peers, filter AgilePlus nodes)
+- [x] T097: Implement device registration (DeviceNode entity, sync vector initialization)
+- [x] T098: Implement event replication protocol (NATS over Tailscale, subject-based routing)
+- [x] T099: Implement vector clock sync (track per-entity sequence numbers across devices)
+
+### WP17 — Git-Backed State Sync
+**File**: `tasks/WP17-git-backed-state.md`
+**Dependencies**: WP16
+**Priority**: P3 | **Est. lines**: ~350
+**Goal**: Serialize SQLite state to deterministic, mergeable files for git-backed sync.
+
+- [x] T100: Define export format (JSONL events, JSON snapshots, deterministic ordering)
+- [x] T101: Implement state export (SQLite → git-trackable files in `.agileplus/` directory)
+- [x] T102: Implement state import (git-trackable files → SQLite, merge with existing)
+- [x] T103: Implement conflict detection for git merge scenarios
+
+### WP18 — CLI Device Commands
+**File**: `tasks/WP18-cli-device-commands.md`
+**Dependencies**: WP17
+**Priority**: P3 | **Est. lines**: ~250
+**Goal**: Add `agileplus device [discover|sync|status]` CLI commands.
+
+- [x] T104: Add `device discover` subcommand (list Tailscale peers running AgilePlus)
+- [x] T105: Add `device sync` subcommand (trigger P2P sync with specific peer or all)
+- [x] T106: Add `device status` subcommand (show sync vector, last sync times)
+
+---
+
+## Group 7: Integration Testing & Hardening (P3)
+
+### WP19 — End-to-End Integration Tests
+**File**: `tasks/WP19-e2e-integration-tests.md`
+**Dependencies**: WP14
+**Priority**: P3 | **Est. lines**: ~400
+**Goal**: Full pipeline integration tests with all platform services.
+
+- [x] T107: Create test harness (Process Compose up, wait for health, seed test data)
+- [x] T108: Test feature lifecycle (create → sync → transition → audit → verify events)
+- [x] T109: Test dashboard real-time updates (SSE connection, state change, DOM verification)
+- [x] T110: Test sync conflict resolution (create conflict, verify detection and resolution)
+- [x] T111: Test service failure recovery (kill service, verify restart, verify no data loss)
+
+### WP20 — Contract Tests
+**File**: `tasks/WP20-contract-tests.md`
+**Dependencies**: WP19
+**Priority**: P3 | **Est. lines**: ~300
+**Goal**: Pact contract tests for new crate boundaries.
+
+- [x] T112: Add pact tests for agileplus-events ↔ agileplus-sqlite boundary
+- [x] T113: Add pact tests for agileplus-sync ↔ agileplus-plane boundary
+- [x] T114: Add pact tests for agileplus-api ↔ agileplus-dashboard boundary
+- [x] T115: Add pact tests for agileplus-api ↔ agileplus-events boundary
+
+### WP21 — Performance Benchmarks
+**File**: `tasks/WP21-performance-benchmarks.md`
+**Dependencies**: WP20
+**Priority**: P3 | **Est. lines**: ~300
+**Goal**: Verify constitution performance gates with benchmarks.
+
+- [x] T116: Benchmark event append throughput (target: 10K events/sec)
+- [x] T117: Benchmark event replay/snapshot rebuild (target: <10ms for 1K events)
+- [x] T118: Benchmark API response times (target: <100ms p95)
+- [x] T119: Benchmark sync round-trip (target: <5s for single feature)
+- [x] T120: Benchmark memory usage at idle (target: <100MB excluding Neo4j JVM)

--- a/.agileplus/specs/004-modules-and-cycles/meta.json
+++ b/.agileplus/specs/004-modules-and-cycles/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "004-modules-and-cycles",
+  "title": "AgilePlus Modules & Cycles Domain Model",
+  "status": "active",
+  "created": "2026-03-03"
+}

--- a/.agileplus/specs/004-modules-and-cycles/spec.md
+++ b/.agileplus/specs/004-modules-and-cycles/spec.md
@@ -1,0 +1,196 @@
+# Feature Specification: AgilePlus Modules & Cycles Domain Model
+
+**Feature Branch**: `004-modules-and-cycles`
+**Created**: 2026-03-03
+**Status**: Draft
+**Input**: AgilePlus native Modules and Cycles domain model
+
+## User Scenarios & Testing
+
+### User Story 1 - Module Hierarchy & Feature Grouping (Priority: P1)
+
+A project lead creates a Module called "Authentication" and assigns three existing Features (login, SSO, password-reset) to it as owned children. They create a sub-Module "OAuth Providers" nested under Authentication. A fourth Feature "unified-search" is tagged to Authentication as a secondary association (it's primarily owned by the "Content" Module). CLI and dashboard views show Features grouped by Module, with tagged Features distinguished from owned ones.
+
+**Why this priority**: Without Modules, teams with 20+ features have no organizational structure — this is the foundational grouping primitive.
+
+**Independent Test**: Create Modules via CLI, assign Features, verify tree listing and Feature queries return correct groupings.
+
+**Acceptance Scenarios**:
+
+1. **Given** no Modules exist, **When** `agileplus module create "Authentication"` is run, **Then** a Module with slug "authentication" is persisted and returned
+2. **Given** Module "Authentication" exists, **When** `agileplus module create "OAuth Providers" --parent authentication` is run, **Then** a child Module is created under Authentication
+3. **Given** Feature "login" exists, **When** `agileplus module assign login authentication` is run, **Then** Feature.module_id is set to Authentication's id
+4. **Given** Feature "unified-search" is owned by "Content", **When** `agileplus module tag unified-search authentication` is run, **Then** a tag record is created; `agileplus module show authentication` lists unified-search under "Tagged Features"
+5. **Given** Module "Authentication" owns 3 Features, **When** `agileplus module list --tree` is run, **Then** output shows hierarchical tree with Feature counts
+
+---
+
+### User Story 2 - Cycle Lifecycle Planning (Priority: P1)
+
+A PM creates Cycle "Sprint 2026-Q1-W10" with start 2026-03-03 and end 2026-03-14. They assign 5 Features from across two Modules. The Cycle tracks its own lifecycle (Draft → Active → Review → Shipped → Archived). Dashboard shows aggregate WP progress. The Cycle cannot transition to Shipped until all assigned Features are at least Validated.
+
+**Why this priority**: Time-boxed planning is the core value proposition of Cycles — without lifecycle enforcement, it's just a label.
+
+**Independent Test**: Create a Cycle, add Features, advance through lifecycle states, verify gate enforcement.
+
+**Acceptance Scenarios**:
+
+1. **Given** no Cycles exist, **When** `agileplus cycle create "Sprint W10" --start 2026-03-03 --end 2026-03-14` is run, **Then** a Cycle in Draft state is created
+2. **Given** Cycle "Sprint W10" in Draft, **When** `agileplus cycle transition "Sprint W10" active` is run, **Then** Cycle moves to Active
+3. **Given** Cycle has Feature "login" in Implementing state, **When** `agileplus cycle transition "Sprint W10" shipped` is run, **Then** transition is REJECTED with reason "Feature login not yet Validated"
+4. **Given** all assigned Features are Validated or Shipped, **When** `agileplus cycle transition "Sprint W10" shipped` is run, **Then** Cycle transitions to Shipped
+5. **Given** Cycle exists, **When** `agileplus cycle show "Sprint W10"` is run, **Then** output shows assigned Features, WP counts per state, and date range
+
+---
+
+### User Story 3 - Module-Scoped vs Cross-Module Cycles (Priority: P2)
+
+A developer creates a Cycle scoped to the "Notifications" Module for a focused refactoring sprint. Only Features owned by or tagged to "Notifications" can be added. Separately, a PM creates a release Cycle with no module scope, spanning Authentication and Billing Modules.
+
+**Why this priority**: Configurable scoping adds flexibility but builds on the base Cycle entity.
+
+**Independent Test**: Create both scoped and unscoped Cycles, verify Feature assignment validation.
+
+**Acceptance Scenarios**:
+
+1. **Given** Module "Notifications" exists, **When** `agileplus cycle create "Notif Refactor" --start ... --end ... --module notifications` is run, **Then** Cycle is created with module_scope set
+2. **Given** scoped Cycle, **When** attempting to add Feature "login" (owned by Authentication, not tagged to Notifications), **Then** operation is REJECTED with "Feature not in Module scope"
+3. **Given** scoped Cycle, **When** adding Feature "alert-settings" (owned by Notifications), **Then** addition succeeds
+4. **Given** unscoped Cycle (no --module), **When** adding Features from any Module, **Then** all additions succeed
+
+---
+
+### User Story 4 - Plane.so Bidirectional Sync (Priority: P2)
+
+When a Module or Cycle is created in AgilePlus, it pushes to Plane.so as the corresponding Plane entity. When updated in Plane, changes pull back. Feature-to-Module and Feature-to-Cycle assignments sync as Plane issue-to-module and issue-to-cycle mappings.
+
+**Why this priority**: Sync is essential for teams using Plane.so but builds on the domain model being correct first.
+
+**Independent Test**: Create Module/Cycle in AgilePlus, verify Plane API calls, simulate inbound webhook, verify state update.
+
+**Acceptance Scenarios**:
+
+1. **Given** sync enabled, **When** Module "Auth" is created in AgilePlus, **Then** a Plane Module is created via POST to `/api/v1/workspaces/{slug}/projects/{id}/modules/`
+2. **Given** sync mapping exists, **When** Plane Module name is updated via webhook, **Then** AgilePlus Module friendly_name is updated
+3. **Given** Feature assigned to Module in AgilePlus, **When** sync runs, **Then** corresponding Plane issue is added to Plane Module
+4. **Given** Cycle created in AgilePlus, **When** sync runs, **Then** Plane Cycle is created with matching dates and name
+5. **Given** conflict (both sides changed), **When** sync runs, **Then** configured conflict_strategy applies
+
+---
+
+### User Story 5 - Dashboard Module & Cycle Views (Priority: P3)
+
+Dashboard sidebar shows Module tree with expandable hierarchy and Feature counts. A Cycle kanban view shows Cycles as columns by state with Feature cards inside. Cycle detail page shows burndown of WPs.
+
+**Why this priority**: Visual views are high-value but can be added after CLI and domain model are solid.
+
+**Independent Test**: Verify dashboard endpoints return correct HTML with Module tree and Cycle kanban.
+
+**Acceptance Scenarios**:
+
+1. **Given** Modules with Features exist, **When** dashboard sidebar loads, **Then** Module tree is rendered with correct counts
+2. **Given** Cycles in various states exist, **When** Cycle kanban page loads, **Then** Cycles appear in correct state columns
+3. **Given** Cycle with assigned Features, **When** Cycle detail page loads, **Then** WP burndown and Feature progress are displayed
+
+---
+
+### Edge Cases
+
+- **Circular Module hierarchy**: Attempting to set a Module's parent to itself or to a descendant is rejected
+- **Feature with no Module**: Allowed — module_id is nullable for backward compatibility with existing Features
+- **Empty Cycle**: Valid — a Cycle in Draft with no assigned Features is a planning placeholder
+- **Overlapping Cycles**: Features can be in multiple concurrent Cycles
+- **Module-scoped Cycle with subsequently-untagged Feature**: If a Feature is removed from a Module after being added to a scoped Cycle, the Feature remains in the Cycle (no cascade removal)
+- **Deleting a Cycle**: Unlinks Features but does not change Feature states
+- **Deleting a Module with children**: Rejected — must delete or reparent child Modules first
+- **Plane sync conflict**: Uses existing conflict_strategy config (local-wins, remote-wins, manual)
+
+## Requirements
+
+### Functional Requirements
+
+#### Module Entity
+
+- **FR-M01**: System MUST support a Module entity with id, slug, friendly_name, description, parent_module_id (nullable), created_at, updated_at
+- **FR-M02**: System MUST enforce tree hierarchy — Modules can nest, but circular references are rejected
+- **FR-M03**: Each Feature MUST have an optional module_id foreign key for strict ownership (one Module per Feature)
+- **FR-M04**: System MUST support many-to-many tagging via module_feature_tags join table
+- **FR-M05**: Module queries MUST return both owned and tagged Features, distinguished by relationship type
+- **FR-M06**: Module deletion MUST be rejected if it still owns Features or has child Modules
+- **FR-M07**: Module slug MUST be unique among siblings (same parent_module_id)
+
+#### Cycle Entity
+
+- **FR-C01**: System MUST support a Cycle entity with id, name, description, state (CycleState), start_date, end_date, module_scope_id (nullable), created_at, updated_at
+- **FR-C02**: CycleState MUST follow lifecycle: Draft → Active → Review → Shipped → Archived
+- **FR-C03**: Feature-to-Cycle assignment MUST be many-to-many via cycle_features join table
+- **FR-C04**: When module_scope_id is set, only Features owned by or tagged to that Module are assignable
+- **FR-C05**: When module_scope_id is null, any Feature is assignable
+- **FR-C06**: System MUST compute aggregate WP progress per Cycle (count per WpState across all assigned Features)
+- **FR-C07**: Cycle transition to Shipped MUST be gated on all assigned Features being Validated or Shipped
+
+#### Storage Port
+
+- **FR-S01**: StoragePort MUST be extended with Module CRUD operations
+- **FR-S02**: StoragePort MUST be extended with Cycle CRUD operations
+- **FR-S03**: StoragePort MUST support module_feature_tags and cycle_features join table operations
+- **FR-S04**: SQLite migrations MUST add modules, module_feature_tags, cycles, cycle_features tables and Feature.module_id column
+
+#### CLI
+
+- **FR-CLI01**: `agileplus module create|list|show|assign|tag|untag|delete` commands
+- **FR-CLI02**: `agileplus cycle create|list|show|add|remove|transition` commands
+- **FR-CLI03**: `agileplus module list --tree` MUST render hierarchical tree output
+
+#### Dashboard
+
+- **FR-D01**: Module tree view in sidebar with Feature counts
+- **FR-D02**: Cycle kanban view with state columns and Feature cards
+- **FR-D03**: Cycle detail page with WP burndown
+- **FR-D04**: Module detail page with owned/tagged Feature lists
+
+#### Plane.so Sync
+
+- **FR-P01**: Module create/update MUST push to Plane.so Modules API
+- **FR-P02**: Cycle create/update MUST push to Plane.so Cycles API
+- **FR-P03**: Plane Module/Cycle updates MUST pull into AgilePlus via webhook or poll
+- **FR-P04**: Feature-Module and Feature-Cycle assignments MUST sync to Plane issue-module and issue-cycle mappings
+- **FR-P05**: Sync mappings MUST use existing sync_mappings infrastructure with entity_type discriminator
+
+### Key Entities
+
+- **Module**: Hierarchical grouping of Features. Has parent/child relationships and many-to-many tags. Maps to Plane.so Module.
+- **Cycle**: Time-boxed implementation phase with lifecycle state machine. Contains Features via join table. Optionally scoped to a Module. Maps to Plane.so Cycle.
+- **ModuleFeatureTag**: Join table linking Features to Modules (many-to-many secondary association)
+- **CycleFeature**: Join table linking Features to Cycles (many-to-many)
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: Teams can organize 50+ Features into a Module hierarchy navigable in under 3 CLI commands
+- **SC-002**: Cycle-based planning allows selecting Features, enforcing time bounds, and gating completion on Feature states
+- **SC-003**: Module and Cycle data round-trips through Plane.so sync without data loss (verified by automated contract tests)
+- **SC-004**: All Module and Cycle operations available via CLI without requiring dashboard access
+- **SC-005**: Dashboard renders Module tree and Cycle views with SSE-driven real-time updates
+
+## Assumptions
+
+- Plane.so API supports Module and Cycle CRUD (`/api/v1/workspaces/{slug}/projects/{id}/modules/` and `/cycles/`)
+- Existing sync_mappings table can be extended with entity_type discriminator
+- Dashboard SSE infrastructure (spec003) is available
+- Backward compatibility: existing Features with no Module continue to work (module_id nullable)
+
+## Dependencies
+
+- spec003 (Platform Completion) — dashboard SSE, NATS event bus
+- agileplus-plane crate — existing sync infrastructure
+- agileplus-domain — Feature and WorkPackage entities
+
+## Out of Scope
+
+- Module/Cycle permissions (deferred to multi-user feature)
+- Module templates or archetypes
+- Cycle velocity/capacity planning algorithms
+- Automatic Feature-to-Cycle assignment
+- GitHub Projects sync for Modules/Cycles

--- a/.agileplus/specs/004-modules-and-cycles/tasks.md
+++ b/.agileplus/specs/004-modules-and-cycles/tasks.md
@@ -1,0 +1,192 @@
+# Work Package Index: 004 Modules & Cycles
+
+**Feature**: 004-modules-and-cycles
+**Total WPs**: 7 | **Total Subtasks**: 38
+**MVP Scope**: WP01 → WP02 → WP03 → WP04 = Domain + Storage + CLI (4 WPs)
+**Full Scope**: + WP05 (Dashboard) + WP06 (Plane Sync) + WP07 (Integration Tests)
+
+---
+
+## Dependency Graph
+
+```
+WP01 (Domain Entities)
+├── WP02 (Storage Port + SQLite)  [depends: WP01]
+│   ├── WP03 (CLI Module Commands)  [depends: WP02]
+│   ├── WP04 (CLI Cycle Commands)   [depends: WP02]
+│   ├── WP05 (Dashboard Views)      [depends: WP02]
+│   └── WP06 (Plane.so Sync)        [depends: WP02]
+└── WP07 (Integration Tests)        [depends: WP03, WP04]
+```
+
+**Parallelizable**: WP03, WP04, WP05, WP06 can all run in parallel after WP02.
+
+---
+
+## Phase 1 — Domain Model
+
+### WP01: Domain Entities — Module & Cycle (6 subtasks, ~350 lines)
+
+**Goal**: Add Module, Cycle, CycleState, ModuleFeatureTag, CycleFeature to agileplus-domain and extend Feature with module_id.
+**Priority**: P1 | **Dependencies**: none
+**FRs**: FR-M01, FR-M02, FR-M03, FR-M04, FR-M07, FR-C01, FR-C02, FR-C03, FR-C04, FR-C05, FR-C07
+**Prompt**: `tasks/WP01-domain-entities.md`
+
+Subtasks:
+- [ ] T001: Create Module struct with slug, friendly_name, description, parent_module_id
+- [ ] T002: Create ModuleFeatureTag struct (module_id, feature_id, created_at)
+- [ ] T003: Create CycleState enum with transition validation (Draft→Active→Review→Shipped→Archived)
+- [ ] T004: Create Cycle struct with lifecycle state machine and module scope
+- [ ] T005: Create CycleFeature struct and module-scope validation logic
+- [ ] T006: Extend Feature with optional module_id field, extend DomainError
+
+---
+
+## Phase 2 — Storage
+
+### WP02: Storage Port Extension + SQLite Adapter (7 subtasks, ~450 lines)
+
+**Goal**: Extend StoragePort trait with Module/Cycle CRUD and implement in SQLite adapter.
+**Priority**: P1 | **Dependencies**: WP01
+**FRs**: FR-S01, FR-S02, FR-S03, FR-S04, FR-M05, FR-M06, FR-C06
+**Prompt**: `tasks/WP02-storage-adapter.md`
+
+Subtasks:
+- [ ] T007: Add Module CRUD methods to StoragePort trait
+- [ ] T008: Add Cycle CRUD methods to StoragePort trait
+- [ ] T009: Add join table methods (tag/untag, add/remove Feature from Cycle)
+- [ ] T010: Create SQLite migration 010_modules_cycles.sql (4 tables + indexes + ALTER)
+- [ ] T011: Implement Module CRUD in SQLite adapter (with circular ref check)
+- [ ] T012: Implement Cycle CRUD in SQLite adapter (with aggregate WP progress)
+- [ ] T013: Implement join table operations and module-scope validation in SQLite
+
+---
+
+## Phase 3 — CLI (parallelizable)
+
+### WP03: CLI Module Commands (5 subtasks, ~350 lines)
+
+**Goal**: Add `agileplus module` subcommand group with create, list, show, assign, tag, untag, delete.
+**Priority**: P1 | **Dependencies**: WP02
+**FRs**: FR-CLI01, FR-CLI03
+**Prompt**: `tasks/WP03-cli-module.md`
+
+Subtasks:
+- [ ] T014: Create module.rs command module with ModuleArgs enum (create, list, show, assign, tag, untag, delete)
+- [ ] T015: Implement module create (with --parent flag) and module delete (with child/feature guards)
+- [ ] T016: Implement module list (flat + --tree recursive) and module show (owned + tagged features)
+- [ ] T017: Implement module assign/tag/untag commands
+- [ ] T018: Wire module commands into main.rs Commands enum + unit tests
+
+### WP04: CLI Cycle Commands (5 subtasks, ~350 lines)
+
+**Goal**: Add `agileplus cycle` subcommand group with create, list, show, add, remove, transition.
+**Priority**: P1 | **Dependencies**: WP02
+**FRs**: FR-CLI02
+**Prompt**: `tasks/WP04-cli-cycle.md`
+
+Subtasks:
+- [ ] T019: Create cycle.rs command module with CycleArgs enum
+- [ ] T020: Implement cycle create (--start, --end, --module scope) and cycle list (by state)
+- [ ] T021: Implement cycle show (assigned features, WP progress aggregate, date range)
+- [ ] T022: Implement cycle add/remove (Feature assignment with scope validation)
+- [ ] T023: Implement cycle transition (with gate enforcement for Shipped) + wire into main.rs + tests
+
+---
+
+## Phase 4 — Dashboard
+
+### WP05: Dashboard Module & Cycle Views (5 subtasks, ~400 lines)
+
+**Goal**: Add Module tree sidebar, Cycle kanban, and Cycle detail views to dashboard.
+**Priority**: P3 | **Dependencies**: WP02
+**FRs**: FR-D01, FR-D02, FR-D03, FR-D04
+**Prompt**: `tasks/WP05-dashboard-views.md`
+
+Subtasks:
+- [ ] T024: Add Module and Cycle API routes in agileplus-api (list, show, tree)
+- [ ] T025: Create module_tree.html Askama template (recursive tree with feature counts)
+- [ ] T026: Create cycle_kanban.html template (columns by CycleState, feature cards)
+- [ ] T027: Create cycle_detail.html template (WP burndown, feature progress table)
+- [ ] T028: Wire routes into API router, add SSE event types for module/cycle changes
+
+---
+
+## Phase 5 — Plane.so Sync
+
+### WP06: Plane.so Module & Cycle Sync (5 subtasks, ~400 lines)
+
+**Goal**: Bidirectional sync of Modules and Cycles with Plane.so API.
+**Priority**: P2 | **Dependencies**: WP02
+**FRs**: FR-P01, FR-P02, FR-P03, FR-P04, FR-P05
+**Prompt**: `tasks/WP06-plane-sync.md`
+
+Subtasks:
+- [ ] T029: Extend PlaneClient with module CRUD API methods (POST/PUT/DELETE /modules/)
+- [ ] T030: Extend PlaneClient with cycle CRUD API methods (POST/PUT/DELETE /cycles/)
+- [ ] T031: Implement outbound push for Module/Cycle create/update/delete events
+- [ ] T032: Implement inbound pull/webhook for Plane Module/Cycle changes
+- [ ] T033: Add sync_mappings entries for module and cycle entity types + assignment sync
+
+---
+
+## Phase 6 — Quality
+
+### WP07: Integration Tests (5 subtasks, ~350 lines)
+
+**Goal**: End-to-end tests covering Module→Cycle→Feature lifecycle through CLI.
+**Priority**: P1 | **Dependencies**: WP03, WP04
+**FRs**: SC-001, SC-002
+**Prompt**: `tasks/WP07-integration-tests.md`
+
+Subtasks:
+- [ ] T034: Test Module hierarchy CRUD lifecycle (create tree, assign features, list --tree, delete guards)
+- [ ] T035: Test Cycle lifecycle (create, add features, transition through states, gate enforcement)
+- [ ] T036: Test Module-scoped Cycle (scope validation, rejection of out-of-scope features)
+- [ ] T037: Test backward compatibility (existing features with no module_id still work)
+- [ ] T038: Test edge cases (circular module ref, overlapping cycles, empty cycle, delete with children)
+
+---
+
+## Subtask Index
+
+| ID | Description | WP | Parallel |
+|----|-------------|-----|----------|
+| T001 | Module struct | WP01 | |
+| T002 | ModuleFeatureTag struct | WP01 | [P] T001 |
+| T003 | CycleState enum + transitions | WP01 | [P] T001 |
+| T004 | Cycle struct | WP01 | |
+| T005 | CycleFeature + scope validation | WP01 | |
+| T006 | Feature.module_id + DomainError | WP01 | [P] T001 |
+| T007 | StoragePort Module CRUD | WP02 | |
+| T008 | StoragePort Cycle CRUD | WP02 | [P] T007 |
+| T009 | StoragePort join table ops | WP02 | |
+| T010 | SQLite migration 010 | WP02 | |
+| T011 | SQLite Module CRUD impl | WP02 | |
+| T012 | SQLite Cycle CRUD impl | WP02 | [P] T011 |
+| T013 | SQLite join table impl | WP02 | |
+| T014 | CLI module command scaffold | WP03 | |
+| T015 | CLI module create/delete | WP03 | |
+| T016 | CLI module list/show | WP03 | |
+| T017 | CLI module assign/tag/untag | WP03 | |
+| T018 | CLI module wiring + tests | WP03 | |
+| T019 | CLI cycle command scaffold | WP04 | |
+| T020 | CLI cycle create/list | WP04 | |
+| T021 | CLI cycle show | WP04 | |
+| T022 | CLI cycle add/remove | WP04 | |
+| T023 | CLI cycle transition + tests | WP04 | |
+| T024 | Dashboard API routes | WP05 | |
+| T025 | Module tree template | WP05 | [P] T024 |
+| T026 | Cycle kanban template | WP05 | [P] T024 |
+| T027 | Cycle detail template | WP05 | [P] T024 |
+| T028 | SSE events + router wiring | WP05 | |
+| T029 | Plane module API methods | WP06 | |
+| T030 | Plane cycle API methods | WP06 | [P] T029 |
+| T031 | Outbound push module/cycle | WP06 | |
+| T032 | Inbound pull/webhook | WP06 | |
+| T033 | Sync mappings + assignment sync | WP06 | |
+| T034 | Integration: module hierarchy | WP07 | |
+| T035 | Integration: cycle lifecycle | WP07 | [P] T034 |
+| T036 | Integration: scoped cycles | WP07 | [P] T034 |
+| T037 | Integration: backward compat | WP07 | [P] T034 |
+| T038 | Integration: edge cases | WP07 | |

--- a/.agileplus/specs/005-heliosapp-completion/meta.json
+++ b/.agileplus/specs/005-heliosapp-completion/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "005-heliosapp-completion",
+  "title": "Heliosapp Completion",
+  "status": "active",
+  "created": "2026-03-27"
+}

--- a/.agileplus/specs/005-heliosapp-completion/spec.md
+++ b/.agileplus/specs/005-heliosapp-completion/spec.md
@@ -1,0 +1,76 @@
+# Spec: heliosApp Completion and Modernization
+
+## Meta
+
+- **ID**: 005-heliosapp-completion
+- **Title**: heliosApp Completion and Modernization
+- **Created**: 2026-03-25
+- **State**: in_progress
+- **Repo**: /Users/kooshapari/CodeProjects/Phenotype/repos/heliosApp
+
+## Overview
+
+Complete modernization and stabilization of heliosApp (1022 commits since 2025-01-01).
+
+## Past Work (Retroactive Specs)
+
+### Core Runtime (Completed)
+- TypeScript/Bun runtime implementation
+- Biome linting migration (oxc)
+- Desktop/solid-jsx components
+- Consolidated stabilization efforts
+
+### CI/CD (Completed)
+- Policy gate workflows
+- Quality gate integration
+- Biome formatting standards
+
+## Present Work (Current)
+
+### WP001: OXC Migration
+- State: merged
+- Commits: oxc-migration-20260305-heliosapp-consolidated
+- Files: biome.json, package configs
+
+### WP002: Consolidated Stabilization
+- State: merged
+- Focus: CI and runtime stability
+- PR: #306
+
+### WP003: Phase 2 Decomposition
+- State: merged
+- Feature decomposition
+- PR: #305
+
+## Future Work (Planned)
+
+### WP010: Feature Completeness Audit
+- Audit all features against PRD
+- Identify stubbed/unimplemented features
+- Complete missing implementations
+
+### WP011: Performance Optimization
+- Bundle size reduction
+- Runtime performance
+- Memory profiling
+
+### WP012: Desktop Integration
+- Complete desktop app features
+- IPC communication
+- System tray integration
+
+## Work Packages
+
+| ID | Description | State |
+|----|-------------|-------|
+| WP001 | OXC Migration | shipped |
+| WP002 | Consolidated Stabilization | shipped |
+| WP003 | Phase 2 Decomposition | shipped |
+| WP010 | Feature Completeness Audit | specified |
+| WP011 | Performance Optimization | specified |
+| WP012 | Desktop Integration | specified |
+
+## Traces
+
+- Related: 001-spec-driven-development-engine
+- Related: 003-agileplus-platform-completion

--- a/.agileplus/specs/005-heliosapp-completion/tasks.md
+++ b/.agileplus/specs/005-heliosapp-completion/tasks.md
@@ -1,0 +1,3 @@
+# Tasks
+
+_No tasks defined yet._

--- a/.agileplus/specs/006-helioscli-completion/meta.json
+++ b/.agileplus/specs/006-helioscli-completion/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "006-helioscli-completion",
+  "title": "Helioscli Completion",
+  "status": "active",
+  "created": "2026-03-27"
+}

--- a/.agileplus/specs/006-helioscli-completion/spec.md
+++ b/.agileplus/specs/006-helioscli-completion/spec.md
@@ -1,0 +1,61 @@
+# Spec: heliosCLI Completion
+
+## Meta
+
+- **ID**: 006-helioscli-completion
+- **Title**: heliosCLI Multi-Runtime Agent CLI Completion
+- **Created**: 2026-03-25
+- **State**: specified
+- **Repo**: /Users/kooshapari/CodeProjects/Phenotype/repos/heliosCLI
+
+## Overview
+
+Complete heliosCLI multi-runtime AI coding CLI (153 commits since 2025-01-01).
+
+## Architecture
+
+### Components
+- **codex-rs**: Rust core
+- **codex-cli**: TypeScript CLI
+- **Bazel monorepo**: Build system
+- **thegent integration**: Agent orchestration
+
+## Past Work (Completed)
+
+### WP001: Expect Pattern Cleanup
+- State: shipped
+- Cleanup of test expect patterns
+
+## Present Work (Current)
+
+### WP010: Bazel Build Optimization
+- Build caching
+- Remote execution
+- Incremental builds
+
+## Future Work (Planned)
+
+### WP020: Multi-Runtime Integration
+- Codex runtime
+- Claude runtime
+- Gemini runtime
+- Cursor runtime
+- Copilot runtime
+
+### WP021: thegent Orchestration
+- Full thegent integration
+- Agent lifecycle management
+
+## Work Packages
+
+| ID | Description | State |
+|----|-------------|-------|
+| WP001 | Expect cleanup | shipped |
+| WP010 | Bazel optimization | in_progress |
+| WP020 | Multi-runtime | specified |
+| WP021 | thegent integration | specified |
+
+## Traces
+
+- Related: 001-spec-driven-development-engine
+- Related: 007-thegent-completion

--- a/.agileplus/specs/006-helioscli-completion/tasks.md
+++ b/.agileplus/specs/006-helioscli-completion/tasks.md
@@ -1,0 +1,3 @@
+# Tasks
+
+_No tasks defined yet._

--- a/.agileplus/specs/007-thegent-completion/meta.json
+++ b/.agileplus/specs/007-thegent-completion/meta.json
@@ -1,0 +1,6 @@
+{
+  "id": "007-thegent-completion",
+  "title": "Thegent Completion",
+  "status": "active",
+  "created": "2026-03-27"
+}

--- a/.agileplus/specs/007-thegent-completion/spec.md
+++ b/.agileplus/specs/007-thegent-completion/spec.md
@@ -1,0 +1,84 @@
+# Spec: thegent Completion and Decomposition
+
+## Meta
+
+- **ID**: 007-thegent-completion
+- **Title**: thegent Agent Framework Completion
+- **Created**: 2026-03-25
+- **State**: in_progress
+- **Repo**: /Users/kooshapari/CodeProjects/Phenotype/repos/thegent
+
+## Overview
+
+Complete decomposition and stabilization of thegent agent framework (1027 commits since 2025-01-01).
+
+## Past Work (Completed)
+
+### WP001: Domain Extraction - MODELS
+- State: shipped
+- Commit: refactor: extract MODELS domain from CLI
+
+### WP002: Domain Extraction - PLAN
+- State: shipped
+- Commit: refactor(cli): extract plan domain subpackage
+
+### WP003: Domain Extraction - GOVERNANCE
+- State: shipped
+- Commit: refactor(cli): extract governance domain subpackage
+
+### WP004: Domain Extraction - TEAM
+- State: shipped
+- Commit: refactor(cli): extract TEAM domain subpackage
+
+### WP005: Cache Migration
+- State: shipped
+- Feature: phenotype-cache-adapter TieredCache migration
+
+### WP006: Atlas Generation
+- State: shipped
+- Feature: codebase atlas generation system
+
+### WP007: UUID Serde Feature
+- State: shipped
+- Fix: offload uuid serde feature
+
+## Present Work (Current)
+
+### WP010: Remaining Port Interfaces
+- State: merged
+- PR: #740
+
+### WP011: GitOps Refactor
+- State: in_progress
+- Track remaining gitops refactor
+- Shim split
+
+## Future Work (Planned)
+
+### WP020: Phench Wave 3
+- State: specified
+- Shared-modules rollout
+
+### WP021: Full Domain Decomposition
+- Complete CLI god package extraction
+- All domains separated
+
+### WP022: Integration Testing
+- Full E2E coverage
+- Contract testing
+
+## Work Packages
+
+| ID | Description | State |
+|----|-------------|-------|
+| WP001-WP007 | Domain extractions | shipped |
+| WP010 | Remaining port interfaces | shipped |
+| WP011 | GitOps refactor | in_progress |
+| WP020 | Phench Wave 3 | specified |
+| WP021 | Full decomposition | specified |
+| WP022 | Integration testing | specified |
+
+## Traces
+
+- Related: 001-spec-driven-development-engine
+- Related: 004-modules-and-cycles

--- a/.agileplus/specs/007-thegent-completion/tasks.md
+++ b/.agileplus/specs/007-thegent-completion/tasks.md
@@ -1,0 +1,3 @@
+# Tasks
+
+_No tasks defined yet._

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,11 +19,14 @@ AgilePlus tracks its own work through its own system.
 3. **Update work package status**: `agileplus status <feature-id> --wp <wp-id> --state <state>`
 4. **No code without corresponding AgilePlus spec**
 
-## Specs Location
+## Spec Management
 
-- kitty-specs/<feature-id>/spec.md
-- kitty-specs/<feature-id>/plan.md
-- kitty-specs/<feature-id>/tasks/WP*.md
+Use AgilePlus: `agileplus specify` and `agileplus status`
+
+Specs are stored in `.agileplus/specs/<feature-id>/`:
+- `.agileplus/specs/<feature-id>/spec.md` - feature description
+- `.agileplus/specs/<feature-id>/meta.json` - id, title, status
+- `.agileplus/specs/<feature-id>/tasks.md` - work packages
 
 ## Worklog
 


### PR DESCRIPTION
## Summary
- Migrates all 7 kitty-specs to `.agileplus/specs/<feature-id>/` format (spec.md, meta.json, tasks.md)
- Archives original `kitty-specs/` to `.archive/kitty-specs/`
- Updates CLAUDE.md Specs Location section to reference AgilePlus-native paths

## Changes
- `.agileplus/specs/001-spec-driven-development-engine/`
- `.agileplus/specs/002-org-wide-release-governance-dx-automation/`
- `.agileplus/specs/003-agileplus-platform-completion/`
- `.agileplus/specs/004-modules-and-cycles/`
- `.agileplus/specs/005-heliosapp-completion/`
- `.agileplus/specs/006-helioscli-completion/`
- `.agileplus/specs/007-thegent-completion/`
- `.archive/kitty-specs/` (archived originals)
- `CLAUDE.md` updated Spec Management section