### PR TITLE
fix(ci): repair VitePress Pages and Release Drafter workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -33,10 +33,12 @@ jobs:
           enablement: true
 
       - name: Install dependencies
+        working-directory: docs
         run: bun install --frozen-lockfile
 
       - name: Build VitePress site
-        run: bun run build
+        working-directory: docs
+        run: bun run docs:build
         env:
           GITHUB_PAGES: "true"
 

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,6 +3,11 @@ on:
   push:
     branches:
       - main
+
+permissions:
+  contents: write
+  pull-requests: read
+
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- **deploy.yml (VitePress Pages)**: Fixed 3 issues that prevented the build from running:
  - Pinned `actions/checkout` from non-existent `v6` to `v4`
  - Added `working-directory: docs` to the install and build steps (the `package.json` and `bun.lock` live in `docs/`, not the repo root)
  - Fixed the build script name from `build` to `docs:build` (the correct script name in `docs/package.json`)
- **release-drafter.yml**: Added required `permissions` block (`contents: write`, `pull-requests: read`) so the Release Drafter action can create and update draft releases

## Test plan

- [ ] Push to `main` with a `docs/**` change to verify VitePress Pages builds and deploys
- [ ] Push any commit to `main` to verify Release Drafter creates/updates a draft release
- Note: GitHub Actions billing constraint means CI jobs will fail at billing gate — verify workflow YAML syntax is valid locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build pipeline configuration for improved CI/CD workflow efficiency.
  * Enhanced workflow permissions to support automated release management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->