### PR TITLE
feat(evidence): real evidence bundle infrastructure

### DIFF
--- a/.github/workflows/evidence-capture.yml
+++ b/.github/workflows/evidence-capture.yml
@@ -1,0 +1,127 @@
+name: Evidence Capture
+
+on:
+  push:
+    branches:
+      - "feat/**"
+      - "fix/**"
+      - "chore/**"
+
+permissions:
+  contents: read
+
+jobs:
+  capture-evidence:
+    name: Capture evidence bundle
+    runs-on: ubuntu-latest
+    env:
+      BRANCH: ${{ github.ref_name }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      COMMIT_SHA: ${{ github.sha }}
+      REPO: ${{ github.repository }}
+      RUN_NUMBER: ${{ github.run_number }}
+      RUN_ID: ${{ github.run_id }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
+      - name: Cache Cargo registry and build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Run cargo test and capture results
+        id: cargo_test
+        run: |
+          mkdir -p .agileplus/evidence/ci-run
+          cargo test 2>&1 | tee .agileplus/evidence/ci-run/test-results.txt
+          PASSED=$(grep -c '^test .* \.\.\. ok$' .agileplus/evidence/ci-run/test-results.txt || echo "0")
+          FAILED=$(grep -c '^test .* \.\.\. FAILED$' .agileplus/evidence/ci-run/test-results.txt || echo "0")
+          echo "passed_count=$PASSED" >> "$GITHUB_OUTPUT"
+          echo "failed_count=$FAILED" >> "$GITHUB_OUTPUT"
+        continue-on-error: true
+
+      - name: Collect git log
+        run: |
+          git log --format="%H|%s|%ai|%an" -10 > .agileplus/evidence/ci-run/git-log.txt
+
+      - name: Write evidence bundle JSON
+        env:
+          PASSED_COUNT: ${{ steps.cargo_test.outputs.passed_count }}
+          FAILED_COUNT: ${{ steps.cargo_test.outputs.failed_count }}
+        run: |
+          TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          # Limit test output to 4096 chars; escape for JSON embedding
+          TEST_OUTPUT="$(head -c 4096 .agileplus/evidence/ci-run/test-results.txt \
+            | python3 -c 'import sys,json; print(json.dumps(sys.stdin.read()))' \
+            | sed 's/^"//;s/"$//')"
+          if [ "${FAILED_COUNT}" = "0" ]; then
+            TEST_PASSED="true"
+            CONCLUSION="success"
+          else
+            TEST_PASSED="false"
+            CONCLUSION="failure"
+          fi
+          cat > .agileplus/evidence/ci-run/bundle.json <<BUNDLE_EOF
+          {
+            "feature_id": "ci-run",
+            "timestamp": "${TIMESTAMP}",
+            "branch": "${BRANCH}",
+            "commit": "${COMMIT_SHA}",
+            "test_results": {
+              "passed": ${TEST_PASSED},
+              "passed_count": ${PASSED_COUNT},
+              "failed_count": ${FAILED_COUNT},
+              "summary": "${PASSED_COUNT} passed, ${FAILED_COUNT} failed",
+              "output_snippet": "${TEST_OUTPUT}"
+            },
+            "git_log": [],
+            "prs": [],
+            "ci_links": [
+              {
+                "id": ${RUN_ID},
+                "title": "CI run #${RUN_NUMBER} on ${BRANCH}",
+                "status": "completed",
+                "conclusion": "${CONCLUSION}",
+                "url": "${RUN_URL}",
+                "created_at": "${TIMESTAMP}"
+              }
+            ],
+            "repo": "${REPO}"
+          }
+          BUNDLE_EOF
+
+      - name: Upload evidence bundle as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: evidence-bundle-${{ github.run_number }}
+          path: .agileplus/evidence/ci-run/
+          retention-days: 90
+          if-no-files-found: warn
+
+      - name: Summary
+        env:
+          PASSED_COUNT: ${{ steps.cargo_test.outputs.passed_count }}
+          FAILED_COUNT: ${{ steps.cargo_test.outputs.failed_count }}
+        run: |
+          echo "## Evidence Bundle Captured" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Metric | Value |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|--------|-------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Branch | \`${BRANCH}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Commit | \`${COMMIT_SHA}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Tests passed | ${PASSED_COUNT} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Tests failed | ${FAILED_COUNT} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Artifact | \`evidence-bundle-${RUN_NUMBER}\` |" >> "$GITHUB_STEP_SUMMARY"

--- a/crates/agileplus-dashboard/src/routes.rs
+++ b/crates/agileplus-dashboard/src/routes.rs
@@ -23,12 +23,13 @@ use agileplus_domain::domain::{
 use crate::app_state::SharedState;
 use crate::process_detector;
 use crate::templates::{
-    AgentActivityPartial, AgentSettingsPage, AgentView, DashboardPage, EcosystemProject,
-    EventTimelinePartial, EventsPage, EvidenceBundleView, FeatureDetailPage, FeatureView,
-    FeaturesPage, HealthPanelPartial, HomePage, HubPage, KanbanPartial, MediaAssetView,
-    PlaneHealthEndpointView, PlaneSettingsPage, ProjectSummaryView, ProjectSwitcherPartial,
-    ProjectView, ReportArtifactView, ServicesSettingsPage, SettingsPage, ToastPartial,
-    WpListPartial, WpView, all_feature_states,
+    AgentActivityPartial, AgentSettingsPage, AgentView, CiLinkView, DashboardPage,
+    EcosystemProject, EventTimelinePartial, EventsPage, EvidenceBundleView,
+    FeatureDetailPage, FeatureEvidencePartial, FeatureView, FeaturesPage, GenerateEvidenceResponse,
+    GitCommitView, HealthPanelPartial, HomePage, HubPage, KanbanPartial, MediaAssetView,
+    PlaneHealthEndpointView, PlaneSettingsPage, PrLinkView, ProjectSummaryView,
+    ProjectSwitcherPartial, ProjectView, ReportArtifactView, ServicesSettingsPage, SettingsPage,
+    ToastPartial, WpListPartial, WpView, all_feature_states,
 };
 
 use serde::{Deserialize, Serialize};
@@ -148,6 +149,15 @@ fn is_htmx(headers: &HeaderMap) -> bool {
         .and_then(|v| v.to_str().ok())
         .map(|v| v == "true")
         .unwrap_or(false)
+}
+
+/// Minimal HTML entity escaping for embedding text content in HTML attributes/elements.
+fn html_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&#39;")
 }
 
 fn render<T: Template>(tpl: T) -> Response {
@@ -370,6 +380,13 @@ fn build_feature_evidence_bundles(
     feature: &FeatureView,
     workpackages: &[WpView],
 ) -> Vec<EvidenceBundleView> {
+    // Try to load real bundles from disk first.
+    let disk_bundles = load_evidence_bundles_from_disk(&feature.id.to_string());
+    if !disk_bundles.is_empty() {
+        return disk_bundles;
+    }
+
+    // Fall back to stub bundles when no disk bundles exist yet.
     let mut bundles = vec![EvidenceBundleView {
         id: format!("bundle-{id}-summary", id = feature.id),
         fr_id: format!("FR-{id}", id = feature.id),
@@ -380,15 +397,19 @@ fn build_feature_evidence_bundles(
         created_at: Utc::now().format("%Y-%m-%d %H:%M:%S UTC").to_string(),
         artifact_ext: "md".into(),
         status: "available".into(),
-        content_preview: Some(
-            "# Feature Summary
-
-This feature provides..."
-                .to_string(),
-        ),
+        content_preview: Some("# Feature Summary\n\nThis feature provides...".to_string()),
         is_text_artifact: true,
         is_image_artifact: false,
         download_url: format!("/api/evidence/{}/summary/content", feature.id),
+        test_passed: None,
+        tests_passed_count: 0,
+        tests_failed_count: 0,
+        test_summary: None,
+        commit_count: 0,
+        pr_count: 0,
+        ci_links: vec![],
+        git_commits: vec![],
+        pr_links: vec![],
     }];
 
     for wp in workpackages {
@@ -405,16 +426,20 @@ This feature provides..."
             ),
             created_at: Utc::now().format("%Y-%m-%d %H:%M:%S UTC").to_string(),
             artifact_ext: "json".into(),
-            status: if wp.progress > 0 {
-                "accepted"
-            } else {
-                "generated"
-            }
-            .into(),
+            status: if wp.progress > 0 { "accepted" } else { "generated" }.into(),
             content_preview: Some(r#"{"status":"generated","progress":0}"#.to_string()),
             is_text_artifact: true,
             is_image_artifact: false,
             download_url: format!("/api/evidence/{}/{}/content", feature.id, wp.id),
+            test_passed: None,
+            tests_passed_count: 0,
+            tests_failed_count: 0,
+            test_summary: None,
+            commit_count: 0,
+            pr_count: 0,
+            ci_links: vec![],
+            git_commits: vec![],
+            pr_links: vec![],
         });
     }
 
@@ -1088,33 +1113,230 @@ pub async fn time_footer() -> Html<String> {
 
 // ── /api/evidence ────────────────────────────────────────────────────────
 
+/// Load real evidence bundles from `.agileplus/evidence/<feature_id>/bundle.json`.
+fn load_evidence_bundles_from_disk(feature_id: &str) -> Vec<EvidenceBundleView> {
+    let bundle_path = PathBuf::from(".agileplus")
+        .join("evidence")
+        .join(feature_id)
+        .join("bundle.json");
+
+    let content = match fs::read_to_string(&bundle_path) {
+        Ok(c) => c,
+        Err(_) => return vec![],
+    };
+
+    let val: serde_json::Value = match serde_json::from_str(&content) {
+        Ok(v) => v,
+        Err(_) => return vec![],
+    };
+
+    let timestamp = val["timestamp"]
+        .as_str()
+        .unwrap_or("unknown")
+        .to_string();
+
+    // Parse test_results
+    let tr = &val["test_results"];
+    let test_passed = tr["passed"].as_bool();
+    let tests_passed_count = tr["passed_count"].as_u64().unwrap_or(0) as u32;
+    let tests_failed_count = tr["failed_count"].as_u64().unwrap_or(0) as u32;
+    let test_summary = tr["summary"].as_str().map(str::to_string);
+    let test_output = tr["output_snippet"].as_str().map(str::to_string);
+
+    // Parse git commits
+    let git_commits: Vec<GitCommitView> = val["git_log"]
+        .as_array()
+        .unwrap_or(&vec![])
+        .iter()
+        .map(|c| GitCommitView {
+            short_hash: c["short_hash"].as_str().unwrap_or("").to_string(),
+            subject: c["subject"].as_str().unwrap_or("").to_string(),
+            date: c["date"].as_str().unwrap_or("").to_string(),
+            author: c["author"].as_str().unwrap_or("").to_string(),
+            url: c["url"].as_str().unwrap_or("").to_string(),
+        })
+        .collect();
+
+    // Parse PRs
+    let pr_links: Vec<PrLinkView> = val["prs"]
+        .as_array()
+        .unwrap_or(&vec![])
+        .iter()
+        .map(|p| PrLinkView {
+            number: p["number"].as_u64().unwrap_or(0),
+            title: p["title"].as_str().unwrap_or("").to_string(),
+            url: p["url"].as_str().unwrap_or("").to_string(),
+            state: p["state"].as_str().unwrap_or("").to_lowercase(),
+            head_ref: p["headRefName"].as_str().unwrap_or("").to_string(),
+            created_at: p["createdAt"].as_str().unwrap_or("").to_string(),
+        })
+        .collect();
+
+    // Parse CI links
+    let ci_links: Vec<CiLinkView> = val["ci_links"]
+        .as_array()
+        .unwrap_or(&vec![])
+        .iter()
+        .map(|c| CiLinkView {
+            id: c["id"].as_i64().unwrap_or(0),
+            title: c["title"].as_str().unwrap_or("").to_string(),
+            status: c["status"].as_str().unwrap_or("").to_string(),
+            conclusion: c["conclusion"].as_str().unwrap_or("pending").to_string(),
+            url: c["url"].as_str().unwrap_or("").to_string(),
+            created_at: c["created_at"].as_str().unwrap_or("").to_string(),
+        })
+        .collect();
+
+    let commit_count = git_commits.len();
+    let pr_count = pr_links.len();
+    let status = if test_passed.unwrap_or(false) {
+        "verified"
+    } else {
+        "generated"
+    };
+
+    vec![EvidenceBundleView {
+        id: format!("bundle-{feature_id}-disk"),
+        fr_id: format!("FR-{feature_id}"),
+        evidence_type: "generated_bundle".into(),
+        wp_id: "auto".into(),
+        wp_title: format!("Evidence Bundle — {feature_id}"),
+        artifact_path: bundle_path.display().to_string(),
+        created_at: timestamp,
+        artifact_ext: "json".into(),
+        status: status.into(),
+        content_preview: test_output,
+        is_text_artifact: true,
+        is_image_artifact: false,
+        download_url: format!("/api/features/{feature_id}/evidence/bundle.json"),
+        test_passed,
+        tests_passed_count,
+        tests_failed_count,
+        test_summary,
+        commit_count,
+        pr_count,
+        ci_links,
+        git_commits,
+        pr_links,
+    }]
+}
+
 pub async fn evidence_content(
     State(_state): State<SharedState>,
     Path((feature_id, artifact_id)): Path<(i64, String)>,
 ) -> Response {
-    // In production, this would serve from MinIO or local filesystem
-    // For now, return a sample response
-    let sample_content = format!(
-        "# Evidence Bundle {}
+    // Serve from .agileplus/evidence/<feature_id>/<artifact_id>
+    let artifact_path = PathBuf::from(".agileplus")
+        .join("evidence")
+        .join(feature_id.to_string())
+        .join(&artifact_id);
 
-## Artifact ID: {}
+    if let Ok(content) = fs::read_to_string(&artifact_path) {
+        let escaped = html_escape(&content);
+        return Html(format!(
+            "<pre class='text-xs font-mono text-zinc-300 whitespace-pre-wrap'>{escaped}</pre>",
+        ))
+        .into_response();
+    }
 
-This is sample evidence content.",
-        feature_id, artifact_id
-    );
-    Html(sample_content).into_response()
+    Html(format!(
+        "# Evidence Bundle {feature_id}\n\n## Artifact ID: {artifact_id}\n\nNo artifact found at expected path."
+    ))
+    .into_response()
 }
 
 pub async fn evidence_preview(
     State(_state): State<SharedState>,
     Path((feature_id, artifact_id)): Path<(i64, String)>,
 ) -> Response {
-    // Return an htmx partial with inline preview
+    let artifact_path = PathBuf::from(".agileplus")
+        .join("evidence")
+        .join(feature_id.to_string())
+        .join(&artifact_id);
+
+    let text = fs::read_to_string(&artifact_path)
+        .unwrap_or_else(|_| format!("No preview — artifact not found: {artifact_id}"));
+    let escaped = html_escape(&text);
     let preview = format!(
-        "<div class='p-3 rounded bg-zinc-800 border border-zinc-700'>         <pre class='text-xs font-mono text-zinc-300'>Evidence #{} - {}</pre>         </div>",
-        feature_id, artifact_id
+        "<div class='p-3 rounded bg-zinc-800 border border-zinc-700'>\
+         <pre class='text-xs font-mono text-zinc-300 max-h-48 overflow-y-auto'>{escaped}</pre>\
+         </div>"
     );
     Html(preview).into_response()
+}
+
+// ── /api/features/{id}/evidence ───────────────────────────────────────────
+
+/// `GET /api/features/{id}/evidence`
+/// Returns the evidence gallery partial for the feature.
+pub async fn feature_evidence_list(
+    State(_state): State<SharedState>,
+    Path(feature_id): Path<String>,
+) -> Response {
+    let bundles = load_evidence_bundles_from_disk(&feature_id);
+    let tmpl = FeatureEvidencePartial {
+        evidence_bundles: bundles,
+    };
+    match tmpl.render() {
+        Ok(html) => Html(html).into_response(),
+        Err(e) => {
+            tracing::error!("Template render error: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR.into_response()
+        }
+    }
+}
+
+/// `POST /api/features/{id}/evidence/generate`
+/// Runs `scripts/generate-evidence.sh <feature-id>` asynchronously and
+/// returns a JSON status response.
+pub async fn feature_evidence_generate(
+    State(_state): State<SharedState>,
+    Path(feature_id): Path<String>,
+) -> Response {
+    // Locate the script relative to the process working directory.
+    let script = PathBuf::from("scripts").join("generate-evidence.sh");
+
+    if !script.exists() {
+        return axum::Json(GenerateEvidenceResponse {
+            feature_id: feature_id.clone(),
+            bundle_path: String::new(),
+            status: "error".into(),
+            message: "generate-evidence.sh not found — ensure the server is started from the repo root".into(),
+        })
+        .into_response();
+    }
+
+    let bundle_path = format!(".agileplus/evidence/{feature_id}/bundle.json");
+    let fid = feature_id.clone();
+
+    // Spawn async so the HTTP response returns immediately.
+    tokio::spawn(async move {
+        let out = tokio::process::Command::new("bash")
+            .arg(&script)
+            .arg(&fid)
+            .output()
+            .await;
+        match out {
+            Ok(o) if o.status.success() => {
+                tracing::info!("Evidence bundle generated for feature {fid}");
+            }
+            Ok(o) => {
+                let stderr = String::from_utf8_lossy(&o.stderr);
+                tracing::warn!("Evidence generation failed for {fid}: {stderr}");
+            }
+            Err(e) => {
+                tracing::error!("Failed to run generate-evidence.sh for {fid}: {e}");
+            }
+        }
+    });
+
+    axum::Json(GenerateEvidenceResponse {
+        feature_id,
+        bundle_path,
+        status: "started".into(),
+        message: "Evidence generation started — poll GET /api/features/{id}/evidence for results".into(),
+    })
+    .into_response()
 }
 
 pub async fn stream_placeholder() -> StatusCode {
@@ -1438,6 +1660,14 @@ pub fn router(state: SharedState) -> Router {
         .route(
             "/api/evidence/{feature_id}/{artifact_id}/preview",
             get(evidence_preview),
+        )
+        .route(
+            "/api/features/{id}/evidence",
+            get(feature_evidence_list),
+        )
+        .route(
+            "/api/features/{id}/evidence/generate",
+            post(feature_evidence_generate),
         )
         .with_state(state)
 }

--- a/crates/agileplus-dashboard/src/routes/dashboard.rs
+++ b/crates/agileplus-dashboard/src/routes/dashboard.rs
@@ -9,9 +9,10 @@ use chrono::Utc;
 
 use crate::app_state::SharedState;
 use crate::templates::{
-    AgentActivityPartial, AgentView, DashboardPage, EventTimelinePartial, EvidenceBundleView,
-    FeatureDetailPage, FeatureView, HealthPanelPartial, KanbanPartial, MediaAssetView,
-    ProjectSwitcherPartial, ProjectView, ReportArtifactView, WpListPartial, WpView,
+    AgentActivityPartial, AgentView, CiLinkView, DashboardPage, EventTimelinePartial,
+    EvidenceBundleView, FeatureDetailPage, FeatureView, GitCommitView, HealthPanelPartial,
+    KanbanPartial, MediaAssetView, PrLinkView, ProjectSwitcherPartial, ProjectView,
+    ReportArtifactView, WpListPartial, WpView,
 };
 
 use super::helpers::{
@@ -73,6 +74,19 @@ fn build_feature_evidence_bundles(
         created_at: Utc::now().format("%Y-%m-%d %H:%M:%S UTC").to_string(),
         artifact_ext: "md".into(),
         status: "available".into(),
+        content_preview: Some("# Feature Summary\n\nThis feature provides...".to_string()),
+        is_text_artifact: true,
+        is_image_artifact: false,
+        download_url: format!("/api/evidence/{}/summary/content", feature.id),
+        test_passed: None,
+        tests_passed_count: 0,
+        tests_failed_count: 0,
+        test_summary: None,
+        commit_count: 0,
+        pr_count: 0,
+        ci_links: vec![],
+        git_commits: vec![],
+        pr_links: vec![],
     }];
 
     for wp in workpackages {
@@ -89,12 +103,20 @@ fn build_feature_evidence_bundles(
             ),
             created_at: Utc::now().format("%Y-%m-%d %H:%M:%S UTC").to_string(),
             artifact_ext: "json".into(),
-            status: if wp.progress > 0 {
-                "accepted"
-            } else {
-                "generated"
-            }
-            .into(),
+            status: if wp.progress > 0 { "accepted" } else { "generated" }.into(),
+            content_preview: Some(r#"{"status":"generated","progress":0}"#.to_string()),
+            is_text_artifact: true,
+            is_image_artifact: false,
+            download_url: format!("/api/evidence/{}/{}/content", feature.id, wp.id),
+            test_passed: None,
+            tests_passed_count: 0,
+            tests_failed_count: 0,
+            test_summary: None,
+            commit_count: 0,
+            pr_count: 0,
+            ci_links: vec![],
+            git_commits: vec![],
+            pr_links: vec![],
         });
     }
 

--- a/crates/agileplus-dashboard/src/templates.rs
+++ b/crates/agileplus-dashboard/src/templates.rs
@@ -129,11 +129,62 @@ pub struct EvidenceBundleView {
     pub created_at: String,
     pub artifact_ext: String,
     pub status: String,
-    // New fields for evidence viewer/gallery
+    // Preview / download
     pub content_preview: Option<String>,
     pub is_text_artifact: bool,
     pub is_image_artifact: bool,
     pub download_url: String,
+    // Evidence gallery enrichment fields
+    pub test_passed: Option<bool>,
+    pub tests_passed_count: u32,
+    pub tests_failed_count: u32,
+    pub test_summary: Option<String>,
+    pub commit_count: usize,
+    pub pr_count: usize,
+    pub ci_links: Vec<CiLinkView>,
+    pub git_commits: Vec<GitCommitView>,
+    pub pr_links: Vec<PrLinkView>,
+}
+
+/// A single CI run link for the evidence gallery.
+#[derive(Debug, Clone)]
+pub struct CiLinkView {
+    pub id: i64,
+    pub title: String,
+    pub status: String,
+    pub conclusion: String,
+    pub url: String,
+    pub created_at: String,
+}
+
+/// A git commit entry for the evidence gallery.
+#[derive(Debug, Clone)]
+pub struct GitCommitView {
+    pub short_hash: String,
+    pub subject: String,
+    pub date: String,
+    pub author: String,
+    pub url: String,
+}
+
+/// A PR link for the evidence gallery.
+#[derive(Debug, Clone)]
+pub struct PrLinkView {
+    pub number: u64,
+    pub title: String,
+    pub url: String,
+    pub state: String,
+    pub head_ref: String,
+    pub created_at: String,
+}
+
+/// JSON body returned from `POST /api/features/{id}/evidence/generate`.
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct GenerateEvidenceResponse {
+    pub feature_id: String,
+    pub bundle_path: String,
+    pub status: String,
+    pub message: String,
 }
 
 #[derive(Debug, Clone)]

--- a/scripts/generate-evidence.sh
+++ b/scripts/generate-evidence.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# generate-evidence.sh — Generates an evidence bundle for a feature.
+# Usage: ./scripts/generate-evidence.sh <feature-id>
+# Outputs: .agileplus/evidence/<feature-id>/bundle.json
+#
+# Requires: cargo, git, gh (GitHub CLI), jq
+
+set -euo pipefail
+
+FEATURE_ID="${1:-}"
+if [[ -z "$FEATURE_ID" ]]; then
+  echo "Usage: $0 <feature-id>" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+EVIDENCE_DIR="$REPO_ROOT/.agileplus/evidence/$FEATURE_ID"
+TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+mkdir -p "$EVIDENCE_DIR"
+
+echo "[evidence] Generating bundle for feature: $FEATURE_ID"
+
+# ── 1. Run cargo tests ─────────────────────────────────────────────────────
+echo "[evidence] Running cargo test..."
+TEST_RESULTS_FILE="$EVIDENCE_DIR/test-results.txt"
+TEST_PASSED=false
+TEST_SUMMARY=""
+
+if cargo test 2>&1 | tee "$TEST_RESULTS_FILE"; then
+  TEST_PASSED=true
+  TEST_SUMMARY="All tests passed"
+else
+  TEST_SUMMARY="Some tests failed — see test-results.txt"
+fi
+
+# Count pass/fail
+TESTS_PASSED_COUNT=$(grep -c '^test .* \.\.\. ok$' "$TEST_RESULTS_FILE" 2>/dev/null || echo "0")
+TESTS_FAILED_COUNT=$(grep -c '^test .* \.\.\. FAILED$' "$TEST_RESULTS_FILE" 2>/dev/null || echo "0")
+
+# ── 2. Collect git log ─────────────────────────────────────────────────────
+echo "[evidence] Collecting git log..."
+GIT_LOG_FILE="$EVIDENCE_DIR/git-log.txt"
+GIT_REMOTE_URL="$(git -C "$REPO_ROOT" remote get-url origin 2>/dev/null || echo "")"
+
+# Extract org/repo from remote URL for link building
+GH_REPO=""
+if [[ "$GIT_REMOTE_URL" =~ github\.com[:/]([^/]+/[^/.]+)(\.git)?$ ]]; then
+  GH_REPO="${BASH_REMATCH[1]}"
+fi
+
+git -C "$REPO_ROOT" log --oneline -10 2>/dev/null | tee "$GIT_LOG_FILE" || true
+
+# Build structured git entries
+GIT_ENTRIES="[]"
+if command -v jq &>/dev/null; then
+  GIT_ENTRIES=$(git -C "$REPO_ROOT" log --format="%H|%s|%ai|%an" -10 2>/dev/null | \
+    jq -R -s 'split("\n") | map(select(length > 0)) | map(
+      split("|") |
+      {
+        hash: .[0],
+        short_hash: (.[0] // "" | .[0:7]),
+        subject: .[1],
+        date: .[2],
+        author: .[3],
+        url: (if env.GH_REPO != "" then "https://github.com/\(env.GH_REPO)/commit/\(.[0])" else "" end)
+      }
+    )' GH_REPO="${GH_REPO}" 2>/dev/null || echo "[]")
+fi
+
+# ── 3. Collect open PRs ────────────────────────────────────────────────────
+echo "[evidence] Collecting PRs..."
+PR_FILE="$EVIDENCE_DIR/prs.json"
+PR_ENTRIES="[]"
+
+if command -v gh &>/dev/null && [[ -n "$GH_REPO" ]]; then
+  # Look for PRs mentioning the feature ID or on feature branches
+  PR_ENTRIES=$(gh pr list \
+    --repo "$GH_REPO" \
+    --json number,title,url,state,createdAt,headRefName \
+    --limit 20 2>/dev/null | \
+    jq --arg fid "$FEATURE_ID" '[.[] | select(
+      (.title | ascii_downcase | contains($fid | ascii_downcase)) or
+      (.headRefName | ascii_downcase | contains($fid | ascii_downcase))
+    )]' 2>/dev/null || echo "[]")
+  echo "$PR_ENTRIES" > "$PR_FILE"
+else
+  echo "[]" > "$PR_FILE"
+fi
+
+# ── 4. Collect CI links ────────────────────────────────────────────────────
+echo "[evidence] Collecting CI run links..."
+CI_LINKS="[]"
+if command -v gh &>/dev/null && [[ -n "$GH_REPO" ]]; then
+  CI_LINKS=$(gh run list \
+    --repo "$GH_REPO" \
+    --limit 5 \
+    --json databaseId,displayTitle,status,conclusion,url,createdAt 2>/dev/null | \
+    jq '[.[] | {
+      id: .databaseId,
+      title: .displayTitle,
+      status: .status,
+      conclusion: (.conclusion // "pending"),
+      url: .url,
+      created_at: .createdAt
+    }]' 2>/dev/null || echo "[]")
+fi
+
+# ── 5. Write bundle.json ───────────────────────────────────────────────────
+echo "[evidence] Writing bundle.json..."
+BUNDLE_FILE="$EVIDENCE_DIR/bundle.json"
+
+# Read test output (limit to 4KB for bundle)
+TEST_OUTPUT_RAW=""
+if [[ -f "$TEST_RESULTS_FILE" ]]; then
+  TEST_OUTPUT_RAW=$(head -c 4096 "$TEST_RESULTS_FILE" | sed 's/"/\\"/g' | tr '\n' '\\' | sed 's/\\/\\n/g' | sed 's/\\n$//') || true
+fi
+
+cat > "$BUNDLE_FILE" <<EOF
+{
+  "feature_id": "$FEATURE_ID",
+  "timestamp": "$TIMESTAMP",
+  "test_results": {
+    "passed": $TEST_PASSED,
+    "passed_count": $TESTS_PASSED_COUNT,
+    "failed_count": $TESTS_FAILED_COUNT,
+    "summary": "$TEST_SUMMARY",
+    "output_snippet": "$TEST_OUTPUT_RAW"
+  },
+  "git_log": $GIT_ENTRIES,
+  "prs": $PR_ENTRIES,
+  "ci_links": $CI_LINKS,
+  "repo": "$GH_REPO"
+}
+EOF
+
+echo "[evidence] Bundle written to: $BUNDLE_FILE"
+echo "[evidence] Done."

--- a/templates/partials/feature-evidence.html
+++ b/templates/partials/feature-evidence.html
@@ -1,166 +1,307 @@
 <div class="space-y-4">
   {% for bundle in evidence_bundles %}
     <article class="rounded border border-zinc-700 bg-zinc-900 p-4"
-             x-data="{ showPreview: false }"
+             x-data="{ showPreview: false, showCommits: false, showPRs: false, showCI: false }"
              id="evidence-{{ bundle.id }}">
-      <div class="flex items-start justify-between gap-4">
+
+      {# ── Header ──────────────────────────────────────────────────────── #}
+      <div class="flex items-start justify-between gap-4 flex-wrap">
         <div>
           <div class="text-xs uppercase tracking-wide text-zinc-500">Evidence bundle</div>
           <h3 class="text-base font-semibold text-zinc-100 mt-1">{{ bundle.wp_title }}</h3>
         </div>
-        <span class="text-xs rounded border border-zinc-600 px-2 py-0.5 text-zinc-300">{{ bundle.status }}</span>
-      </div>
-      
-      <div class="mt-3 grid md:grid-cols-2 gap-3 text-sm">
-        <div class="text-zinc-400">
-          <div class="text-xs uppercase tracking-wide text-zinc-500">Artifact</div>
-          <div class="font-mono break-all mt-1 text-xs text-zinc-300">{{ bundle.artifact_path }}</div>
+        <div class="flex items-center gap-2 flex-wrap">
+          {% match bundle.test_passed %}
+            {% when Some with (true) %}
+              <span class="inline-flex items-center gap-1 rounded border border-emerald-600 bg-emerald-900/40 px-2 py-0.5 text-xs text-emerald-300">
+                <svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/></svg>
+                Tests passed
+              </span>
+            {% when Some with (false) %}
+              <span class="inline-flex items-center gap-1 rounded border border-red-600 bg-red-900/40 px-2 py-0.5 text-xs text-red-300">
+                <svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
+                Tests failed
+              </span>
+            {% when None %}
+          {% endmatch %}
+          <span class="text-xs rounded border border-zinc-600 px-2 py-0.5 text-zinc-300">{{ bundle.status }}</span>
         </div>
-        <div class="text-zinc-400">
+      </div>
+
+      {# ── Metadata grid ────────────────────────────────────────────────── #}
+      <div class="mt-3 grid sm:grid-cols-2 md:grid-cols-4 gap-3 text-sm">
+        <div>
+          <div class="text-xs uppercase tracking-wide text-zinc-500">FR ID</div>
+          <div class="mt-1 font-mono text-zinc-300 text-xs">{{ bundle.fr_id }}</div>
+        </div>
+        <div>
           <div class="text-xs uppercase tracking-wide text-zinc-500">Type</div>
-          <div class="mt-1">{{ bundle.evidence_type }} ({{ bundle.artifact_ext }})</div>
+          <div class="mt-1 text-zinc-300">{{ bundle.evidence_type }}</div>
         </div>
-        <div class="text-zinc-400">
-          <div class="text-xs uppercase tracking-wide text-zinc-500">Feature requirement</div>
-          <div class="mt-1 font-mono">{{ bundle.fr_id }}</div>
+        <div>
+          <div class="text-xs uppercase tracking-wide text-zinc-500">Tests</div>
+          <div class="mt-1 text-zinc-300">
+            <span class="text-emerald-400">{{ bundle.tests_passed_count }} pass</span>
+            {% if bundle.tests_failed_count > 0 %}
+              · <span class="text-red-400">{{ bundle.tests_failed_count }} fail</span>
+            {% endif %}
+          </div>
         </div>
-        <div class="text-zinc-400">
+        <div>
           <div class="text-xs uppercase tracking-wide text-zinc-500">Created</div>
-          <div class="mt-1">{{ bundle.created_at }}</div>
+          <div class="mt-1 text-zinc-400 text-xs">{{ bundle.created_at }}</div>
         </div>
       </div>
-      
-      <!-- Action buttons -->
-      <div class="flex gap-2 mt-4 flex-wrap">
-        {% if bundle.is_text_artifact || bundle.is_image_artifact %}
-          <button @click="showPreview = !showPreview"
-                  class="px-3 py-1 text-xs rounded bg-zinc-800 hover:bg-zinc-700 text-zinc-200 transition-colors">
-            <span x-show="!showPreview">View Preview</span>
-            <span x-show="showPreview">Hide Preview</span>
+
+      {# ── Action strip ─────────────────────────────────────────────────── #}
+      <div class="mt-3 flex gap-2 flex-wrap text-xs">
+        {% if bundle.commit_count > 0 %}
+          <button @click="showCommits = !showCommits"
+                  class="inline-flex items-center gap-1 rounded bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 px-2 py-1 text-zinc-300 transition-colors">
+            <svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+              <circle cx="12" cy="12" r="3"/><path d="M2 12h7m6 0h7"/>
+            </svg>
+            {{ bundle.commit_count }} commits
           </button>
         {% endif %}
-        
+        {% if bundle.pr_count > 0 %}
+          <button @click="showPRs = !showPRs"
+                  class="inline-flex items-center gap-1 rounded bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 px-2 py-1 text-zinc-300 transition-colors">
+            <svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+              <path stroke-linecap="round" d="M6 3v12m0 0a3 3 0 103 3m-3-3a3 3 0 013 3m6-15v3m0-3a3 3 0 110 6 3 3 0 010-6zM9 6h6"/>
+            </svg>
+            {{ bundle.pr_count }} PRs
+          </button>
+        {% endif %}
+        {% let ci_count = bundle.ci_links.len() %}
+        {% if ci_count > 0 %}
+          <button @click="showCI = !showCI"
+                  class="inline-flex items-center gap-1 rounded bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 px-2 py-1 text-zinc-300 transition-colors">
+            <svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+              <rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8m-4-4v4"/>
+            </svg>
+            {{ ci_count }} CI runs
+          </button>
+        {% endif %}
+        {% if bundle.is_text_artifact || bundle.is_image_artifact %}
+          <button @click="showPreview = !showPreview"
+                  class="inline-flex items-center gap-1 rounded bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 px-2 py-1 text-zinc-300 transition-colors">
+            <svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+              <path d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/><path d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/>
+            </svg>
+            <span x-show="!showPreview">View preview</span>
+            <span x-show="showPreview" style="display:none">Hide preview</span>
+          </button>
+        {% endif %}
         <a href="{{ bundle.download_url }}"
-           class="px-3 py-1 text-xs rounded bg-blue-800 hover:bg-blue-700 text-blue-100 transition-colors inline-block">
+           class="inline-flex items-center gap-1 rounded bg-blue-900/40 hover:bg-blue-800/50 border border-blue-700 px-2 py-1 transition-colors text-blue-300">
+          <svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+            <path stroke-linecap="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"/>
+          </svg>
           Download
         </a>
       </div>
-      
-      <!-- Inline preview (text artifacts) -->
+
+      {# ── Git commit list ────────────────────────────────────────────────── #}
+      {% if bundle.commit_count > 0 %}
+        <div x-show="showCommits" x-transition
+             class="mt-3 rounded bg-zinc-800 border border-zinc-700 overflow-hidden"
+             style="display:none">
+          <div class="px-3 py-2 text-xs uppercase tracking-wide text-zinc-500 border-b border-zinc-700 bg-zinc-800/80">
+            Git commits
+          </div>
+          <ul class="divide-y divide-zinc-700/60">
+            {% for commit in bundle.git_commits %}
+              <li class="px-3 py-2 flex items-start gap-3 text-xs hover:bg-zinc-700/30 transition-colors">
+                <span class="font-mono text-zinc-400 shrink-0 w-14">
+                  {% if commit.url.is_empty() %}
+                    {{ commit.short_hash }}
+                  {% else %}
+                    <a href="{{ commit.url }}" target="_blank" rel="noopener noreferrer"
+                       class="text-blue-400 hover:underline">{{ commit.short_hash }}</a>
+                  {% endif %}
+                </span>
+                <span class="text-zinc-300 flex-1 min-w-0 break-words" title="{{ commit.subject }}">
+                  {{ commit.subject }}
+                </span>
+                <span class="text-zinc-500 shrink-0">{{ commit.author }}</span>
+              </li>
+            {% endfor %}
+          </ul>
+        </div>
+      {% endif %}
+
+      {# ── PR links ──────────────────────────────────────────────────────── #}
+      {% if bundle.pr_count > 0 %}
+        <div x-show="showPRs" x-transition
+             class="mt-3 rounded bg-zinc-800 border border-zinc-700 overflow-hidden"
+             style="display:none">
+          <div class="px-3 py-2 text-xs uppercase tracking-wide text-zinc-500 border-b border-zinc-700 bg-zinc-800/80">
+            Pull requests
+          </div>
+          <ul class="divide-y divide-zinc-700/60">
+            {% for pr in bundle.pr_links %}
+              <li class="px-3 py-2 flex items-center gap-3 text-xs hover:bg-zinc-700/30 transition-colors">
+                <span class="text-zinc-500 shrink-0 font-mono">#{{ pr.number }}</span>
+                <a href="{{ pr.url }}" target="_blank" rel="noopener noreferrer"
+                   class="flex-1 min-w-0 break-words text-blue-400 hover:underline" title="{{ pr.title }}">
+                  {{ pr.title }}
+                </a>
+                <span class="shrink-0 rounded border px-1.5 py-0.5
+                  {% if pr.state == "open" %}border-emerald-600 text-emerald-400{% else %}border-zinc-600 text-zinc-400{% endif %}">
+                  {{ pr.state }}
+                </span>
+              </li>
+            {% endfor %}
+          </ul>
+        </div>
+      {% endif %}
+
+      {# ── CI run links ──────────────────────────────────────────────────── #}
+      {% let ci_links_len = bundle.ci_links.len() %}
+      {% if ci_links_len > 0 %}
+        <div x-show="showCI" x-transition
+             class="mt-3 rounded bg-zinc-800 border border-zinc-700 overflow-hidden"
+             style="display:none">
+          <div class="px-3 py-2 text-xs uppercase tracking-wide text-zinc-500 border-b border-zinc-700 bg-zinc-800/80">
+            CI runs
+          </div>
+          <ul class="divide-y divide-zinc-700/60">
+            {% for run in bundle.ci_links %}
+              <li class="px-3 py-2 flex items-center gap-3 text-xs hover:bg-zinc-700/30 transition-colors">
+                <span class="shrink-0 rounded border px-1.5 py-0.5
+                  {% if run.conclusion == "success" %}border-emerald-600 text-emerald-400{% else if run.conclusion == "failure" %}border-red-600 text-red-400{% else %}border-yellow-600 text-yellow-400{% endif %}">
+                  {{ run.conclusion }}
+                </span>
+                <a href="{{ run.url }}" target="_blank" rel="noopener noreferrer"
+                   class="flex-1 min-w-0 break-words text-blue-400 hover:underline" title="{{ run.title }}">
+                  {{ run.title }}
+                </a>
+                <span class="text-zinc-500 shrink-0">{{ run.created_at }}</span>
+              </li>
+            {% endfor %}
+          </ul>
+        </div>
+      {% endif %}
+
+      {# ── Text artifact preview ──────────────────────────────────────────── #}
       {% if bundle.is_text_artifact %}
-        <div x-show="showPreview"
-             class="mt-4 p-3 rounded bg-zinc-800 border border-zinc-700"
-             x-transition>
-          <div class="max-h-48 overflow-y-auto">
+        <div x-show="showPreview" x-transition
+             class="mt-3 p-3 rounded bg-zinc-800 border border-zinc-700"
+             style="display:none">
+          <div class="max-h-56 overflow-y-auto">
             {% match bundle.content_preview %}
               {% when Some with (preview) %}
                 <pre class="text-xs font-mono text-zinc-300 whitespace-pre-wrap break-words">{{ preview }}</pre>
               {% else %}
-                <p class="text-xs text-zinc-400">No preview available</p>
-              {% endmatch %}
+                <p class="text-xs text-zinc-400">No preview available.</p>
+            {% endmatch %}
           </div>
         </div>
       {% endif %}
-      
-      <!-- Image gallery lightbox -->
+
+      {# ── Image artifact preview ─────────────────────────────────────────── #}
       {% if bundle.is_image_artifact %}
-        <div x-show="showPreview"
-             class="mt-4 p-3 rounded bg-zinc-800 border border-zinc-700"
-             x-transition>
+        <div x-show="showPreview" x-transition
+             class="mt-3 p-3 rounded bg-zinc-800 border border-zinc-700"
+             style="display:none">
           <div class="relative">
-            <img src="{{ bundle.artifact_path }}" 
-                 alt="Evidence artifact" 
-                 class="w-full h-auto rounded border border-zinc-600 cursor-pointer"
+            <img src="{{ bundle.artifact_path }}"
+                 alt="Evidence artifact"
+                 class="w-full h-auto rounded border border-zinc-600 cursor-pointer hover:opacity-90 transition-opacity"
                  @click="showLightbox('{{ bundle.id }}')"
                  loading="lazy">
-            <div class="text-xs text-zinc-400 mt-2">Click to expand</div>
+            <div class="text-xs text-zinc-400 mt-2">Click image to expand in lightbox</div>
           </div>
         </div>
       {% endif %}
+
     </article>
   {% else %}
-    <p class="text-zinc-500 text-sm">No evidence bundles available.</p>
+    <div class="rounded border border-dashed border-zinc-700 bg-zinc-900/50 p-8 text-center">
+      <p class="text-zinc-500 text-sm mb-3">No evidence bundles generated yet.</p>
+      <button hx-post="evidence/generate"
+              hx-swap="none"
+              hx-indicator="#evidence-spinner"
+              class="px-4 py-2 rounded bg-blue-800 hover:bg-blue-700 text-blue-100 text-sm transition-colors">
+        Generate evidence bundle
+      </button>
+      <span id="evidence-spinner" class="htmx-indicator ml-2 text-xs text-zinc-400">Running&hellip;</span>
+    </div>
   {% endfor %}
 </div>
 
-<!-- Lightbox modal for image viewing -->
+{# ── Lightbox modal ────────────────────────────────────────────────────────── #}
 <div id="evidence-lightbox"
-     class="hidden fixed inset-0 bg-black/80 z-50 flex items-center justify-center">
-  <div class="relative max-w-4xl max-h-[90vh] flex items-center justify-center">
-    <button onclick="document.getElementById('evidence-lightbox').classList.add('hidden')"
-            class="absolute top-4 right-4 text-white text-2xl hover:text-gray-300 z-10">
-      ✕
+     class="hidden fixed inset-0 bg-black/80 z-50 flex items-center justify-center"
+     role="dialog" aria-modal="true" aria-label="Evidence image viewer">
+  <div class="relative max-w-4xl max-h-[90vh] flex items-center justify-center px-12">
+    <button onclick="hideLightbox()"
+            aria-label="Close lightbox"
+            class="absolute -top-10 right-0 text-white font-semibold hover:text-gray-300 z-10 px-3 py-1 rounded bg-zinc-800 border border-zinc-600 text-sm">
+      ✕ close
     </button>
-    
-    <img id="lightbox-image" 
-         src="" 
-         alt="Evidence artifact" 
-         class="max-w-full max-h-[85vh] object-contain rounded">
-    
-    <!-- Navigation arrows -->
     <button onclick="previousImage()"
-            class="absolute left-4 text-white text-2xl hover:text-gray-300 z-10">
+            aria-label="Previous image"
+            class="absolute left-0 text-white text-2xl hover:text-gray-300 z-10 bg-zinc-800/80 border border-zinc-600 rounded-full w-10 h-10 flex items-center justify-center">
       ‹
     </button>
+    <img id="lightbox-image" src="" alt="Evidence artifact"
+         class="max-w-full max-h-[85vh] object-contain rounded shadow-2xl">
     <button onclick="nextImage()"
-            class="absolute right-4 text-white text-2xl hover:text-gray-300 z-10">
+            aria-label="Next image"
+            class="absolute right-0 text-white text-2xl hover:text-gray-300 z-10 bg-zinc-800/80 border border-zinc-600 rounded-full w-10 h-10 flex items-center justify-center">
       ›
     </button>
   </div>
 </div>
 
 <script>
-let _galleryImages = [];
-let _currentImageIndex = 0;
+(function () {
+  let _images = [];
+  let _idx = 0;
 
-function showLightbox(bundleId) {
-  const lightbox = document.getElementById('evidence-lightbox');
-  const elem = document.getElementById('evidence-' + bundleId);
-  if (elem) {
-    const imgs = elem.querySelectorAll('img');
-    const lightboxImg = document.getElementById('lightbox-image');
-    if (imgs.length > 0) {
-      _galleryImages = Array.from(imgs).map(i => i.src);
-      _currentImageIndex = 0;
-      lightboxImg.src = _galleryImages[0];
-      lightbox.classList.remove('hidden');
-    }
-  }
-}
+  window.showLightbox = function (bundleId) {
+    const lb = document.getElementById('evidence-lightbox');
+    const card = document.getElementById('evidence-' + bundleId);
+    if (!card) return;
+    const imgs = card.querySelectorAll('img');
+    if (!imgs.length) return;
+    _images = Array.from(imgs).map(i => i.src);
+    _idx = 0;
+    document.getElementById('lightbox-image').src = _images[0];
+    lb.classList.remove('hidden');
+    lb.focus();
+  };
 
-function hideLightbox() {
-  const lightbox = document.getElementById('evidence-lightbox');
-  lightbox.classList.add('hidden');
-  _galleryImages = [];
-  _currentImageIndex = 0;
-}
+  window.hideLightbox = function () {
+    document.getElementById('evidence-lightbox').classList.add('hidden');
+    _images = [];
+    _idx = 0;
+  };
 
-function previousImage() {
-  if (_galleryImages.length > 0) {
-    _currentImageIndex = (_currentImageIndex - 1 + _galleryImages.length) % _galleryImages.length;
-    document.getElementById('lightbox-image').src = _galleryImages[_currentImageIndex];
-  }
-}
+  window.previousImage = function () {
+    if (!_images.length) return;
+    _idx = (_idx - 1 + _images.length) % _images.length;
+    document.getElementById('lightbox-image').src = _images[_idx];
+  };
 
-function nextImage() {
-  if (_galleryImages.length > 0) {
-    _currentImageIndex = (_currentImageIndex + 1) % _galleryImages.length;
-    document.getElementById('lightbox-image').src = _galleryImages[_currentImageIndex];
-  }
-}
+  window.nextImage = function () {
+    if (!_images.length) return;
+    _idx = (_idx + 1) % _images.length;
+    document.getElementById('lightbox-image').src = _images[_idx];
+  };
 
-document.getElementById('evidence-lightbox')?.addEventListener('click', (e) => {
-  if (e.target.id === 'evidence-lightbox') {
-    hideLightbox();
-  }
-});
+  document.getElementById('evidence-lightbox')?.addEventListener('click', function (e) {
+    if (e.target.id === 'evidence-lightbox') window.hideLightbox();
+  });
 
-document.addEventListener('keydown', (e) => {
-  if (e.key === 'Escape') {
-    const lightbox = document.getElementById('evidence-lightbox');
-    if (lightbox && !lightbox.classList.contains('hidden')) {
-      hideLightbox();
-    }
-  }
-});
+  document.addEventListener('keydown', function (e) {
+    const lb = document.getElementById('evidence-lightbox');
+    if (!lb || lb.classList.contains('hidden')) return;
+    if (e.key === 'Escape') window.hideLightbox();
+    if (e.key === 'ArrowLeft') window.previousImage();
+    if (e.key === 'ArrowRight') window.nextImage();
+  });
+}());
 </script>


### PR DESCRIPTION
## Summary

- **Evidence generator script** (`scripts/generate-evidence.sh`): runs `cargo test`, collects git log, queries open PRs and CI runs via `gh` CLI, and writes a structured `bundle.json` to `.agileplus/evidence/<feature-id>/`
- **New Rust routes**: `GET /api/features/{id}/evidence` returns the evidence gallery partial; `POST /api/features/{id}/evidence/generate` triggers the script asynchronously
- **Enriched data model**: `EvidenceBundleView` now carries test pass/fail counts, `GitCommitView`, `PrLinkView`, and `CiLinkView` lists — all populated from real disk bundles
- **Overhauled template** (`templates/partials/feature-evidence.html`): dark-theme gallery cards with expandable commit list, PR links, CI run links, test pass/fail badge, image lightbox with keyboard nav, and an empty-state "Generate evidence bundle" CTA
- **CI workflow** (`.github/workflows/evidence-capture.yml`): triggers on `feat/**`, `fix/**`, `chore/**` pushes; captures `cargo test` output and uploads as a GitHub Actions artifact retained for 90 days

## Test plan

- [ ] Run `cargo check -p agileplus-dashboard` — must finish with 0 errors (verified locally)
- [ ] Run `./scripts/generate-evidence.sh <feature-id>` in repo root — verify `.agileplus/evidence/<feature-id>/bundle.json` is written
- [ ] Start dashboard server, navigate to a feature detail page — evidence gallery section should render
- [ ] `POST /api/features/{id}/evidence/generate` should return `{"status":"started",...}` and background job should write bundle
- [ ] `GET /api/features/{id}/evidence` on a feature with a bundle on disk should return populated gallery with commit/PR/CI counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)