### PR TITLE
fix: implement missing StoragePort methods in test MockStorage impls

### DIFF
--- a/crates/agileplus-api/tests/api_integration.rs
+++ b/crates/agileplus-api/tests/api_integration.rs
@@ -474,6 +474,20 @@ impl StoragePort for MockStorage {
     ) -> Result<(), DomainError> {
         Ok(())
     }
+
+    async fn create_project(
+        &self,
+        _project: &agileplus_domain::domain::project::Project,
+    ) -> Result<i64, DomainError> {
+        Ok(1)
+    }
+
+    async fn get_project_by_slug(
+        &self,
+        _slug: &str,
+    ) -> Result<Option<agileplus_domain::domain::project::Project>, DomainError> {
+        Ok(None)
+    }
 }
 
 // ── ContentStoragePort for MockStorage ───────────────────────────────────────

--- a/crates/agileplus-api/tests/api_integration/support/storage.rs
+++ b/crates/agileplus-api/tests/api_integration/support/storage.rs
@@ -1,6 +1,7 @@
 use std::sync::{Arc, Mutex};
 
 use agileplus_domain::domain::audit::{AuditEntry, hash_entry};
+use agileplus_domain::domain::project::Project;
 use agileplus_domain::domain::backlog::BacklogItem;
 use agileplus_domain::domain::cycle::{Cycle, CycleFeature};
 use agileplus_domain::domain::feature::Feature;
@@ -21,6 +22,7 @@ pub(crate) struct MockStorage {
     pub(crate) cycle_features: Arc<Mutex<Vec<CycleFeature>>>,
     pub(crate) governance: Arc<Mutex<Vec<GovernanceContract>>>,
     pub(crate) audit: Arc<Mutex<Vec<AuditEntry>>>,
+    pub(crate) projects: Arc<Mutex<Vec<Project>>>,
 }
 
 impl MockStorage {

--- a/crates/agileplus-api/tests/api_integration/support/storage_port_impl/storage_impl.rs
+++ b/crates/agileplus-api/tests/api_integration/support/storage_port_impl/storage_impl.rs
@@ -5,6 +5,7 @@ use agileplus_domain::domain::cycle::{Cycle, CycleFeature, CycleState, CycleWith
 use agileplus_domain::domain::governance::{Evidence, GovernanceContract, PolicyRule};
 use agileplus_domain::domain::metric::Metric;
 use agileplus_domain::domain::module::{Module, ModuleFeatureTag, ModuleWithFeatures};
+use agileplus_domain::domain::project::Project;
 use agileplus_domain::domain::sync_mapping::SyncMapping;
 use agileplus_domain::error::DomainError;
 use agileplus_domain::ports::storage::StoragePort;
@@ -272,4 +273,31 @@ impl StoragePort for MockStorage {
     ) -> impl Future<Output = Result<(), DomainError>> + Send {
         sync_mapping::delete_sync_mapping(self, entity_type, entity_id)
     }
+
+    fn create_project(
+        &self,
+        project: &Project,
+    ) -> impl Future<Output = Result<i64, DomainError>> + Send {
+        let mut projects = self.projects.lock().expect("projects lock poisoned");
+        let id = (projects.len() as i64) + 1;
+        let mut p = project.clone();
+        p.id = id;
+        projects.push(p);
+        async move { Ok(id) }
+    }
+
+    fn get_project_by_slug(
+        &self,
+        slug: &str,
+    ) -> impl Future<Output = Result<Option<Project>, DomainError>> + Send {
+        let found = self
+            .projects
+            .lock()
+            .expect("projects lock poisoned")
+            .iter()
+            .find(|p| p.slug == slug)
+            .cloned();
+        async move { Ok(found) }
+    }
+
 }


### PR DESCRIPTION
## Summary

- Adds `create_project` and `get_project_by_slug` to the `StoragePort` impl on `MockStorage` in `crates/agileplus-api/tests/api_integration.rs`
- Adds the same methods to the modular `MockStorage` impl in `crates/agileplus-api/tests/api_integration/support/storage_port_impl/storage_impl.rs`
- Adds a `projects: Arc<Mutex<Vec<Project>>>` field to the `MockStorage` struct in `support/storage.rs` and imports `domain::project::Project`

**Before:** `cargo check --workspace --all-targets` failed with `E0046: not all trait items implemented, missing: create_project, get_project_by_slug`

**After:** `cargo check --workspace --all-targets` completes with zero errors and zero warnings.

## Test plan

- [x] `cargo check --workspace --all-targets` passes cleanly
- [ ] CI (GitHub Actions) — billing-blocked, exempt per repo policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)