### PR TITLE
fix(ci): fix VitePress Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,8 +29,6 @@ jobs:
 
       - name: Setup Pages
         uses: actions/configure-pages@v5
-        with:
-          enablement: true
 
       - name: Install dependencies
         working-directory: docs


### PR DESCRIPTION
## Summary
- Remove deprecated `enablement: true` from `configure-pages` step (this option was removed in v5)
- All other settings are correct: `working-directory: docs`, correct artifact path, proper permissions

## Test plan
- [ ] Merge and verify GitHub Actions Pages workflow runs successfully on push to main
- [ ] Verify `https://kooshapari.github.io/AgilePlus/` is accessible after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)