### PR TITLE
ci(governance): restore repo-tracked governance baseline

### DIFF
--- a/.github/RULESET_BASELINE.md
+++ b/.github/RULESET_BASELINE.md
@@ -1,0 +1,35 @@
+# AgilePlus Ruleset Baseline
+
+This repository already has meaningful CI and policy workflows. GitHub rulesets
+should require the following on protected branches:
+
+- pull request required before merge
+- no force push
+- no branch deletion
+- linear history
+- CODEOWNERS review
+- conversation resolution before merge
+- required checks:
+  - `policy-gate`
+  - `pr-governance-gate`
+  - `verify`
+  - `semgrep`
+  - `secrets`
+  - `lint-rust`
+  - `license-check`
+  - `snyk-test` when Snyk is configured
+
+## Branch Policy
+
+- `stack/*`, `layer/*`, `release/*`, and similar integration branches are valid
+  stacked PR lanes.
+- `fix/*` must not target `main` or `master` unless the PR carries a documented
+  exception label such as `layered-pr-exception`.
+- Merge commits in PR branches are disallowed.
+- Local `--no-verify` usage is not accepted as a reason to bypass server-side
+  workflow checks.
+
+## Exception Policy
+
+- Only documented billing or quota failures may be excluded from required checks.
+- Review threads and blocking comments must be resolved before merge.

--- a/.github/workflows/pr-governance-gate.yml
+++ b/.github/workflows/pr-governance-gate.yml
@@ -1,0 +1,169 @@
+name: pr-governance-gate
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, edited, ready_for_review, labeled, unlabeled]
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+
+permissions:
+  contents: read
+  checks: read
+  pull-requests: read
+  statuses: read
+
+jobs:
+  pr-governance-gate:
+    name: pr-governance-gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Evaluate PR governance policy
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber =
+              context.payload.pull_request?.number ?? context.payload.review?.pull_request?.number;
+            if (!prNumber) {
+              core.setFailed("No pull request number was provided.");
+              return;
+            }
+
+            const query = `
+              query($owner: String!, $repo: String!, $number: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $number) {
+                    number
+                    isDraft
+                    body
+                    headRefName
+                    baseRefName
+                    reviewDecision
+                    labels(first: 50) {
+                      nodes { name }
+                    }
+                    reviewThreads(first: 100) {
+                      nodes { isResolved }
+                    }
+                    commits(last: 1) {
+                      nodes {
+                        commit {
+                          statusCheckRollup {
+                            contexts(first: 100) {
+                              nodes {
+                                __typename
+                                ... on CheckRun {
+                                  name
+                                  status
+                                  conclusion
+                                }
+                                ... on StatusContext {
+                                  context
+                                  state
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            `;
+
+            const result = await github.graphql(query, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              number: prNumber,
+            });
+
+            const current = result.repository.pullRequest;
+            const failures = [];
+            const body = current.body || "";
+            const labels = new Set((current.labels.nodes || []).map((node) => node.name));
+            const unresolvedThreads =
+              (current.reviewThreads.nodes || []).filter((node) => !node.isResolved).length;
+            const billingException = labels.has("ci-billing-exception");
+            const headRef = current.headRefName || "";
+            const baseRef = current.baseRefName || "";
+
+            for (const section of [
+              "## Summary",
+              "## Stack Topology",
+              "## Validation",
+              "## Governance",
+              "## CI Exception",
+            ]) {
+              if (!body.includes(section)) {
+                failures.push(`PR body is missing required section: ${section}`);
+              }
+            }
+
+            if (current.isDraft) {
+              failures.push("PR must be ready for review before governance gate can pass.");
+            }
+
+            if (current.reviewDecision === "CHANGES_REQUESTED") {
+              failures.push("There is an outstanding 'changes requested' review.");
+            }
+
+            if (unresolvedThreads > 0) {
+              failures.push(`${unresolvedThreads} unresolved review thread(s) remain.`);
+            }
+
+            const layeredPrefix = /^(stack|layer|feat|fix|docs|refactor|ci|chore|preview|release)\//;
+            if (!layeredPrefix.test(headRef)) {
+              failures.push(`Head branch '${headRef}' does not use an approved layered prefix.`);
+            }
+            if (/^(fix|feat|docs|refactor|ci|chore)\//.test(headRef) &&
+                ["main", "master"].includes(baseRef) &&
+                !labels.has("layered-pr-exception")) {
+              failures.push(
+                `Branch '${headRef}' targets '${baseRef}' directly without the layered-pr-exception label.`
+              );
+            }
+
+            const contexts =
+              current.commits.nodes?.[0]?.commit?.statusCheckRollup?.contexts?.nodes || [];
+            const allowedConclusions = new Set(["SUCCESS", "SKIPPED", "NEUTRAL"]);
+            const ignoredChecks = [/^pr-governance-gate$/i];
+
+            for (const contextNode of contexts) {
+              const name =
+                contextNode.__typename === "CheckRun"
+                  ? contextNode.name
+                  : contextNode.context;
+              if (!name || ignoredChecks.some((pattern) => pattern.test(name))) {
+                continue;
+              }
+
+              if (billingException && /billing|quota/i.test(name)) {
+                continue;
+              }
+
+              if (contextNode.__typename === "CheckRun") {
+                if (contextNode.status !== "COMPLETED") {
+                  failures.push(`Check '${name}' is still ${contextNode.status}.`);
+                  continue;
+                }
+                if (!allowedConclusions.has(contextNode.conclusion || "")) {
+                  failures.push(`Check '${name}' concluded with ${contextNode.conclusion || "UNKNOWN"}.`);
+                }
+              } else if (contextNode.state !== "SUCCESS") {
+                failures.push(`Status '${name}' is ${contextNode.state}.`);
+              }
+            }
+
+            if (billingException && !/billing|quota/i.test(body)) {
+              failures.push(
+                "The ci-billing-exception label is present, but the PR body does not document the billing or quota-related CI exception."
+              );
+            }
+
+            if (failures.length > 0) {
+              await core.summary.addHeading("PR Governance Gate").addList(failures).write();
+              core.setFailed(failures.join("\\n"));
+              return;
+            }
+
+            await core.summary.addHeading("PR Governance Gate").addRaw("All governance checks passed.").write();

--- a/docs/process/github-rulesets.md
+++ b/docs/process/github-rulesets.md
@@ -1,0 +1,116 @@
+# GitHub Rulesets
+
+This document is the canonical repo-tracked contract for GitHub merge policy on active AgilePlus
+lanes. GitHub rulesets remain an external settings surface, but this file defines the intended
+configuration and the CI-side checks that should backstop it.
+
+## Branch Classes
+
+### Protected Branches
+
+- `main`
+- `canary`
+- `release/*`
+
+### Layered PR Branches
+
+Preferred branch prefixes for stacked and incremental delivery:
+
+- `stack/`
+- `layer/`
+- `feat/`
+- `fix/`
+- `docs/`
+- `refactor/`
+- `ci/`
+- `chore/`
+
+## Required GitHub Ruleset Posture
+
+Apply these rules in GitHub for every protected branch above:
+
+1. Require pull requests before merge.
+2. Require linear history.
+3. Block force pushes.
+4. Block branch deletion.
+5. Require all conversations resolved before merge.
+6. Require status checks to pass.
+7. Require the branch to be up to date before merge.
+8. Require CODEOWNERS review on owned paths.
+9. Dismiss stale approvals when new commits are pushed.
+10. Restrict bypass actors to explicit emergency maintainers only.
+
+## Approval Policy
+
+- Standard changes: at least 1 approval.
+- Constitution or governance-path changes: 2 approvals.
+- No merge while review state is `CHANGES_REQUESTED`.
+- No merge with unresolved review threads.
+
+## CI Policy
+
+Required checks for protected branches should include:
+
+- `policy-gate`
+- `pr-governance-gate`
+- `quality-gate`
+- core CI workflow checks from `.github/workflows/ci.yml`
+- security checks that are intended to block merge for the branch
+
+Recommended security checks:
+
+- `code-scanning-results`
+- `sast-quick`
+- `snyk-scan`
+
+## Billing Exception Rule
+
+The only tolerated merge exception is a documented GitHub Actions billing failure.
+
+Requirements:
+
+1. The failing check name must clearly be billing-related.
+2. The PR must carry the `ci-billing-exception` label.
+3. All non-billing checks must still be green.
+4. All review threads must still be resolved.
+5. Any merge under this exception must be called out in the PR body.
+
+This is an exception for platform billing failure only, not for flaky test suites, lint failures,
+or broken workflow logic.
+
+## Stacked PR Policy
+
+- Stacked PRs are the preferred path for multi-part active work.
+- Each PR in a stack must be independently reviewable.
+- Base branches may target another layer branch instead of `main`.
+- `fix/*` or `feat/*` PRs targeting `main` directly require either:
+  - no stack is needed, or
+  - the `layered-pr-exception` label with rationale in the PR body.
+
+## PR Body Requirements
+
+Every PR must include:
+
+- summary of change and rationale
+- validation performed
+- stack topology
+- governance declaration
+
+The canonical format is enforced through `.github/pull_request_template.md` and
+`.github/workflows/pr-governance-gate.yml`.
+
+## Active Repo Baseline
+
+This policy should be mirrored for active Phenotype repos currently under stabilization:
+
+- `AgilePlus`
+- `heliosCLI`
+- `thegent`
+- `agentapi-plusplus`
+
+When repo-specific workflows differ, preserve the same merge invariants:
+
+- no force push to protected branches
+- no merge with unresolved comments
+- no merge with red CI except the billing exception rule
+- stacked PRs preferred for multi-part work

--- a/docs/sessions/20260402-governance-baseline-split/00_SESSION_OVERVIEW.md
+++ b/docs/sessions/20260402-governance-baseline-split/00_SESSION_OVERVIEW.md
@@ -1,0 +1,17 @@
+## Session Overview
+
+- Project: `AgilePlus`
+- Lane: `layer/agileplus-governance-baseline`
+- Goal: rebuild the governance baseline as a clean PR lane from `origin/main`
+
+## Scope
+
+- add repo-tracked ruleset baseline documentation
+- add PR governance gate workflow
+- add repo-tracked GitHub ruleset contract
+- restore the missing `scripts/self-merge-gate.sh` helper required by the existing workflow
+
+## Notes
+
+- the previously named governance split branch was not actually split; it pointed at the same mixed commit as the runtime, docs, and CLI lanes
+- this lane is rebuilt directly from `origin/main` to keep the PR reviewable and compatible with the repo's layered branch policy

--- a/scripts/self-merge-gate.sh
+++ b/scripts/self-merge-gate.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${GITHUB_EVENT_PATH:-}" || ! -f "${GITHUB_EVENT_PATH:-}" ]]; then
+  echo "GITHUB_EVENT_PATH is missing; cannot evaluate self-merge policy." >&2
+  exit 1
+fi
+
+author=$(
+  python3 - <<'PY'
+import json
+import os
+
+with open(os.environ["GITHUB_EVENT_PATH"], "r", encoding="utf-8") as fh:
+    event = json.load(fh)
+
+print(event.get("pull_request", {}).get("user", {}).get("login", ""))
+PY
+)
+
+reviewer=$(
+  python3 - <<'PY'
+import json
+import os
+
+with open(os.environ["GITHUB_EVENT_PATH"], "r", encoding="utf-8") as fh:
+    event = json.load(fh)
+
+print(event.get("review", {}).get("user", {}).get("login", ""))
+PY
+)
+
+state=$(
+  python3 - <<'PY'
+import json
+import os
+
+with open(os.environ["GITHUB_EVENT_PATH"], "r", encoding="utf-8") as fh:
+    event = json.load(fh)
+
+print(event.get("review", {}).get("state", ""))
+PY
+)
+
+echo "author=$author"
+echo "reviewer=$reviewer"
+echo "state=$state"
+
+if [[ "$state" != "approved" ]]; then
+  echo "Review is not an approval; nothing to block."
+  exit 0
+fi
+
+if [[ -z "$author" || -z "$reviewer" ]]; then
+  echo "Unable to determine PR author or reviewer." >&2
+  exit 1
+fi
+
+if [[ "$author" == "$reviewer" ]]; then
+  echo "ERROR: PR author cannot self-approve a protected merge." >&2
+  exit 1
+fi
+
+echo "Self-merge gate passed."


### PR DESCRIPTION
## Summary
- restore the repo-tracked governance baseline on a clean layered branch
- add the missing `scripts/self-merge-gate.sh` helper used by the existing workflow
- publish the ruleset baseline, PR governance gate workflow, and GitHub ruleset contract as reviewable files

## Stack Topology
- base: `main`
- head: `layer/agileplus-governance-baseline`
- stack: single-layer governance baseline lane

## Validation
- parsed `.github/workflows/pr-governance-gate.yml` with Python YAML
- ran `bash -n scripts/self-merge-gate.sh`
- confirmed branch diff is constrained to governance files and the session note

## Governance
- no force push used
- branch uses approved `layer/*` prefix
- no known CI exception requested for this lane

## CI Exception
- none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it adds/changes merge-blocking GitHub Actions governance checks (PR body/label/branch/CI status enforcement) that could prevent merges if misconfigured, though it does not touch runtime code or production data paths.
> 
> **Overview**
> Adds a repo-tracked governance baseline: `.github/RULESET_BASELINE.md` and `docs/process/github-rulesets.md` define the intended GitHub ruleset posture, required checks, stacked-PR conventions, and the *billing-only* CI exception policy.
> 
> Introduces a new merge-blocking workflow, `.github/workflows/pr-governance-gate.yml`, which queries PR state via GraphQL and fails when required PR template sections are missing, the PR is draft/has `CHANGES_REQUESTED`/unresolved threads, branch naming or targeting violates layered rules (unless `layered-pr-exception`), or any CI check is non-green (except documented billing/quota failures under `ci-billing-exception`).
> 
> Restores `scripts/self-merge-gate.sh` (used by existing `.github/workflows/self-merge-gate.yml`) to block self-approvals, and adds a session note documenting the governance-baseline lane split.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3ded418164440e2f7a5109e7f770d4f43588645. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->