### PR TITLE
Refactor graph store to use UUIDs and in-memory backend

### DIFF
--- a/crates/agileplus-graph/Cargo.toml
+++ b/crates/agileplus-graph/Cargo.toml
@@ -10,8 +10,9 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
-async-trait = "0.1"
+async-trait = { workspace = true }
 uuid = { version = "1", features = ["v4", "serde"] }
+tracing = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "macros"] }

--- a/crates/agileplus-graph/src/graph_store.rs
+++ b/crates/agileplus-graph/src/graph_store.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use std::collections::HashMap;
 use std::sync::Mutex;
 
-use super::types::{Node, NodeType, Relationship, RelType};
+use super::types::{Node, NodeType, RelType, Relationship};
 
 #[derive(Debug, thiserror::Error)]
 pub enum GraphError {
@@ -134,11 +134,20 @@ mod tests {
     #[tokio::test]
     async fn test_upsert_node() {
         let store = InMemoryGraphStore::new();
-        let node = Node::new(NodeType::Feature, serde_json::json!({"slug": "feat-1"}));
+        let node_id = uuid::Uuid::new_v4();
+        let node = Node::with_id(
+            node_id,
+            NodeType::Feature,
+            serde_json::json!({"slug": "feat-1"}),
+        );
 
         store.upsert_node(&node).await.unwrap();
 
-        assert_eq!(store.get_node(node.id).unwrap().properties["slug"], "feat-1");
+        assert_eq!(node.id, node_id);
+        assert_eq!(
+            store.get_node(node.id).unwrap().properties["slug"],
+            "feat-1"
+        );
     }
 
     #[tokio::test]
@@ -163,10 +172,34 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_relationship_with_stable_uuid() {
+        let store = InMemoryGraphStore::new();
+        let node1 = Node::new(NodeType::Feature, serde_json::json!({"slug": "f1"}));
+        let node2 = Node::new(NodeType::Feature, serde_json::json!({"slug": "f2"}));
+        let relationship_id = uuid::Uuid::new_v4();
+
+        store.upsert_node(&node1).await.unwrap();
+        store.upsert_node(&node2).await.unwrap();
+
+        let rel = Relationship::with_id(relationship_id, node1.id, node2.id, RelType::DependsOn);
+        store.create_relationship(&rel).await.unwrap();
+
+        let rels = store.get_relationships_from(node1.id);
+        assert_eq!(rels.len(), 1);
+        assert_eq!(rels[0].id, relationship_id);
+    }
+
+    #[tokio::test]
     async fn test_get_blocking_path() {
         let store = InMemoryGraphStore::new();
-        let blocker = Node::new(NodeType::WorkPackage, serde_json::json!({"title": "blocker"}));
-        let blocked = Node::new(NodeType::WorkPackage, serde_json::json!({"title": "blocked"}));
+        let blocker = Node::new(
+            NodeType::WorkPackage,
+            serde_json::json!({"title": "blocker"}),
+        );
+        let blocked = Node::new(
+            NodeType::WorkPackage,
+            serde_json::json!({"title": "blocked"}),
+        );
 
         store.upsert_node(&blocker).await.unwrap();
         store.upsert_node(&blocked).await.unwrap();

--- a/crates/agileplus-graph/src/lib.rs
+++ b/crates/agileplus-graph/src/lib.rs
@@ -1,8 +1,8 @@
-pub mod types;
 pub mod graph_store;
+pub mod types;
 
-pub use types::{NodeType, RelType, Node, Relationship};
-pub use graph_store::{GraphStore, InMemoryGraphStore, GraphError};
+pub use graph_store::{GraphError, GraphStore, InMemoryGraphStore};
+pub use types::{Node, NodeType, RelType, Relationship};
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -11,4 +11,3 @@ pub enum Error {
     #[error("Config error: {0}")]
     Config(String),
 }
-

--- a/crates/agileplus-graph/src/types.rs
+++ b/crates/agileplus-graph/src/types.rs
@@ -53,8 +53,12 @@ pub struct Node {
 
 impl Node {
     pub fn new(node_type: NodeType, properties: serde_json::Value) -> Self {
+        Self::with_id(uuid::Uuid::new_v4(), node_type, properties)
+    }
+
+    pub fn with_id(id: uuid::Uuid, node_type: NodeType, properties: serde_json::Value) -> Self {
         Node {
-            id: uuid::Uuid::new_v4(),
+            id,
             node_type,
             properties,
         }
@@ -72,8 +76,17 @@ pub struct Relationship {
 
 impl Relationship {
     pub fn new(from_node_id: uuid::Uuid, to_node_id: uuid::Uuid, rel_type: RelType) -> Self {
+        Self::with_id(uuid::Uuid::new_v4(), from_node_id, to_node_id, rel_type)
+    }
+
+    pub fn with_id(
+        id: uuid::Uuid,
+        from_node_id: uuid::Uuid,
+        to_node_id: uuid::Uuid,
+        rel_type: RelType,
+    ) -> Self {
         Relationship {
-            id: uuid::Uuid::new_v4(),
+            id,
             from_node_id,
             to_node_id,
             rel_type,


### PR DESCRIPTION
## **User description**
## Summary
- Replace i64-based IDs with UUID for nodes and relationships
- Remove Neo4j/Cypher dependencies (config, health, nodes, queries, relationships, store)
- Add new `graph_store.rs` with `GraphStore` trait and `InMemoryGraphStore` implementation
- Add `types.rs` with `NodeType`, `RelType`, `Node`, and `Relationship` types
- Simplify lib.rs exports to use new module structure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Redesigned the graph persistence layer with a new `GraphStore` abstraction for improved extensibility.
  * In-memory graph store implementation now available for testing and development scenarios.
  * Core graph types restructured for enhanced clarity and type safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are mostly additive (new `with_id` constructors and tests) with no behavioral changes to the in-memory store beyond allowing stable IDs.
> 
> **Overview**
> Adds support for *caller-supplied stable UUIDs* by introducing `Node::with_id` and `Relationship::with_id`, and updating `new()` to delegate to these constructors.
> 
> Updates in-memory graph store tests to assert stable IDs (including a new test for relationship UUID stability), and tweaks crate wiring by switching `async-trait` to a workspace dependency and adding `tracing` as a dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8598aa3f4fe9e982a606440891773c2c9436c3d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Allow graph nodes and relationships to keep caller-supplied UUIDs**

### What Changed
- Nodes and relationships can now be created with a chosen UUID instead of always generating a new one
- The default creation path still works the same, but now uses the stable-ID path underneath
- In-memory graph tests now check that stored node and relationship IDs stay the same after saving

### Impact
`✅ Stable graph IDs across saves`
`✅ Easier syncing and retries with existing IDs`
`✅ More reliable graph-store tests`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=62j9g6T3OazoON3cCywSYS0TRcqz0WRss2CF-OSKDaM&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
