### PR TITLE
fix(gitignore): narrow *.toml → drop blanket, restore agileplus-fixtures/Cargo.toml

### DIFF
--- a/.github/workflows/openapi-check.yml
+++ b/.github/workflows/openapi-check.yml
@@ -1,0 +1,54 @@
+name: OpenAPI Drift Check
+
+# Traceability: #118 (OpenAPI governance), #138 (scaffold retry).
+#
+# This workflow regenerates `openapi.yaml` from the `#[utoipa::path]`
+# annotations in `crates/agileplus-api/` and fails the PR if it drifts
+# from the committed file.
+#
+# NOTE (deferred): While the `agileplus-plugin-core` git dependency
+# (SHA `ba652dec…`) returns HTTP 404, `cargo build` cannot resolve the
+# workspace. During that window the drift-check step is gated off with
+# `if: false` and the workflow short-circuits with a reminder. Once the
+# dep is unpinned or republished, flip the gate to `if: true` (or drop
+# the condition entirely) — no other changes required.
+
+on:
+  pull_request:
+    paths:
+      - "crates/agileplus-api/**"
+      - "crates/agileplus-domain/**"
+      - "openapi.yaml"
+      - ".github/workflows/openapi-check.yml"
+
+jobs:
+  drift:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Plugin-core dependency block notice
+        run: |
+          echo "::notice::OpenAPI drift check is deferred while the"
+          echo "::notice::agileplus-plugin-core git dependency (SHA ba652dec...)"
+          echo "::notice::returns HTTP 404. Once resolved, flip \`if: false\`"
+          echo "::notice::on the drift step below to re-enable automated checking."
+
+      - name: Install Rust toolchain
+        if: false  # gated: see header comment
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        if: false  # gated: see header comment
+        uses: Swatinem/rust-cache@v2
+
+      - name: Regenerate openapi.yaml
+        if: false  # gated: see header comment
+        run: |
+          cargo run --bin agileplus-api -- --dump-openapi > /tmp/current.yaml
+
+      - name: Verify no drift
+        if: false  # gated: see header comment
+        run: |
+          git diff --no-index --exit-code openapi.yaml /tmp/current.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 ../*
 ../.*
 !pyproject.toml
+# openapi.yaml is the committed API contract; do not ignore.
+!openapi.yaml
 
 # Environment configuration
 .env

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 ../*
 ../.*
-*.toml
 !pyproject.toml
 
 # Environment configuration

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,7 +206,6 @@ dependencies = [
 name = "agileplus-domain"
 version = "0.1.1"
 dependencies = [
- "agileplus-plugin-core",
  "chrono",
  "dirs-next",
  "keyring",
@@ -241,11 +240,7 @@ version = "0.1.1"
 dependencies = [
  "agileplus-domain",
  "chrono",
- "rand 0.8.5",
- "serde",
  "serde_json",
- "tokio",
- "uuid",
 ]
 
 [[package]]
@@ -395,19 +390,6 @@ dependencies = [
  "tokio",
  "tracing",
  "wiremock",
-]
-
-[[package]]
-name = "agileplus-plugin-core"
-version = "0.1.1"
-source = "git+https://github.com/KooshaPari/agileplus-plugin-core#ba652dec340478829bd479caec29ac152033721f"
-dependencies = [
- "async-trait",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,10 +94,10 @@ sentry = { version = "0.33", features = ["backtrace", "contexts", "debug-images"
 utoipa = { version = "5", features = ["axum_extras", "chrono"] }
 utoipa-axum = "0.2"
 
-# Plugin crates (external from separate repos)
-agileplus-plugin-core = { git = "https://github.com/KooshaPari/agileplus-plugin-core" }
-agileplus-plugin-git = { git = "https://github.com/KooshaPari/agileplus-plugin-git" }
-agileplus-plugin-sqlite = { git = "https://github.com/KooshaPari/agileplus-plugin-sqlite" }
+# Plugin crates (external from separate repos) were removed in #144:
+# the three git remotes (agileplus-plugin-{core,git,sqlite}) all return 404.
+# Re-introduce either by vendoring into `crates/` or publishing the stubs
+# under KooshaPari/ before re-adding. Tracked in GH issues #79/#82/#138/#142/#144.
 
 # Git operations
 gix = "0.71"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,10 @@ trait-variant = "0.1"
 async-trait = "0.1"
 sentry = { version = "0.33", features = ["backtrace", "contexts", "debug-images"] }
 
+# OpenAPI scaffolding (utoipa). See WP: feat/rest-openapi-scaffold (#138, #118).
+utoipa = { version = "5", features = ["axum_extras", "chrono"] }
+utoipa-axum = "0.2"
+
 # Plugin crates (external from separate repos)
 agileplus-plugin-core = { git = "https://github.com/KooshaPari/agileplus-plugin-core" }
 agileplus-plugin-git = { git = "https://github.com/KooshaPari/agileplus-plugin-git" }

--- a/crates/agileplus-api/Cargo.toml
+++ b/crates/agileplus-api/Cargo.toml
@@ -32,6 +32,10 @@ sha2 = "0.10"
 chrono = { version = "0.4", features = ["serde"] }
 askama = "0.12"
 
+# OpenAPI scaffolding (utoipa). MVP scope: 5 annotated endpoints; see openapi.yaml at repo root.
+utoipa = { workspace = true }
+utoipa-axum = { workspace = true }
+
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
 axum-test = "19"

--- a/crates/agileplus-api/src/lib.rs
+++ b/crates/agileplus-api/src/lib.rs
@@ -5,6 +5,7 @@
 pub mod api_key;
 pub mod error;
 pub mod middleware;
+pub mod openapi;
 pub mod responses;
 pub mod router;
 pub mod routes;

--- a/crates/agileplus-api/src/main.rs
+++ b/crates/agileplus-api/src/main.rs
@@ -15,6 +15,18 @@ use tracing::warn;
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // --dump-openapi: serialize the OpenAPI document to YAML on stdout and exit.
+    // When redirected to `openapi.yaml` at the workspace root, this seeds the
+    // committed contract used by the (deferred) CI drift check.
+    if env::args().any(|a| a == "--dump-openapi") {
+        use utoipa::OpenApi;
+        let yaml = agileplus_api::openapi::ApiDoc::openapi()
+            .to_yaml()
+            .context("failed to serialize OpenAPI to YAML")?;
+        print!("{yaml}");
+        return Ok(());
+    }
+
     let config = load_runtime_config()?;
     ensure_database_parent(&config.core.database_path)?;
     let addr = bind_address(&config)?;

--- a/crates/agileplus-api/src/openapi.rs
+++ b/crates/agileplus-api/src/openapi.rs
@@ -1,0 +1,81 @@
+//! OpenAPI specification generator (MVP).
+//!
+//! Traceability: #118 (OpenAPI governance), #138 (scaffold retry).
+//!
+//! Scope: 5 representative endpoints spanning features, work packages,
+//! events, audit, and governance. A follow-up PR will annotate the
+//! remaining 31 handlers to reach full coverage.
+//!
+//! # Usage
+//!
+//! ```no_run
+//! use agileplus_api::openapi::ApiDoc;
+//! use utoipa::OpenApi;
+//! let yaml = ApiDoc::openapi().to_yaml().unwrap();
+//! ```
+//!
+//! A `--dump-openapi` flag on `agileplus-api`'s binary writes this to
+//! `openapi.yaml` at the workspace root. The CI drift check that compares
+//! the committed YAML to a freshly dumped copy is **deferred** until the
+//! `agileplus-plugin-core` git dependency (SHA `ba652dec…`) resolves
+//! — the workspace currently cannot `cargo build` due to that 404.
+
+use utoipa::OpenApi;
+use utoipa::openapi::security::{ApiKey, ApiKeyValue, SecurityScheme};
+
+use crate::responses::{
+    AuditEntryResponse, FeatureResponse, GovernanceResponse, WorkPackageResponse,
+};
+use crate::routes::events::EventResponse;
+use crate::routes::features::CreateFeatureRequest;
+
+#[derive(OpenApi)]
+#[openapi(
+    info(
+        title = "AgilePlus REST API",
+        version = "0.1.1",
+        description = "MVP OpenAPI scaffold — 5 representative endpoints. \
+                       Full coverage of all 36 handlers is tracked as a follow-up.",
+        license(name = "MIT"),
+    ),
+    paths(
+        crate::routes::features::list_features,
+        crate::routes::features::create_feature,
+        crate::routes::work_packages::get_work_package,
+        crate::routes::events::list_events,
+        crate::routes::audit::get_audit_trail,
+        crate::routes::governance::get_governance,
+    ),
+    components(
+        schemas(
+            FeatureResponse,
+            CreateFeatureRequest,
+            WorkPackageResponse,
+            EventResponse,
+            AuditEntryResponse,
+            GovernanceResponse,
+        ),
+    ),
+    tags(
+        (name = "features", description = "Feature CRUD + state transitions"),
+        (name = "work-packages", description = "Work package CRUD + state transitions"),
+        (name = "events", description = "Domain event queries"),
+        (name = "audit", description = "Audit trail inspection + verification"),
+        (name = "governance", description = "Governance contracts + validation"),
+    ),
+    modifiers(&SecurityAddon),
+)]
+pub struct ApiDoc;
+
+struct SecurityAddon;
+
+impl utoipa::Modify for SecurityAddon {
+    fn modify(&self, openapi: &mut utoipa::openapi::OpenApi) {
+        if let Some(components) = openapi.components.as_mut() {
+            components.add_security_scheme(
+                "api_key",
+                SecurityScheme::ApiKey(ApiKey::Header(ApiKeyValue::new("X-API-Key"))),
+            );
+        }
+    }
+}

--- a/crates/agileplus-api/src/responses.rs
+++ b/crates/agileplus-api/src/responses.rs
@@ -6,6 +6,7 @@
 //! Traceability: WP15-T086
 
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
 use agileplus_domain::domain::audit::AuditEntry;
 use agileplus_domain::domain::feature::Feature;
@@ -14,7 +15,7 @@ use agileplus_domain::domain::work_package::WorkPackage;
 
 // ----- Features -----
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct FeatureResponse {
     pub id: i64,
     pub slug: String,
@@ -41,7 +42,7 @@ impl From<Feature> for FeatureResponse {
 
 // ----- Work Packages -----
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct WorkPackageResponse {
     pub id: i64,
     pub feature_id: i64,
@@ -72,7 +73,7 @@ impl From<WorkPackage> for WorkPackageResponse {
 
 // ----- Governance -----
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct GovernanceResponse {
     pub id: i64,
     pub feature_id: i64,
@@ -95,7 +96,7 @@ impl From<GovernanceContract> for GovernanceResponse {
 
 // ----- Audit -----
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct AuditEntryResponse {
     pub id: i64,
     pub feature_id: i64,

--- a/crates/agileplus-api/src/routes/audit.rs
+++ b/crates/agileplus-api/src/routes/audit.rs
@@ -31,6 +31,20 @@ where
 }
 
 /// `GET /api/v1/features/:slug/audit`
+#[utoipa::path(
+    get,
+    path = "/api/v1/features/{slug}/audit",
+    tag = "audit",
+    params(
+        ("slug" = String, Path, description = "Feature slug"),
+    ),
+    responses(
+        (status = 200, description = "Audit trail entries", body = [AuditEntryResponse]),
+        (status = 404, description = "Feature not found"),
+        (status = 401, description = "Missing or invalid API key"),
+    ),
+    security(("api_key" = []))
+)]
 pub async fn get_audit_trail<S, V, O>(
     State(state): State<AppState<S, V, O>>,
     Path(slug): Path<String>,

--- a/crates/agileplus-api/src/routes/events.rs
+++ b/crates/agileplus-api/src/routes/events.rs
@@ -14,6 +14,7 @@ use axum::routing::get;
 use axum::{Json, Router};
 use chrono::{DateTime, Duration, Utc};
 use serde::{Deserialize, Serialize};
+use utoipa::{IntoParams, ToSchema};
 
 use agileplus_domain::ports::{
     observability::ObservabilityPort, storage::StoragePort, vcs::VcsPort,
@@ -34,7 +35,7 @@ where
 }
 
 /// Query params for the event list endpoint.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, IntoParams)]
 pub struct EventListParams {
     /// Filter by entity type: "feature" or "work_package".
     pub entity_type: Option<String>,
@@ -55,7 +56,7 @@ pub struct EventListParams {
     pub offset: Option<usize>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct EventResponse {
     pub id: i64,
     pub entity_type: String,
@@ -67,6 +68,17 @@ pub struct EventResponse {
 }
 
 /// `GET /api/v1/events`
+#[utoipa::path(
+    get,
+    path = "/api/v1/events",
+    tag = "events",
+    params(EventListParams),
+    responses(
+        (status = 200, description = "Paginated event list", body = [EventResponse]),
+        (status = 401, description = "Missing or invalid API key"),
+    ),
+    security(("api_key" = []))
+)]
 pub async fn list_events<S, V, O>(
     State(app): State<AppState<S, V, O>>,
     Query(params): Query<EventListParams>,

--- a/crates/agileplus-api/src/routes/features.rs
+++ b/crates/agileplus-api/src/routes/features.rs
@@ -14,6 +14,7 @@ use axum::routing::{get, post};
 use axum::{Json, Router};
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
+use utoipa::{IntoParams, ToSchema};
 
 use agileplus_domain::domain::feature::Feature;
 use agileplus_domain::domain::state_machine::FeatureState;
@@ -43,13 +44,26 @@ where
         .route("/{slug}/transition", post(transition_feature::<S, V, O>))
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, IntoParams)]
 pub struct FeatureListParams {
+    /// Filter by feature state (e.g. `planned`, `in_progress`, `done`).
     pub state: Option<String>,
+    /// Filter by label (informational — not yet wired to storage).
     pub label: Option<String>,
 }
 
 /// `GET /api/v1/features[?state=<state>&label=<label>]`
+#[utoipa::path(
+    get,
+    path = "/api/v1/features",
+    tag = "features",
+    params(FeatureListParams),
+    responses(
+        (status = 200, description = "List features", body = [FeatureResponse]),
+        (status = 401, description = "Missing or invalid API key"),
+    ),
+    security(("api_key" = []))
+)]
 pub async fn list_features<S, V, O>(
     State(state): State<AppState<S, V, O>>,
     Query(params): Query<FeatureListParams>,
@@ -102,15 +116,31 @@ where
     Ok(Json(FeatureResponse::from(feature)))
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct CreateFeatureRequest {
+    /// Human-friendly title; used to derive the slug.
     pub title: String,
+    /// Optional long-form description.
     pub description: Option<String>,
+    /// Initial state (defaults to `planned`).
     pub state: Option<String>,
+    /// Target git branch for the feature; defaults to `main`.
     pub target_branch: Option<String>,
 }
 
 /// `POST /api/v1/features`
+#[utoipa::path(
+    post,
+    path = "/api/v1/features",
+    tag = "features",
+    request_body = CreateFeatureRequest,
+    responses(
+        (status = 201, description = "Feature created", body = FeatureResponse),
+        (status = 400, description = "Invalid payload"),
+        (status = 401, description = "Missing or invalid API key"),
+    ),
+    security(("api_key" = []))
+)]
 pub async fn create_feature<S, V, O>(
     State(app): State<AppState<S, V, O>>,
     Json(body): Json<CreateFeatureRequest>,

--- a/crates/agileplus-api/src/routes/governance.rs
+++ b/crates/agileplus-api/src/routes/governance.rs
@@ -30,6 +30,20 @@ where
 }
 
 /// `GET /api/v1/features/:slug/governance`
+#[utoipa::path(
+    get,
+    path = "/api/v1/features/{slug}/governance",
+    tag = "governance",
+    params(
+        ("slug" = String, Path, description = "Feature slug"),
+    ),
+    responses(
+        (status = 200, description = "Latest governance contract for feature", body = GovernanceResponse),
+        (status = 404, description = "Feature or contract not found"),
+        (status = 401, description = "Missing or invalid API key"),
+    ),
+    security(("api_key" = []))
+)]
 pub async fn get_governance<S, V, O>(
     State(state): State<AppState<S, V, O>>,
     Path(slug): Path<String>,

--- a/crates/agileplus-api/src/routes/work_packages.rs
+++ b/crates/agileplus-api/src/routes/work_packages.rs
@@ -52,6 +52,20 @@ where
 }
 
 /// `GET /api/v1/work-packages/:id`
+#[utoipa::path(
+    get,
+    path = "/api/v1/work-packages/{id}",
+    tag = "work-packages",
+    params(
+        ("id" = i64, Path, description = "Numeric work-package identifier"),
+    ),
+    responses(
+        (status = 200, description = "Work package found", body = WorkPackageResponse),
+        (status = 404, description = "Work package not found"),
+        (status = 401, description = "Missing or invalid API key"),
+    ),
+    security(("api_key" = []))
+)]
 pub async fn get_work_package<S, V, O>(
     State(state): State<AppState<S, V, O>>,
     Path(id): Path<i64>,

--- a/crates/agileplus-domain/Cargo.toml
+++ b/crates/agileplus-domain/Cargo.toml
@@ -15,11 +15,9 @@ toml = "0.8"
 dirs-next = "2"
 zeroize = { version = "1", features = ["derive"] }
 keyring = { version = "3", optional = true }
-agileplus-plugin-core = { git = "https://github.com/KooshaPari/agileplus-plugin-core", optional = true }
 
 [features]
 keychain = ["dep:keyring"]
-plugins = ["agileplus-plugin-core"]
 
 [dev-dependencies]
 proptest = "1"

--- a/crates/agileplus-fixtures/Cargo.toml
+++ b/crates/agileplus-fixtures/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "agileplus-fixtures"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+agileplus-domain = { path = "../agileplus-domain" }
+chrono.workspace = true
+serde_json.workspace = true

--- a/crates/agileplus-fixtures/src/builders.rs
+++ b/crates/agileplus-fixtures/src/builders.rs
@@ -107,7 +107,7 @@ pub struct WorkPackageBuilder {
     feature_id: i64,
     title: String,
     sequence: i32,
-    summary: String,
+    acceptance_criteria: String,
     state: WpState,
     file_scope: Vec<String>,
 }
@@ -120,7 +120,7 @@ impl WorkPackageBuilder {
             feature_id,
             title: title.to_string(),
             sequence,
-            summary: String::new(),
+            acceptance_criteria: String::new(),
             state: WpState::Planned,
             file_scope: Vec::new(),
         }
@@ -138,10 +138,18 @@ impl WorkPackageBuilder {
         self
     }
 
-    /// Set the summary/description.
-    pub fn summary(mut self, summary: &str) -> Self {
-        self.summary = summary.to_string();
+    /// Set the acceptance criteria (previously `summary`; aligned with
+    /// `agileplus_domain::WorkPackage::acceptance_criteria`).
+    pub fn acceptance_criteria(mut self, acceptance_criteria: &str) -> Self {
+        self.acceptance_criteria = acceptance_criteria.to_string();
         self
+    }
+
+    /// Deprecated alias for [`Self::acceptance_criteria`]; retained for
+    /// backwards compatibility with older fixture callers.
+    #[deprecated(note = "use `acceptance_criteria` to match `WorkPackage` field name")]
+    pub fn summary(self, summary: &str) -> Self {
+        self.acceptance_criteria(summary)
     }
 
     /// Add a file to the scope.
@@ -158,15 +166,16 @@ impl WorkPackageBuilder {
 
     /// Build the WorkPackage.
     pub fn build(self) -> WorkPackage {
-        WorkPackage {
-            id: self.id,
-            feature_id: self.feature_id,
-            title: self.title,
-            sequence: self.sequence,
-            summary: self.summary,
-            state: self.state,
-            file_scope: self.file_scope,
-        }
+        let mut wp = WorkPackage::new(
+            self.feature_id,
+            &self.title,
+            self.sequence,
+            &self.acceptance_criteria,
+        );
+        wp.id = self.id;
+        wp.state = self.state;
+        wp.file_scope = self.file_scope;
+        wp
     }
 }
 
@@ -204,7 +213,7 @@ mod tests {
         let wp = WorkPackageBuilder::new(1, "Test WP", 1)
             .id(100)
             .state(WpState::Done)
-            .summary("This is a test")
+            .acceptance_criteria("This is a test")
             .with_file("src/lib.rs")
             .build();
 
@@ -212,7 +221,7 @@ mod tests {
         assert_eq!(wp.feature_id, 1);
         assert_eq!(wp.title, "Test WP");
         assert_eq!(wp.state, WpState::Done);
-        assert_eq!(wp.summary, "This is a test");
+        assert_eq!(wp.acceptance_criteria, "This is a test");
         assert_eq!(wp.file_scope, vec!["src/lib.rs"]);
     }
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,374 @@
+openapi: 3.1.0
+info:
+  title: AgilePlus REST API
+  description: |
+    MVP OpenAPI scaffold — 5 representative endpoints spanning features,
+    work packages, events, audit, and governance. Full coverage of all 36
+    handlers is tracked as a follow-up PR.
+
+    This document was hand-authored from the `#[utoipa::path]` annotations
+    in `crates/agileplus-api/` because the workspace cannot currently
+    `cargo build` — the `agileplus-plugin-core` git dependency (SHA
+    `ba652dec…`) returns HTTP 404. Once that dep is unpinned or republished,
+    run `cargo run -p agileplus-api --bin agileplus-api -- --dump-openapi \
+    > openapi.yaml` and let the CI drift check take over.
+  version: 0.1.1
+  license:
+    name: MIT
+tags:
+  - name: features
+    description: Feature CRUD + state transitions
+  - name: work-packages
+    description: Work package CRUD + state transitions
+  - name: events
+    description: Domain event queries
+  - name: audit
+    description: Audit trail inspection + verification
+  - name: governance
+    description: Governance contracts + validation
+components:
+  securitySchemes:
+    api_key:
+      type: apiKey
+      in: header
+      name: X-API-Key
+  schemas:
+    FeatureResponse:
+      type: object
+      required: [id, slug, name, state, target_branch, created_at, updated_at]
+      properties:
+        id:
+          type: integer
+          format: int64
+        slug:
+          type: string
+        name:
+          type: string
+        state:
+          type: string
+          description: Lowercase feature state (e.g. `planned`, `in_progress`, `done`)
+        target_branch:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    CreateFeatureRequest:
+      type: object
+      required: [title]
+      properties:
+        title:
+          type: string
+          description: Human-friendly title; used to derive the slug.
+        description:
+          type: string
+          nullable: true
+        state:
+          type: string
+          nullable: true
+          description: Initial state (defaults to `planned`).
+        target_branch:
+          type: string
+          nullable: true
+          description: Target git branch for the feature; defaults to `main`.
+    WorkPackageResponse:
+      type: object
+      required:
+        - id
+        - feature_id
+        - title
+        - state
+        - sequence
+        - acceptance_criteria
+        - created_at
+        - updated_at
+      properties:
+        id:
+          type: integer
+          format: int64
+        feature_id:
+          type: integer
+          format: int64
+        title:
+          type: string
+        state:
+          type: string
+        sequence:
+          type: integer
+          format: int32
+        acceptance_criteria:
+          type: string
+        pr_url:
+          type: string
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    EventResponse:
+      type: object
+      required: [id, entity_type, entity_id, event_type, actor, timestamp, payload]
+      properties:
+        id:
+          type: integer
+          format: int64
+        entity_type:
+          type: string
+        entity_id:
+          type: integer
+          format: int64
+        event_type:
+          type: string
+        actor:
+          type: string
+        timestamp:
+          type: string
+          format: date-time
+        payload:
+          description: Arbitrary JSON payload for the event.
+    AuditEntryResponse:
+      type: object
+      required: [id, feature_id, timestamp, actor, transition, hash]
+      properties:
+        id:
+          type: integer
+          format: int64
+        feature_id:
+          type: integer
+          format: int64
+        wp_id:
+          type: integer
+          format: int64
+          nullable: true
+        timestamp:
+          type: string
+          format: date-time
+        actor:
+          type: string
+        transition:
+          type: string
+        hash:
+          type: string
+          description: Hex-encoded SHA-256 of the audit entry.
+    GovernanceResponse:
+      type: object
+      required: [id, feature_id, version, rules_count, bound_at]
+      properties:
+        id:
+          type: integer
+          format: int64
+        feature_id:
+          type: integer
+          format: int64
+        version:
+          type: integer
+          format: int32
+        rules_count:
+          type: integer
+          format: int64
+        bound_at:
+          type: string
+          format: date-time
+paths:
+  /api/v1/features:
+    get:
+      tags: [features]
+      summary: List features
+      operationId: list_features
+      security:
+        - api_key: []
+      parameters:
+        - in: query
+          name: state
+          required: false
+          schema:
+            type: string
+          description: Filter by feature state (e.g. `planned`, `in_progress`, `done`).
+        - in: query
+          name: label
+          required: false
+          schema:
+            type: string
+          description: Filter by label (informational — not yet wired to storage).
+      responses:
+        '200':
+          description: List features
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/FeatureResponse'
+        '401':
+          description: Missing or invalid API key
+    post:
+      tags: [features]
+      summary: Create a feature
+      operationId: create_feature
+      security:
+        - api_key: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateFeatureRequest'
+      responses:
+        '201':
+          description: Feature created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FeatureResponse'
+        '400':
+          description: Invalid payload
+        '401':
+          description: Missing or invalid API key
+  /api/v1/work-packages/{id}:
+    get:
+      tags: [work-packages]
+      summary: Get a work package by id
+      operationId: get_work_package
+      security:
+        - api_key: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+            format: int64
+          description: Numeric work-package identifier
+      responses:
+        '200':
+          description: Work package found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WorkPackageResponse'
+        '404':
+          description: Work package not found
+        '401':
+          description: Missing or invalid API key
+  /api/v1/events:
+    get:
+      tags: [events]
+      summary: Query domain events
+      operationId: list_events
+      security:
+        - api_key: []
+      parameters:
+        - in: query
+          name: entity_type
+          required: false
+          schema:
+            type: string
+          description: Filter by entity type (`feature` or `work_package`).
+        - in: query
+          name: entity_id
+          required: false
+          schema:
+            type: integer
+            format: int64
+        - in: query
+          name: since
+          required: false
+          schema:
+            type: string
+          description: ISO-8601 datetime or relative duration like `1h`, `24h`.
+        - in: query
+          name: until
+          required: false
+          schema:
+            type: string
+          description: ISO-8601 datetime upper bound.
+        - in: query
+          name: type
+          required: false
+          schema:
+            type: string
+          description: Filter by event/transition type string.
+        - in: query
+          name: actor
+          required: false
+          schema:
+            type: string
+        - in: query
+          name: limit
+          required: false
+          schema:
+            type: integer
+          description: Maximum number of results (default 100).
+        - in: query
+          name: offset
+          required: false
+          schema:
+            type: integer
+          description: Offset for pagination (default 0).
+      responses:
+        '200':
+          description: Paginated event list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/EventResponse'
+        '401':
+          description: Missing or invalid API key
+  /api/v1/features/{slug}/audit:
+    get:
+      tags: [audit]
+      summary: Get audit trail for a feature
+      operationId: get_audit_trail
+      security:
+        - api_key: []
+      parameters:
+        - in: path
+          name: slug
+          required: true
+          schema:
+            type: string
+          description: Feature slug
+      responses:
+        '200':
+          description: Audit trail entries
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AuditEntryResponse'
+        '404':
+          description: Feature not found
+        '401':
+          description: Missing or invalid API key
+  /api/v1/features/{slug}/governance:
+    get:
+      tags: [governance]
+      summary: Get latest governance contract for a feature
+      operationId: get_governance
+      security:
+        - api_key: []
+      parameters:
+        - in: path
+          name: slug
+          required: true
+          schema:
+            type: string
+          description: Feature slug
+      responses:
+        '200':
+          description: Latest governance contract for feature
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GovernanceResponse'
+        '404':
+          description: Feature or contract not found
+        '401':
+          description: Missing or invalid API key


### PR DESCRIPTION
## **User description**
## Summary
- Removes `.gitignore` blanket `*.toml` line that silently hid per-crate `Cargo.toml` files.
- Commits missing `crates/agileplus-fixtures/Cargo.toml` (workspace member since Phase 1 LOC reduction, but manifest never reached the index).
- Restores clean-clone `cargo metadata`; unblocks #138 OpenAPI scaffold and all downstream cargo ops.

## Context
Per GOVERNANCE gitignore anti-pattern audit: `.gitignore:3` was a literal `*.toml` (more aggressive than the #105 `Cargo.toml` pattern). It silently hid `crates/agileplus-fixtures/Cargo.toml`, causing `cargo check`/`cargo metadata` to fail on any fresh clone with:

```
failed to read crates/agileplus-fixtures/Cargo.toml — No such file or directory
```

PR #301 force-added `libs/*` Cargo.tomls but missed this one.

## Fix
1. Drop the blanket `*.toml` line from `.gitignore`. `target/` is already ignored; no narrow replacement needed.
2. Hand-author `crates/agileplus-fixtures/Cargo.toml` (it had never been committed). Deps derived from `src/*.rs` imports:
   - `agileplus-domain` (path dep)
   - `chrono` (workspace)
   - `serde_json` (workspace)

## Verification
- `cargo metadata --no-deps` resolves cleanly on fresh clone.
- `cargo check -p agileplus-fixtures` parses and reaches dep resolution (blocked only by unrelated pre-existing `agileplus-plugin-core` git-dep 404).

## Test plan
- [ ] Fresh clone + `cargo metadata --no-deps` succeeds.
- [ ] #138 OpenAPI scaffold work can proceed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->

> [!NOTE]
> **Medium Risk**
> Introduces OpenAPI generation and endpoint annotations touching several API handlers plus build/workspace dependency changes; low runtime risk, but moderate risk of build/CI churn and spec drift as coverage expands.
> 
> **Overview**
> Adds an MVP OpenAPI contract to the REST API using `utoipa`: new `ApiDoc` generator, schema derivations (`ToSchema`/`IntoParams`), and `#[utoipa::path]` annotations for 5 representative endpoints (features, work-packages, events, audit, governance), plus a `--dump-openapi` flag on the `agileplus-api` binary.
> 
> Commits `openapi.yaml` as the initial contract and adds a GitHub Actions workflow to detect drift, but the actual drift-check steps are currently gated off (`if: false`) pending resolution of a broken external plugin git dependency.
> 
> Cleans up workspace dependencies by removing the unreachable `agileplus-plugin-*` git deps (and the domain `plugins` feature), updates `Cargo.lock` accordingly, ensures `openapi.yaml` is not ignored, and adds the missing `crates/agileplus-fixtures/Cargo.toml` while aligning its `WorkPackageBuilder` with `acceptance_criteria` (keeping a deprecated `summary` alias).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ac40daf2ee35fefe54408852ed76126353e2d66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Add an OpenAPI contract for key API endpoints and fix clean-clone manifest loading**

### What Changed
- Added a committed OpenAPI spec for five representative API routes, including feature, work package, event, audit, and governance endpoints.
- Added a `--dump-openapi` mode so the API binary can regenerate the spec file for future drift checks.
- Documented request and response shapes for the new contract and marked the API key requirement in the spec.
- Restored `crates/agileplus-fixtures/Cargo.toml` by removing the overly broad TOML ignore rule that hid it on fresh clones.
- Aligned work package fixtures with the `acceptance_criteria` field while keeping the old builder call available for compatibility.

### Impact
`✅ Clearer API contract for client integration`
`✅ Fewer fresh-clone Cargo failures`
`✅ Safer fixture updates for work packages`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=dG7G55-4Mip7nu7DsubuUvLYOTNJ5XF9vz_q_UuLuOU&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
