### PR TITLE
fix(gitignore): remove *.yaml + *.json blankets (follow-up to #364)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
 ../*
 ../.*
 *.toml
-*.yaml
-*.json
 !pyproject.toml
 
 # Environment configuration


### PR DESCRIPTION
## Summary
- Removes bare `*.yaml` and `*.json` blankets from `.gitignore`, which matched files at any depth and risked silently ignoring new workflow/config files.
- Follow-up to #364 (which addresses the corresponding `*.toml` anti-pattern). Based on `main`.

## Anti-pattern evidence (pre-fix)
```
$ git check-ignore -v example.yaml example.json
.gitignore:4:*.yaml	example.yaml
.gitignore:5:*.json	example.json
```
177 yaml/json files already tracked (grandfathered). The blankets only harmed *new* files.

## Post-fix verification
```
$ git check-ignore -v example.yaml example.json .github/workflows/ci.yml
(exit 1, nothing ignored)
```

## Test plan
- [x] `git check-ignore` exits 1 for yaml/json after fix
- [x] Existing tracked files unaffected (2 lines deleted only)

Closes task from audit #141.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts `.gitignore` patterns, affecting which new files Git will track (no runtime behavior changes).
> 
> **Overview**
> Removes the broad `*.yaml` and `*.json` ignore patterns from the root `.gitignore`, so new YAML/JSON workflow/config files are no longer silently ignored at any depth.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 202aa4a828df1fa70fcae17dd90f59f05a613998. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->