### PR TITLE
fix(deps): remove phantom agileplus-plugin-{core,git,sqlite} git-deps (404 remotes)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,7 +206,6 @@ dependencies = [
 name = "agileplus-domain"
 version = "0.1.1"
 dependencies = [
- "agileplus-plugin-core",
  "chrono",
  "dirs-next",
  "keyring",
@@ -241,11 +240,7 @@ version = "0.1.1"
 dependencies = [
  "agileplus-domain",
  "chrono",
- "rand 0.8.5",
- "serde",
  "serde_json",
- "tokio",
- "uuid",
 ]
 
 [[package]]
@@ -395,19 +390,6 @@ dependencies = [
  "tokio",
  "tracing",
  "wiremock",
-]
-
-[[package]]
-name = "agileplus-plugin-core"
-version = "0.1.1"
-source = "git+https://github.com/KooshaPari/agileplus-plugin-core#ba652dec340478829bd479caec29ac152033721f"
-dependencies = [
- "async-trait",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,10 +94,10 @@ sentry = { version = "0.33", features = ["backtrace", "contexts", "debug-images"
 utoipa = { version = "5", features = ["axum_extras", "chrono"] }
 utoipa-axum = "0.2"
 
-# Plugin crates (external from separate repos)
-agileplus-plugin-core = { git = "https://github.com/KooshaPari/agileplus-plugin-core" }
-agileplus-plugin-git = { git = "https://github.com/KooshaPari/agileplus-plugin-git" }
-agileplus-plugin-sqlite = { git = "https://github.com/KooshaPari/agileplus-plugin-sqlite" }
+# Plugin crates (external from separate repos) were removed in #144:
+# the three git remotes (agileplus-plugin-{core,git,sqlite}) all return 404.
+# Re-introduce either by vendoring into `crates/` or publishing the stubs
+# under KooshaPari/ before re-adding. Tracked in GH issues #79/#82/#138/#142/#144.
 
 # Git operations
 gix = "0.71"

--- a/crates/agileplus-domain/Cargo.toml
+++ b/crates/agileplus-domain/Cargo.toml
@@ -15,11 +15,9 @@ toml = "0.8"
 dirs-next = "2"
 zeroize = { version = "1", features = ["derive"] }
 keyring = { version = "3", optional = true }
-agileplus-plugin-core = { git = "https://github.com/KooshaPari/agileplus-plugin-core", optional = true }
 
 [features]
 keychain = ["dep:keyring"]
-plugins = ["agileplus-plugin-core"]
 
 [dev-dependencies]
 proptest = "1"

--- a/crates/agileplus-fixtures/src/builders.rs
+++ b/crates/agileplus-fixtures/src/builders.rs
@@ -107,7 +107,7 @@ pub struct WorkPackageBuilder {
     feature_id: i64,
     title: String,
     sequence: i32,
-    summary: String,
+    acceptance_criteria: String,
     state: WpState,
     file_scope: Vec<String>,
 }
@@ -120,7 +120,7 @@ impl WorkPackageBuilder {
             feature_id,
             title: title.to_string(),
             sequence,
-            summary: String::new(),
+            acceptance_criteria: String::new(),
             state: WpState::Planned,
             file_scope: Vec::new(),
         }
@@ -138,10 +138,18 @@ impl WorkPackageBuilder {
         self
     }
 
-    /// Set the summary/description.
-    pub fn summary(mut self, summary: &str) -> Self {
-        self.summary = summary.to_string();
+    /// Set the acceptance criteria (previously `summary`; aligned with
+    /// `agileplus_domain::WorkPackage::acceptance_criteria`).
+    pub fn acceptance_criteria(mut self, acceptance_criteria: &str) -> Self {
+        self.acceptance_criteria = acceptance_criteria.to_string();
         self
+    }
+
+    /// Deprecated alias for [`Self::acceptance_criteria`]; retained for
+    /// backwards compatibility with older fixture callers.
+    #[deprecated(note = "use `acceptance_criteria` to match `WorkPackage` field name")]
+    pub fn summary(self, summary: &str) -> Self {
+        self.acceptance_criteria(summary)
     }
 
     /// Add a file to the scope.
@@ -158,15 +166,16 @@ impl WorkPackageBuilder {
 
     /// Build the WorkPackage.
     pub fn build(self) -> WorkPackage {
-        WorkPackage {
-            id: self.id,
-            feature_id: self.feature_id,
-            title: self.title,
-            sequence: self.sequence,
-            summary: self.summary,
-            state: self.state,
-            file_scope: self.file_scope,
-        }
+        let mut wp = WorkPackage::new(
+            self.feature_id,
+            &self.title,
+            self.sequence,
+            &self.acceptance_criteria,
+        );
+        wp.id = self.id;
+        wp.state = self.state;
+        wp.file_scope = self.file_scope;
+        wp
     }
 }
 
@@ -204,7 +213,7 @@ mod tests {
         let wp = WorkPackageBuilder::new(1, "Test WP", 1)
             .id(100)
             .state(WpState::Done)
-            .summary("This is a test")
+            .acceptance_criteria("This is a test")
             .with_file("src/lib.rs")
             .build();
 
@@ -212,7 +221,7 @@ mod tests {
         assert_eq!(wp.feature_id, 1);
         assert_eq!(wp.title, "Test WP");
         assert_eq!(wp.state, WpState::Done);
-        assert_eq!(wp.summary, "This is a test");
+        assert_eq!(wp.acceptance_criteria, "This is a test");
         assert_eq!(wp.file_scope, vec!["src/lib.rs"]);
     }
 


### PR DESCRIPTION
## **User description**
## Summary

Closes #144. The workspace pins three sister plugin repos (`agileplus-plugin-{core,git,sqlite}`) under `KooshaPari/` that all return HTTP 404, so `cargo check` on fresh clones fails to resolve `Cargo.lock`.

## Usage audit

| Crate | Workspace root decl | Rust consumers |
|-------|--------------------:|----------------|
| `agileplus-plugin-core` | yes (L93) + optional dep on `agileplus-domain` behind non-default `plugins` feature | 1 file: `crates/agileplus-domain/src/plugins/registry.rs` — **but the `plugins/` module is not declared in `lib.rs`, so it's orphaned dead code** |
| `agileplus-plugin-git` | yes | 0 |
| `agileplus-plugin-sqlite` | yes | 0 |

Since the `plugins` feature is off by default and the single consumer is orphaned, removing all three declarations is safe and unblocks every fresh clone.

## Changes

- Drop the three `git = "https://github.com/KooshaPari/agileplus-plugin-*"` lines from workspace `Cargo.toml`, replace with a breadcrumb comment pointing at #79/#82/#138/#142/#144.
- Drop the optional `agileplus-plugin-core` dep and `plugins` feature from `crates/agileplus-domain/Cargo.toml`.
- Run `cargo update` — `Cargo.lock` no longer references the 404 revision `ba652dec…`.
- Leave `crates/agileplus-domain/src/plugins/` files in-tree as breadcrumbs for future reintroduction (vendor into `crates/` or publish stubs).

## Verification

- `cargo check -p agileplus-domain` — clean.
- `cargo check --workspace` — clean through this path; fails later at a pre-existing unrelated error in `agileplus-fixtures` (`WorkPackage.summary` field mismatch) that is outside this PR's scope.

## Test plan

- [x] `cargo update` removes `agileplus-plugin-core v0.1.1` from Cargo.lock
- [x] `cargo check -p agileplus-domain` succeeds
- [ ] Fresh clone + `cargo check` on CI (tracking #79/#82/#138/#142)

Related: #79, #82, #138, #142.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with Claude Code

<!-- CURSOR_SUMMARY -->

> [!NOTE]
> **Low Risk**
> Low risk: this only removes unreachable git-based plugin deps/features (unblocking builds) and updates test fixtures to match a renamed `WorkPackage` field, with no runtime logic changes in production code paths.
> 
> **Overview**
> Fixes fresh-build failures by removing the 404’ing git dependencies for `agileplus-plugin-{core,git,sqlite}` from the workspace and dropping the optional `agileplus-plugin-core` dependency/`plugins` feature from `agileplus-domain` (with a comment on how to reintroduce them).
> 
> Updates `agileplus-fixtures`’ `WorkPackageBuilder` to use `acceptance_criteria` instead of `summary`, adds a deprecated `summary()` alias for compatibility, and switches `build()` to construct via `WorkPackage::new()`; lockfile is updated to remove the git-sourced `agileplus-plugin-core` entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9692c1a0aebfca88127f98cd87cac4476e97f254. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Remove broken plugin dependencies and keep work package fixtures working**

### What Changed
- Removed three plugin repository references that pointed to missing remotes, so fresh clones can resolve dependencies and run checks again
- Kept the plugin files in the tree as placeholders for future reintroduction
- Updated the work package fixture builder to use `acceptance_criteria` instead of the stale `summary` field
- Kept `summary()` available as a deprecated alias so older fixture code still works

### Impact
`✅ Fresh clones can build dependency graphs`
`✅ Fewer cargo check failures`
`✅ Less breakage in fixture-based tests`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=KzE2VwvfN2AVfECTJvMvORgfKcSV7jl6DwdFIa54RSg&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
