### PR TITLE
fix(fixtures): align WorkPackage fields with agileplus-domain

### DIFF
--- a/crates/agileplus-fixtures/src/builders.rs
+++ b/crates/agileplus-fixtures/src/builders.rs
@@ -107,7 +107,7 @@ pub struct WorkPackageBuilder {
     feature_id: i64,
     title: String,
     sequence: i32,
-    summary: String,
+    acceptance_criteria: String,
     state: WpState,
     file_scope: Vec<String>,
 }
@@ -120,7 +120,7 @@ impl WorkPackageBuilder {
             feature_id,
             title: title.to_string(),
             sequence,
-            summary: String::new(),
+            acceptance_criteria: String::new(),
             state: WpState::Planned,
             file_scope: Vec::new(),
         }
@@ -138,10 +138,18 @@ impl WorkPackageBuilder {
         self
     }
 
-    /// Set the summary/description.
-    pub fn summary(mut self, summary: &str) -> Self {
-        self.summary = summary.to_string();
+    /// Set the acceptance criteria (previously `summary`; aligned with
+    /// `agileplus_domain::WorkPackage::acceptance_criteria`).
+    pub fn acceptance_criteria(mut self, acceptance_criteria: &str) -> Self {
+        self.acceptance_criteria = acceptance_criteria.to_string();
         self
+    }
+
+    /// Deprecated alias for [`Self::acceptance_criteria`]; retained for
+    /// backwards compatibility with older fixture callers.
+    #[deprecated(note = "use `acceptance_criteria` to match `WorkPackage` field name")]
+    pub fn summary(self, summary: &str) -> Self {
+        self.acceptance_criteria(summary)
     }
 
     /// Add a file to the scope.
@@ -158,15 +166,16 @@ impl WorkPackageBuilder {
 
     /// Build the WorkPackage.
     pub fn build(self) -> WorkPackage {
-        WorkPackage {
-            id: self.id,
-            feature_id: self.feature_id,
-            title: self.title,
-            sequence: self.sequence,
-            summary: self.summary,
-            state: self.state,
-            file_scope: self.file_scope,
-        }
+        let mut wp = WorkPackage::new(
+            self.feature_id,
+            &self.title,
+            self.sequence,
+            &self.acceptance_criteria,
+        );
+        wp.id = self.id;
+        wp.state = self.state;
+        wp.file_scope = self.file_scope;
+        wp
     }
 }
 
@@ -204,7 +213,7 @@ mod tests {
         let wp = WorkPackageBuilder::new(1, "Test WP", 1)
             .id(100)
             .state(WpState::Done)
-            .summary("This is a test")
+            .acceptance_criteria("This is a test")
             .with_file("src/lib.rs")
             .build();
 
@@ -212,7 +221,7 @@ mod tests {
         assert_eq!(wp.feature_id, 1);
         assert_eq!(wp.title, "Test WP");
         assert_eq!(wp.state, WpState::Done);
-        assert_eq!(wp.summary, "This is a test");
+        assert_eq!(wp.acceptance_criteria, "This is a test");
         assert_eq!(wp.file_scope, vec!["src/lib.rs"]);
     }
 


### PR DESCRIPTION
## **User description**
## Summary

Fixes #147 — `agileplus-fixtures::WorkPackageBuilder` carried a stale `summary`
field that does not exist on the canonical `agileplus_domain::WorkPackage`.
Surfaced by #367's full-workspace `cargo check` once phantom plugin git-deps
were removed.

Exact error:

```
error[E0560]: struct `WorkPackage` has no field named `summary`
  --> crates/agileplus-fixtures/src/builders.rs:166:13
```

## Changes

- Rename builder state `summary` → `acceptance_criteria` to match domain.
- Keep a `#[deprecated]` `summary()` setter alias for legacy callers.
- `build()` now delegates to `WorkPackage::new(...)` so the many new optional
  fields (`plane_sub_issue_id`, `base_commit`, `head_commit`, `agent_id`,
  `pr_url`, `pr_state`, `worktree_path`, `created_at`, `updated_at`) stay in
  sync with domain drift automatically.
- Update the builder unit test.

## Stack

Part of the workspace-clean chain:
#364 → #365 → #366 → #367 → **this**. Refs #139, #147.

Base branch: `fix/remove-phantom-plugin-git-deps` (PR #367).

## Test plan

- [x] `cargo check -p agileplus-fixtures` — passes clean.
- [ ] `cargo test -p agileplus-fixtures` — not run (out of Parsec throttle
      scope: check-only).
- [ ] Full workspace `cargo check` — expected to still surface *unrelated*
      errors from other crates; out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to test fixtures and primarily rename a field while delegating construction to `WorkPackage::new`, with a deprecated alias kept to avoid breaking older callers.
> 
> **Overview**
> Aligns `agileplus-fixtures::WorkPackageBuilder` with the canonical `agileplus_domain::WorkPackage` by renaming the internal `summary` field/setter to `acceptance_criteria`.
> 
> Updates `build()` to construct via `WorkPackage::new(...)` (then overrides `id`, `state`, and `file_scope`) so fixture creation stays in sync with domain defaults/added fields, and refreshes the unit test accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42adbff1249d0c5a099594c1419012c56129ee71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Keep work package fixtures aligned with the current work package fields**

### What Changed
- Work package fixtures now use `acceptance_criteria` instead of the old `summary` field, matching the current work package shape
- Older fixture code that still calls `summary()` keeps working through a deprecated alias
- Building a work package fixture now follows the current default work package setup, so new fields stay aligned with the domain model
- Updated fixture tests to check the new field name and behavior

### Impact
`✅ Fewer fixture build failures`
`✅ Safer workspace checks`
`✅ Clearer work package test data`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=N-GEL5ZxVY6pXMcXCv5NYDJy6aXC4rtSR2v4tWxExao&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
