### PR TITLE
fix(hooks): remove auto-staging that violates dirty-tree commit discipline

### DIFF
--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# 5-line glue: point git at canonical .githooks/ tree (Rust replacement is overkill for one git-config call).
+# Justification: per Phenotype scripting policy, ≤5-line shell glue is acceptable when a real-language
+# replacement is a net loss. This is a one-shot `git config` invocation per checkout.
+set -euo pipefail
+git -C "$(git rev-parse --show-toplevel)" config core.hooksPath .githooks
+echo "[install-hooks] core.hooksPath -> .githooks (canonical, staged-only secret scan)"


### PR DESCRIPTION
## **User description**
## Summary

The locally-installed `.git/hooks/pre-commit` had drifted from the canonical `.githooks/pre-commit` (shipped in PR #359). The stale hook ran:

    trufflehog git "file://$canonical_root" --since-commit HEAD --only-verified --fail

which scans the **entire canonical working tree** rather than only the files in the current commit. In multi-worktree setups (kitty-specs, sibling agent branches, etc.) this surfaces unrelated dirty files and forces operators to bypass the hook with `core.hooksPath=/dev/null` — a direct violation of the dirty-tree commit discipline (`~/.claude/CLAUDE.md` MODE 1/2/3 separation by provenance).

The canonical `.githooks/pre-commit` already does the right thing: it scans only `git diff --cached --name-only` files, so unrelated dirty content is ignored.

## What this PR does

Adds `scripts/install-hooks.sh` (5-line bash glue, justified per scripting policy) that points `core.hooksPath` at the tracked `.githooks/` tree. Once run per checkout, every commit uses the staged-only scanner and bypass-via-/dev/null is no longer needed.

## What it does NOT do

- Does not disable any validation. Trufflehog secret scan still runs on staged files. `pre-push` lint/test guards untouched.
- Does not remove a literal `git add` from the hook (none exists). The reported "auto-staging" symptom traces to the stale hook scanning beyond the staged scope, not to a `git add` line. The fix is to make the canonical hook authoritative.

## Other discipline-breaking patterns found

- None beyond the stale `.git/hooks/pre-commit`. `.githooks/pre-push` (PR #359) already wraps quality gates with bounded timeouts and `HOOKS_SKIP` bypass.
- The pre-push hook flagged 4 unrelated pre-existing issues during local validation — not introduced by this PR.

## Test plan

- [x] With `core.hooksPath=.githooks`, drop an untracked file in the tree, stage only an unrelated file, run the hook → only the staged file is scanned (verified: 501 bytes scanned, untracked `.test-unrelated-dirty` ignored)
- [x] `bash -n .githooks/pre-commit` passes
- [x] `HOOKS_SKIP=1` and `PRE_COMMIT_SKIP_SECRETS=1` bypass paths still work
- [ ] Run `scripts/install-hooks.sh` after pulling this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->

> [!NOTE]
> **Low Risk**
> Low risk: adds a small helper script that only updates local git config (`core.hooksPath`) and prints a message, without changing runtime application logic or validation behavior.
> 
> **Overview**
> Adds `scripts/install-hooks.sh`, a small helper that sets `core.hooksPath` to the repository’s tracked `.githooks` directory from the repo root.
> 
> This makes the canonical hooks authoritative per checkout (instead of relying on potentially stale `.git/hooks`), helping ensure secret scanning and other hook behavior runs from the staged, versioned hook scripts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ea091a7d9d18019c4133ef2da07bcd0e2ec4204. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Install the canonical Git hooks for staged-file secret scanning**

### What Changed
- Added a one-step setup script that points Git to the tracked `.githooks/` directory
- Running the script makes the canonical pre-commit hook active in each checkout, so the secret scan only checks staged changes
- This avoids unrelated dirty files in other worktrees from causing pre-commit failures or forcing hook bypasses

### Impact
`✅ Fewer false pre-commit failures`
`✅ Staged-only secret scanning`
`✅ Less need to bypass hooks`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=iMcVHJJI80OtpGEsXL0xIZ4fpO28auX065aAk15Avd8&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
