### PR TITLE
docs(spec-016): rewrite plan.md + tasks.md as phased WBS with DAG

### DIFF
--- a/kitty-specs/016-agent-framework-expansion/plan.md
+++ b/kitty-specs/016-agent-framework-expansion/plan.md
@@ -1,20 +1,196 @@
 # Plan: Agent Framework Expansion — Complete Across 6 Repositories
 
-## Phase 1: Orchestration Foundation
-- [ ] WP-001: Agentora — Complete Agent Orchestration Framework
-- [ ] WP-002: AgentMCP — Implement MCP Protocol Server
+> Specification: `spec.md` (this directory) · Spec ID: `AgilePlus-016` · Status: IN_PROGRESS
+>
+> Planner mandate: This document contains specs, acceptance criteria, references,
+> and dependency structure only. **No code.** Implementers consult per-repo
+> source trees and existing crates referenced below.
 
-## Phase 2: Communication, Policy, and Mobility
-- [ ] WP-003: agent-wave — Event-Driven Agent Communication
-- [ ] WP-004: agentops-policy-federation — Policy Distribution Across Agents
-- [ ] WP-005: helMo — Agent Mobility and Communication
-- [ ] WP-006: agent-devops-setups — CI/CD Templates for Agent Projects
+## Scope Reaffirmation
 
-## Dependencies
-- 007-thegent-completion (thegent integration)
-- 015-plugin-system-completion (plugin architecture)
-- 001-spec-driven-development-engine (spec-driven workflow)
+Complete and integrate the agent framework across six Phenotype-org repositories
+so that orchestration, MCP protocol, event-driven communication, policy
+distribution, agent mobility, and DevOps templates compose into a single
+unified agent lifecycle. See `spec.md` "Repositories Affected" and
+"Success Criteria" for normative scope.
 
-## Timeline
-- Phase 1: Week 1-4
-- Phase 2: Week 4-8
+## Cross-Project Reuse Audit (mandatory before Build)
+
+Per Phenotype Org Cross-Project Reuse Protocol, the Discovery phase MUST inspect
+existing assets that overlap with this work and prefer extension over re-author.
+Inputs to consult:
+
+- `repos/agentkit/` — active Rust agent framework with skill system; candidate
+  shared substrate for `Agentora` orchestration types and `AgentMCP` tool
+  surface.
+- `repos/agentapi-plusplus/` — Go multi-model AI gateway; routing/transport
+  patterns inform `agent-wave` event bus and MCP transport choices.
+- `repos/cheap-llm-mcp/` and `repos/thegent-dispatch/` — validated Python
+  FastMCP server and Rust dispatch crate (memory: session_2026_04_22). Reuse
+  the dispatch contract before authoring a new agent-call surface.
+- `repos/phenotype-shared/crates/` — `phenotype-event-sourcing`,
+  `phenotype-cache-adapter`, `phenotype-policy-engine`,
+  `phenotype-state-machine`. **Mandatory** dependencies for orchestration
+  state, policy evaluation, and event audit.
+- Device-automation rebuild repos (`KDesktopVirt`, `KVirtualStage`, `kmobile`)
+  are out of scope for this spec but record any orchestration-layer touchpoints
+  for spec 011 handoff.
+
+Reuse decisions and rejections are logged in
+`repos/worklogs/RESEARCH.md` under `[AgilePlus]` `[cross-repo]` tags before
+Phase 2 (Design) begins.
+
+## Phased WBS (Discovery → Design → Build → Test/Validate → Deploy/Handoff)
+
+### Phase 1 — Discovery
+
+Survey current state of all six repos and the shared crates listed above.
+Output: gap analysis per repo, integration interface inventory, reuse
+decisions. No code authored.
+
+- D1.1 Audit Agentora orchestration surface and lifecycle gaps.
+- D1.2 Audit AgentMCP protocol coverage versus current MCP spec.
+- D1.3 Audit agent-wave event bus, routing, persistence semantics.
+- D1.4 Audit agentops-policy-federation distribution + enforcement model.
+- D1.5 Audit helMo mobility prototype: state capture, transport, rollback.
+- D1.6 Audit agent-devops-setups templates against current GitHub Actions /
+  GitLab CI feature set and Phenotype scripting hierarchy (no shell-only
+  templates accepted).
+- D1.7 Cross-repo reuse audit (see "Cross-Project Reuse Audit" above).
+
+### Phase 2 — Design
+
+Author architecture decision records (ADRs) and integration interface
+specifications. References, diagrams, acceptance criteria. No code.
+
+- D2.1 Unified agent-lifecycle state machine spec
+  (init → ready → running → suspended → migrating → terminated → cleaned).
+- D2.2 Orchestration ↔ MCP integration contract: how orchestrated agents
+  surface as MCP tools, capability auto-derivation rules.
+- D2.3 Lifecycle ↔ event-bus contract: delivery guarantees per state,
+  queueing on starting, drop-on-terminated semantics.
+- D2.4 Policy attachment model: per-agent vs per-group, evaluation order,
+  conflict resolution (deny-overrides default).
+- D2.5 Mobility protocol: snapshot format, transport, rollback checkpoints,
+  cross-host messaging.
+- D2.6 DevOps template matrix: which orchestration topologies and which CI
+  systems are first-class.
+
+### Phase 3 — Build
+
+Implement per-repo work packages. Each work package is owned by exactly one
+repository; integration points are exercised through interface contracts
+defined in Phase 2.
+
+- B3.1 Agentora orchestration core (WP-001).
+- B3.2 AgentMCP protocol server + Agentora bridge (WP-002).
+- B3.3 agent-wave bus + lifecycle integration (WP-003).
+- B3.4 agentops-policy-federation distribution + enforcement (WP-004).
+- B3.5 helMo mobility + orchestration hooks (WP-005).
+- B3.6 agent-devops-setups templates (WP-006).
+
+### Phase 4 — Test / Validate
+
+Per-repo unit + integration suites, then cross-repo end-to-end scenarios.
+
+- V4.1 Per-repo quality gates: workspace test, clippy with warnings denied,
+  fmt check.
+- V4.2 Multi-agent orchestration scenario (leader-follower, peer-to-peer).
+- V4.3 MCP-client-driven agent invocation through AgentMCP → Agentora.
+- V4.4 Event-routing scenario across three agents with policy enforcement.
+- V4.5 Mobility scenario with rollback and cross-host messaging.
+- V4.6 Template smoke: dry-run lint of every devops template.
+
+### Phase 5 — Deploy / Handoff
+
+- H5.1 Publish per-repo CHANGELOG entries; tag with CalVer/SemVer per repo
+  policy.
+- H5.2 Update org-pages portfolio entry referencing the unified framework.
+- H5.3 Update `repos/worklogs/ARCHITECTURE.md` with the integration ADR
+  pointers.
+- H5.4 Hand off open follow-ups (device-automation, plugin system) to
+  specs 011 and 015 via tracker updates.
+
+## Dependency DAG
+
+| Phase | Task ID | Description | Depends On |
+|-------|---------|-------------|------------|
+| 1 | D1.1 | Audit Agentora orchestration | — |
+| 1 | D1.2 | Audit AgentMCP protocol | — |
+| 1 | D1.3 | Audit agent-wave events | — |
+| 1 | D1.4 | Audit agentops-policy-federation | — |
+| 1 | D1.5 | Audit helMo mobility | — |
+| 1 | D1.6 | Audit agent-devops-setups | — |
+| 1 | D1.7 | Cross-repo reuse audit | D1.1–D1.6 |
+| 2 | D2.1 | Unified lifecycle state machine spec | D1.1, D1.7 |
+| 2 | D2.2 | Orchestration ↔ MCP contract | D1.1, D1.2, D2.1 |
+| 2 | D2.3 | Lifecycle ↔ event-bus contract | D1.3, D2.1 |
+| 2 | D2.4 | Policy attachment model | D1.4, D2.1 |
+| 2 | D2.5 | Mobility protocol | D1.5, D2.1 |
+| 2 | D2.6 | DevOps template matrix | D1.6, D2.1–D2.5 |
+| 3 | WP-001 | Agentora orchestration build | D2.1 |
+| 3 | WP-002 | AgentMCP build | WP-001, D2.2 |
+| 3 | WP-003 | agent-wave build | WP-001, D2.3 |
+| 3 | WP-004 | agentops-policy-federation build | WP-001, D2.4 |
+| 3 | WP-005 | helMo build | WP-001, D2.5 |
+| 3 | WP-006 | agent-devops-setups build | WP-001..WP-005, D2.6 |
+| 4 | V4.1 | Per-repo quality gates | WP-001..WP-006 |
+| 4 | V4.2 | Multi-agent orchestration scenario | WP-001 |
+| 4 | V4.3 | MCP-client → Agentora scenario | WP-001, WP-002 |
+| 4 | V4.4 | Event + policy scenario | WP-001, WP-003, WP-004 |
+| 4 | V4.5 | Mobility scenario | WP-001, WP-005 |
+| 4 | V4.6 | Template smoke | WP-006 |
+| 5 | H5.1 | CHANGELOG + tag | V4.1–V4.6 |
+| 5 | H5.2 | Org-pages portfolio update | H5.1 |
+| 5 | H5.3 | ARCHITECTURE worklog update | H5.1 |
+| 5 | H5.4 | Handoff to specs 011, 015 | H5.1 |
+
+Critical path: D1.1 → D1.7 → D2.1 → WP-001 → WP-002 → V4.3 → H5.1 → H5.4
+(8 nodes). After WP-001, WP-002..WP-005 fan out in parallel; WP-006 is the
+final convergence node before validation.
+
+## Effort Profile (agent-led)
+
+Per global "Timescales: Agent-Led, Aggressive Estimates" — quoted in tool
+calls / parallel subagents / wall-clock minutes. No human checkpoints.
+
+| Phase | Profile | Wall-clock target |
+|-------|---------|-------------------|
+| 1 — Discovery | 6 parallel `Explore` subagents (one per repo) + 1 reuse audit | 8–12 min |
+| 2 — Design | 3 parallel design subagents on independent contracts; lifecycle anchor sequenced first | 10–15 min |
+| 3 — Build (WP-001) | Major refactor: 3–5 parallel `general-purpose` subagents, 15–30 tool calls | 15–20 min |
+| 3 — Build (WP-002..WP-005) | 4 cross-stack features in parallel, each 8–15 tool calls | 12–18 min |
+| 3 — Build (WP-006) | Small feature, 3–6 tool calls | ~3 min |
+| 4 — Test / Validate | Per-repo gates parallel; scenarios sequential on shared harness | 8–12 min |
+| 5 — Deploy / Handoff | 4 small docs/tag tasks in parallel | 3–5 min |
+
+Total wall-clock budget: ~60–90 min of orchestrated agent activity, no human
+intervention beyond initial prompt and merge approvals.
+
+## Risks & Mitigations
+
+Inherits and refines `spec.md` "Risks" table:
+
+- **Integration drift between repos** — bind each integration contract to a
+  versioned interface in `phenotype-shared`; CI lints downstream consumers
+  against the published contract.
+- **Quality-gate fan-out cost** — run per-repo gates in parallel, never
+  serially; respect the 4-concurrent cargo cap from disk-budget policy.
+- **Cross-repo PR sequencing** — gate WP-002..WP-005 PRs behind the WP-001
+  contract crate version bump rather than coordinating six PRs by hand.
+- **Doc + worklog rot** — Phase 5 explicitly updates ARCHITECTURE worklog and
+  org-pages so this work does not become invisible after merge.
+
+## Out-of-Scope Confirmations
+
+Mirrors `spec.md` "Non-Goals". No new agent types, no UI/UX, no marketplace,
+no training/fine-tuning. Device-automation rebuilds (KDesktopVirt /
+KVirtualStage / kmobile) remain owned by spec 011.
+
+## Traces
+
+- `spec.md` (this directory) — normative scope.
+- Spec 007 — thegent-completion (consumer of orchestration).
+- Spec 015 — plugin-system-completion (peer integration surface).
+- Spec 001 — spec-driven-development-engine (workflow substrate).
+- Memory: `session_2026_04_22_cheap_llm_build.md` — reused dispatch contract.

--- a/kitty-specs/016-agent-framework-expansion/tasks.md
+++ b/kitty-specs/016-agent-framework-expansion/tasks.md
@@ -1,253 +1,260 @@
 # Work Packages: Agent Framework Expansion — Complete Across 6 Repositories
 
-**Inputs**: Design documents from `kitty-specs/016-agent-framework-expansion/`
-**Prerequisites**: spec.md, Rust toolchain, MCP protocol knowledge
-**Scope**: Cross-repo (6 repositories): Agentora, AgentMCP, agent-wave, agentops-policy-federation, helMo, agent-devops-setups
+> Specification: `spec.md` · Plan: `plan.md` · Spec ID: `AgilePlus-016`
+>
+> Planner mandate: deliverables, acceptance criteria, references, dependencies.
+> No code, no shell snippets. Implementers own all source-level decisions.
+
+**Inputs:** `spec.md`, `plan.md`, repo CLAUDE.md files for each affected repo,
+`phenotype-shared` crate APIs, MCP specification (referenced in `spec.md`).
+
+**Prerequisites:** Phase 1 (Discovery) and Phase 2 (Design) tasks from
+`plan.md` complete; reuse audit logged in `repos/worklogs/RESEARCH.md`.
+
+**Scope:** Six repositories — Agentora, AgentMCP, agent-wave,
+agentops-policy-federation, helMo, agent-devops-setups.
 
 ---
 
 ## WP-001: Agentora — Complete Agent Orchestration Framework
 
-- **State:** planned
-- **Sequence:** 1
-- **File Scope:** Agentora repository (src/, tests/, docs/)
-- **Acceptance Criteria:**
-  - Multi-agent coordination with leader-follower and peer-to-peer patterns
-  - Agent task decomposition and assignment engine
-  - Unified agent lifecycle management across all orchestrated agents
-  - Integration hooks for MCP protocol (AgentMCP), event communication (agent-wave), and policy (agentops-policy-federation)
-  - ≥80% test coverage on orchestration core
-  - All quality checks passing
-- **Estimated Effort:** L
+- **Phase:** 3 — Build
+- **Sequence:** 1 (gates WP-002..WP-005)
+- **Owner Repo:** Agentora
+- **File Scope:** Agentora `src/`, `tests/`, `docs/`
+- **Depends On:** Plan task D2.1 (lifecycle state-machine spec)
+- **Estimated Effort:** Major refactor — 3–5 parallel build subagents,
+  15–30 tool calls, ~15–20 min wall clock.
 
-Complete Agentora as the central agent orchestration framework. Agentora coordinates multiple agents, decomposes tasks, assigns work, and manages the unified agent lifecycle. This is the backbone that all other agent framework components integrate with.
+### Deliverables
 
-### Subtasks
-- [ ] T001 Audit current Agentora state: existing orchestration code, gaps, dependencies
-- [ ] T002 Design multi-agent coordination architecture: leader-follower, peer-to-peer, broadcast
-- [ ] T003 Implement AgentOrchestrator: create, manage, and coordinate agent groups
-- [ ] T004 Implement task decomposition engine: break complex tasks into subtasks, assign to agents
-- [ ] T005 Implement agent coordination patterns: leader election, task distribution, result aggregation
-- [ ] T006 Implement unified agent lifecycle: initialize, start, monitor, stop, cleanup
-- [ ] T007 Define integration interfaces for MCP, event communication, policy, and mobility
-- [ ] T008 Implement health monitoring: agent heartbeat, failure detection, recovery
-- [ ] T009 Write unit tests for orchestration core (target: ≥80% coverage)
-- [ ] T010 Write integration tests: multi-agent task execution with mock agents
-- [ ] T011 Add comprehensive rustdoc with orchestration examples
-- [ ] T012 Run quality checks: `cargo test`, `cargo clippy -- -D warnings`, `cargo fmt`
+- Multi-agent coordination supporting leader-follower and peer-to-peer
+  patterns, with a documented choice point for broadcast.
+- Task decomposition + assignment engine.
+- Unified agent-lifecycle implementation matching the D2.1 state-machine spec.
+- Integration interfaces (trait surface) consumed by WP-002, WP-003, WP-004,
+  WP-005. Interfaces published as a versioned crate contract for downstream
+  pinning.
+- Health monitoring: heartbeat, failure detection, recovery hooks.
+- Reuse: build on `phenotype-state-machine` and `phenotype-event-sourcing`
+  rather than re-implementing FSM or audit log primitives.
 
-### Dependencies
-- None (starting WP for this spec)
+### Acceptance Criteria
 
-### Risks & Mitigations
-- Orchestration complexity: Start with leader-follower pattern, add peer-to-peer incrementally
-- Agent failure handling: Implement retry with checkpoint, graceful degradation
+- All deliverables present and exercised by tests.
+- ≥80% line coverage on orchestration core.
+- Multi-agent integration test demonstrates leader-follower and peer-to-peer
+  coordination through public interfaces only.
+- Per-repo Phase 4 gates green (V4.1).
+- Public APIs documented; coordination examples included in repo docs.
+- No suppressions added to bypass clippy or test failures.
+
+### Risks
+
+- Orchestration complexity → start from leader-follower, layer peer-to-peer.
+- Failure recovery semantics → use checkpoint-based retry; document drop
+  vs replay semantics per lifecycle state.
 
 ---
 
-## WP-002: AgentMCP — Implement MCP Protocol Server
+## WP-002: AgentMCP — MCP Protocol Server + Agentora Bridge
 
-- **State:** planned
+- **Phase:** 3 — Build
 - **Sequence:** 2
-- **File Scope:** AgentMCP repository (src/, tests/, docs/)
-- **Acceptance Criteria:**
-  - Complete MCP protocol server implementation (tools, resources, prompts, sampling)
-  - Integrated with Agentora orchestration layer (agents exposed as MCP tools)
-  - MCP tool definitions auto-generated from agent capabilities
-  - MCP resource serving for agent state and results
-  - ≥80% test coverage on MCP server
-  - All quality checks passing
-- **Estimated Effort:** M
+- **Owner Repo:** AgentMCP
+- **File Scope:** AgentMCP `src/`, `tests/`, `docs/`
+- **Depends On:** WP-001 (orchestrator interfaces), plan task D2.2 (MCP
+  contract).
+- **Estimated Effort:** Cross-stack feature — 8–15 tool calls, ~12 min.
 
-Implement the Model Context Protocol (MCP) server in AgentMCP and integrate it with Agentora's orchestration layer. This exposes agent capabilities as MCP tools, enabling external MCP clients to interact with the agent framework.
+### Deliverables
 
-### Subtasks
-- [ ] T013 Audit current AgentMCP state: existing MCP implementation, protocol coverage
-- [ ] T014 Complete MCP tool server: register tools, handle tool calls, return results
-- [ ] T015 Implement MCP resource server: serve agent state, results, and metadata
-- [ ] T016 Implement MCP prompt server: provide structured prompts for agent interactions
-- [ ] T017 Implement MCP sampling: server-initiated analysis requests
-- [ ] T018 Integrate with Agentora: expose orchestrated agents as MCP tools
-- [ ] T019 Implement MCP tool auto-generation from agent capability definitions
-- [ ] T020 Write unit tests for MCP protocol handlers (target: ≥80% coverage)
-- [ ] T021 Write integration tests: MCP client calling agent tools via AgentMCP
-- [ ] T022 Add rustdoc with MCP server setup and tool definition examples
-- [ ] T023 Run quality checks: `cargo test`, `cargo clippy -- -D warnings`, `cargo fmt`
+- MCP protocol server: tools, resources, prompts, sampling. Conformance
+  references the official MCP specification cited in `spec.md`.
+- Agentora bridge: orchestrated agents surface as MCP tools; tool
+  definitions auto-derived from agent capability metadata published by
+  WP-001.
+- MCP resource endpoints serving agent state and run results.
+- MCP version negotiation with documented supported range.
 
-### Dependencies
-- WP-001 (Agentora orchestration layer available for integration)
+### Acceptance Criteria
 
-### Risks & Mitigations
-- MCP spec compliance: Reference official MCP specification, test against MCP conformance
-- Protocol versioning: Support MCP version negotiation, document supported versions
+- ≥80% coverage on protocol handlers.
+- Integration test: external MCP client invokes an Agentora-managed agent
+  end-to-end and receives a result.
+- Per-repo Phase 4 gates green.
+- No suppressions; protocol non-conformance treated as a defect, not a
+  documented exception.
+
+### Risks
+
+- Protocol drift → pin to MCP version in tests; surface negotiation failures
+  loudly per "Optionality and Failure Behavior."
 
 ---
 
 ## WP-003: agent-wave — Event-Driven Agent Communication
 
-- **State:** planned
-- **Sequence:** 3
-- **File Scope:** agent-wave repository (src/, tests/, docs/)
-- **Acceptance Criteria:**
-  - Event-driven communication integrated with agent lifecycle
-  - Event routing and filtering by type, source, and priority
-  - Publish/subscribe pattern for agent-to-agent messaging
-  - Event persistence and replay for debugging
-  - Integration with Agentora for lifecycle-aware event delivery
-  - ≥80% test coverage on event system
-  - All quality checks passing
-- **Estimated Effort:** M
+- **Phase:** 3 — Build
+- **Sequence:** 3 (parallel with WP-002, WP-004, WP-005 after WP-001)
+- **Owner Repo:** agent-wave
+- **File Scope:** agent-wave `src/`, `tests/`, `docs/`
+- **Depends On:** WP-001 (lifecycle hooks), plan task D2.3 (bus contract).
+- **Estimated Effort:** Cross-stack feature — 8–15 tool calls, ~12 min.
 
-Complete agent-wave as the event-driven communication layer for agent-to-agent messaging. Events are integrated with the agent lifecycle, ensuring proper delivery, routing, and filtering. This enables asynchronous coordination between agents.
+### Deliverables
 
-### Subtasks
-- [ ] T024 Audit current agent-wave state: existing event system, routing, gaps
-- [ ] T025 Design event schema: event types, payloads, metadata (source, timestamp, priority)
-- [ ] T026 Implement event bus: publish, subscribe, unsubscribe with topic-based routing
-- [ ] T027 Implement event filtering: by type, source agent, priority, custom predicates
-- [ ] T028 Integrate with Agentora lifecycle: deliver events only to running agents, queue for starting
-- [ ] T029 Implement event persistence: store events for replay, debugging, and audit
-- [ ] T030 Implement event replay: replay events from history for debugging and testing
-- [ ] T031 Write unit tests for event bus and routing (target: ≥80% coverage)
-- [ ] T032 Write integration tests: multi-agent event communication via agent-wave
-- [ ] T033 Add rustdoc with event system setup and usage examples
-- [ ] T034 Run quality checks: `cargo test`, `cargo clippy -- -D warnings`, `cargo fmt`
+- Event bus with publish / subscribe / unsubscribe and topic-based routing.
+- Filter expressions: type, source agent, priority, custom predicates.
+- Lifecycle-aware delivery: queue on `starting`, deliver on `running`, drop
+  with audit on `terminated`.
+- Event persistence + replay backed by `phenotype-event-sourcing`.
+- Reuse: do not re-implement the hash-chained log; depend on
+  `phenotype-event-sourcing`.
 
-### Dependencies
-- WP-001 (Agentora lifecycle available for event delivery integration)
+### Acceptance Criteria
 
-### Risks & Mitigations
-- Event ordering: Implement causal ordering for related events, document ordering guarantees
-- Event volume: Implement rate limiting, backpressure, and event deduplication
+- ≥80% coverage on bus + routing.
+- Integration test: three agents exchange events under back-pressure with
+  documented ordering guarantees.
+- Per-repo Phase 4 gates green.
+
+### Risks
+
+- Event volume → rate limiting and dedup at publish.
+- Ordering → causal ordering for related events; document guarantees.
 
 ---
 
-## WP-004: agentops-policy-federation — Policy Distribution Across Agents
+## WP-004: agentops-policy-federation — Policy Distribution
 
-- **State:** planned
-- **Sequence:** 4
-- **File Scope:** agentops-policy-federation repository (src/, tests/, docs/)
-- **Acceptance Criteria:**
-  - Policy distribution integrated with Agentora orchestration
-  - Policy enforcement at agent level (per-agent policy evaluation)
-  - Policy distribution across agent groups with versioning
-  - Policy conflict detection and resolution
-  - ≥80% test coverage on policy system
-  - All quality checks passing
-- **Estimated Effort:** M
+- **Phase:** 3 — Build
+- **Sequence:** 4 (parallel with WP-002, WP-003, WP-005)
+- **Owner Repo:** agentops-policy-federation
+- **File Scope:** agentops-policy-federation `src/`, `tests/`, `docs/`
+- **Depends On:** WP-001 (group/agent surfaces), plan task D2.4 (policy
+  attachment model).
+- **Estimated Effort:** Cross-stack feature — 8–15 tool calls, ~12 min.
 
-Complete agentops-policy-federation for policy distribution and enforcement across agents. Policies are distributed to agent groups, enforced at the agent level, and versioned for consistency. This ensures agents operate within defined constraints.
+### Deliverables
 
-### Subtasks
-- [ ] T035 Audit current agentops-policy-federation: existing policy code, distribution mechanism
-- [ ] T036 Design policy schema: policy rules, scopes, priorities, versioning
-- [ ] T037 Implement policy distribution: push policies to agent groups, version tracking
-- [ ] T038 Implement policy enforcement: evaluate policies before agent actions
-- [ ] T039 Integrate with Agentora: attach policies to agent groups, enforce during orchestration
-- [ ] T040 Implement policy conflict detection: detect conflicting rules, resolution strategies
-- [ ] T041 Implement policy audit: log policy evaluations, violations, and overrides
-- [ ] T042 Write unit tests for policy distribution and enforcement (target: ≥80%)
-- [ ] T043 Write integration tests: policy enforcement across multi-agent scenarios
-- [ ] T044 Add rustdoc with policy definition and distribution examples
-- [ ] T045 Run quality checks: `cargo test`, `cargo clippy -- -D warnings`, `cargo fmt`
+- Policy schema with rules, scopes, priorities, versioning.
+- Distribution: push to agent groups; version tracking.
+- Enforcement at agent level; deny-overrides default per D2.4.
+- Conflict detection + resolution.
+- Audit log of evaluations, violations, overrides — backed by
+  `phenotype-event-sourcing`.
+- Reuse: build on `phenotype-policy-engine` rather than authoring a parallel
+  rule evaluator.
 
-### Dependencies
-- WP-001 (Agentora orchestration available for policy attachment)
+### Acceptance Criteria
 
-### Risks & Mitigations
-- Policy enforcement performance: Cache policy evaluations, optimize hot paths
-- Policy conflicts: Implement clear resolution strategy (priority-based, deny-overrides)
+- ≥80% coverage on distribution + enforcement.
+- Integration test: multi-agent scenario with conflicting policies; expected
+  resolution outcome verified.
+- Per-repo Phase 4 gates green.
+
+### Risks
+
+- Enforcement performance → cache policy evaluations; benchmark hot paths.
+- Conflict semantics → resolution rule made explicit in docs and tests.
 
 ---
 
-## WP-005: helMo — Agent Mobility and Communication
+## WP-005: helMo — Agent Mobility
 
-- **State:** planned
-- **Sequence:** 5
-- **File Scope:** helMo repository (src/, tests/, docs/)
-- **Acceptance Criteria:**
-  - Agent mobility implementation: migrate agent state between hosts
-  - Integrated with Agentora orchestration (mobility as orchestration action)
-  - State serialization and deserialization for agent migration
-  - Communication between mobile agents and stationary agents
-  - Rollback mechanisms for failed migrations
-  - ≥80% test coverage on mobility core
-  - All quality checks passing
-- **Estimated Effort:** M
+- **Phase:** 3 — Build
+- **Sequence:** 5 (parallel with WP-002, WP-003, WP-004)
+- **Owner Repo:** helMo
+- **File Scope:** helMo `src/`, `tests/`, `docs/`
+- **Depends On:** WP-001 (lifecycle + orchestrator action surface), plan
+  task D2.5 (mobility protocol).
+- **Estimated Effort:** Cross-stack feature — 8–15 tool calls, ~12 min.
 
-Complete helMo for agent mobility — the ability to migrate agent state between hosts. This enables load balancing, fault tolerance, and dynamic resource allocation. helMo integrates with Agentora for orchestration-aware mobility.
+### Deliverables
 
-### Subtasks
-- [ ] T046 Audit current helMo state: existing mobility prototype, serialization approach
-- [ ] T047 Design agent state serialization format: what to serialize, what to reconstruct
-- [ ] T048 Implement state serialization: capture agent context, memory, and execution state
-- [ ] T049 Implement state deserialization: reconstruct agent on target host
-- [ ] T050 Implement agent migration: coordinate source and target hosts, transfer state
-- [ ] T051 Integrate with Agentora: mobility as orchestration action, lifecycle-aware migration
-- [ ] T052 Implement rollback: revert migration on failure, restore original agent state
-- [ ] T053 Implement mobile-stationary agent communication: messaging across migration boundaries
-- [ ] T054 Write unit tests for serialization and migration (target: ≥80% coverage)
-- [ ] T055 Write integration tests: agent migration between mock hosts
-- [ ] T056 Add rustdoc with mobility setup and migration examples
-- [ ] T057 Run quality checks: `cargo test`, `cargo clippy -- -D warnings`, `cargo fmt`
+- Snapshot format for agent state, memory, execution context.
+- Capture + restore implementation honoring D2.5 protocol.
+- Migration coordinator: source ↔ target host handshake, transfer, commit.
+- Rollback on failure with checkpoint restore.
+- Mobile ↔ stationary agent messaging across migration boundaries.
 
-### Dependencies
-- WP-001 (Agentora orchestration for mobility actions)
+### Acceptance Criteria
 
-### Risks & Mitigations
-- State serialization completeness: Thorough testing of agent state capture, document limitations
-- Migration failures: Implement checkpoint-based rollback, test failure scenarios extensively
+- ≥80% coverage on serialization + migration.
+- Integration test: mock multi-host migration with induced failure +
+  rollback.
+- Per-repo Phase 4 gates green.
+
+### Risks
+
+- State capture completeness → enumerate captured fields in docs; treat
+  uncaptured state as a documented defect, not silent loss.
+- Migration failure → checkpoint-based rollback exercised in tests.
 
 ---
 
-## WP-006: agent-devops-setups — CI/CD Templates for Agent Projects
+## WP-006: agent-devops-setups — CI/CD + Deployment Templates
 
-- **State:** planned
+- **Phase:** 3 — Build (final convergence)
 - **Sequence:** 6
-- **File Scope:** agent-devops-setups repository (templates/, docs/)
-- **Acceptance Criteria:**
-  - CI/CD templates for agent projects (GitHub Actions, GitLab CI)
-  - Templates integrate with Agentora, AgentMCP, agent-wave, and policy-federation
-  - Deployment templates for agent orchestration clusters
-  - Monitoring and alerting templates for agent health
-  - Documentation for all templates with usage examples
-  - All templates validated (lint, dry-run)
-- **Estimated Effort:** S
+- **Owner Repo:** agent-devops-setups
+- **File Scope:** agent-devops-setups `templates/`, `docs/`
+- **Depends On:** WP-001 through WP-005 + plan task D2.6 (template matrix).
+- **Estimated Effort:** Small feature — 3–6 tool calls, ~3 min.
 
-Complete agent-devops-setups with CI/CD templates for deploying and managing agent projects. Templates cover GitHub Actions, GitLab CI, deployment configurations, and monitoring setups for the full agent framework.
+### Deliverables
 
-### Subtasks
-- [ ] T058 Audit current agent-devops-setups: existing templates, gaps
-- [ ] T059 Create GitHub Actions template for agent project CI (build, test, lint)
-- [ ] T060 Create GitHub Actions template for agent deployment (orchestration cluster)
-- [ ] T061 Create GitLab CI template mirroring GitHub Actions functionality
-- [ ] T062 Create deployment template: Docker Compose for agent orchestration cluster
-- [ ] T063 Create monitoring template: Prometheus + Grafana dashboards for agent health
-- [ ] T064 Create alerting template: alert rules for agent failures, policy violations
-- [ ] T065 Validate all templates: lint, dry-run, verify syntax
-- [ ] T066 Document all templates with setup instructions and customization guide
-- [ ] T067 Create example agent project using all templates end-to-end
+- GitHub Actions templates: agent-project CI (build, test, lint) and
+  orchestration-cluster deployment.
+- GitLab CI templates mirroring functionality.
+- Deployment template for an orchestration cluster (container + manifest).
+- Monitoring template (Prometheus + Grafana dashboards) for agent health.
+- Alerting template covering agent failure and policy violations.
+- End-to-end example agent project consuming all templates.
+- Compliance: templates conform to Phenotype scripting hierarchy — no new
+  shell beyond ≤5-line glue with inline justification.
 
-### Dependencies
-- WP-001 through WP-005 (agent framework components available for template integration)
+### Acceptance Criteria
 
-### Risks & Mitigations
-- Template drift: Pin dependency versions in templates, document update process
-- Platform compatibility: Test templates on both GitHub Actions and GitLab CI
+- All templates pass platform-native lint + dry-run.
+- Documentation includes per-template setup and customization steps.
+- Example project boots through CI green.
+- Per-repo Phase 4 gates green (V4.6).
+
+### Risks
+
+- Template drift → pin upstream actions/images by digest where possible;
+  document update cadence.
+- Cross-platform parity → tested on both GitHub Actions and GitLab CI.
 
 ---
 
-## Dependency & Execution Summary
+## Dependency Summary
 
 ```
-WP-001 (Agentora orchestration) ─────── first, no deps
-WP-002 (AgentMCP protocol) ──────────── depends on WP-001
-WP-003 (agent-wave events) ──────────── depends on WP-001 (parallel with WP-002)
-WP-004 (agentops-policy-federation) ─── depends on WP-001 (parallel with WP-002, WP-003)
-WP-005 (helMo mobility) ─────────────── depends on WP-001 (parallel with WP-002, WP-003, WP-004)
-WP-006 (agent-devops-setups) ────────── depends on WP-001 through WP-005
+                    ┌── WP-002 (AgentMCP) ──┐
+WP-001 (Agentora) ──┼── WP-003 (agent-wave) ┼── WP-006 (devops-setups)
+                    ├── WP-004 (policy-fed) ─┤
+                    └── WP-005 (helMo) ──────┘
 ```
 
-**Parallelization**: WP-002 through WP-005 can run in parallel after WP-001. WP-006 is the final integration step.
+WP-001 is the gate; WP-002..WP-005 fan out in parallel; WP-006 converges.
 
-**MVP Scope**: WP-001 alone provides agent orchestration. WP-002 adds MCP protocol support for external integration.
+## Phase 4 Validation Hook
+
+Each WP must satisfy `plan.md` V4.x acceptance before its WP closes. Cross-repo
+scenarios (V4.2..V4.5) are owned by Phase 4 and may flag regressions back into
+the originating WP. WP-006 is gated on V4.6.
+
+## Phase 5 Handoff
+
+On Phase 4 sign-off, plan tasks H5.1..H5.4 update CHANGELOGs, the org-pages
+portfolio entry, and `repos/worklogs/ARCHITECTURE.md`. Open follow-ups
+(device-automation, plugin system) are routed to specs 011 and 015.
+
+## MVP Note
+
+Spec MVP slice is WP-001 alone (orchestration-only). WP-001 + WP-002 yields
+external MCP-client integration. Full success criteria (`spec.md`) require
+all six WPs.


### PR DESCRIPTION
## **User description**
## Summary

- Rewrites `kitty-specs/016-agent-framework-expansion/plan.md` and `tasks.md` to comply with global CLAUDE.md planner mandates (no code in plans, phased WBS, explicit DAG, agent-led aggressive timescales).
- `plan.md` now structures work as Phase 1-5 (Discovery -> Design -> Build -> Test/Validate -> Deploy/Handoff) with a Phase | Task ID | Description | Depends On table and an 8-node critical path.
- `tasks.md` restates WP-001..WP-006 against the new DAG, removes embedded cargo command snippets, adds Phenotype Org Cross-Project Reuse mandates pointing at phenotype-state-machine / phenotype-event-sourcing / phenotype-policy-engine, and disallows suppressions.

Spec ID: AgilePlus-016 (IN_PROGRESS) — no scope changes; only plan + tasks docs.

## Test plan

- [ ] No code/shell snippets remain in plan.md or tasks.md
- [ ] DAG table parses (Phase | Task ID | Description | Depends On)
- [ ] Critical path traceable end-to-end
- [ ] WP-001..WP-006 preserved with acceptance criteria intact

Generated with Claude Code (Opus 4.7 1M ctx)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes that restructure the spec’s execution plan and work packages without modifying any production code or behavior.
> 
> **Overview**
> Rewrites `kitty-specs/016-agent-framework-expansion/plan.md` into a phased (Discovery→Handoff) work-breakdown structure, adding an explicit dependency DAG table, critical path, effort profile, and cross-project reuse audit requirements.
> 
> Reworks `tasks.md` to align WP-001..WP-006 with the new DAG, replacing subtask checklists with standardized deliverables/acceptance criteria/risks, tightening reuse mandates (e.g., `phenotype-*` crates), and explicitly disallowing code/shell snippets and quality-gate suppressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 358bbb3fe189bed26cfd1c01463ef39822e43abc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
Rewrite spec 016 into a phased execution plan with explicit dependencies and work packages

### What Changed
- Reworked `plan.md` into a Discovery → Design → Build → Test/Validate → Deploy/Handoff flow with a dependency table and critical path
- Added required reuse checks, scope limits, risks, and handoff steps so the plan reads as an execution guide instead of a loose task list
- Reworked `tasks.md` so each work package now includes clear deliverables, acceptance criteria, dependencies, and repo ownership
- Removed shell and code snippets from the planning docs and added explicit reuse mandates for shared Phenotype crates

### Impact
`✅ Clearer delivery path for the agent framework rollout`
`✅ Fewer missed dependencies between repositories`
`✅ Less rework from duplicated shared logic`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=2-J60ofzTfMv5k2Mnb3GT0t3Q8_rfx1BCP0rOf0JSGo&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
