### PR TITLE
fix(dashboard): resolve route conflicts with agileplus-api router

### DIFF
--- a/crates/agileplus-dashboard/src/routes.rs
+++ b/crates/agileplus-dashboard/src/routes.rs
@@ -2178,7 +2178,10 @@ pub fn router(state: SharedState) -> Router {
         .route("/features", get(features_page))
         .route("/features/{id}", get(feature_page))
         .route("/events", get(events_page))
-        .route("/health", get(health_page))
+        // NOTE: /health is owned by agileplus-api (router.rs, T070, detailed
+        // JSON health). The HTML health page lives at /health-page to avoid
+        // a route conflict panic when build_router merges the two routers.
+        .route("/health-page", get(health_page))
         .route("/settings", get(settings_page))
         .route("/settings/plane", get(plane_settings_page))
         .route("/settings/agents", get(agent_settings_page))
@@ -2225,7 +2228,9 @@ pub fn router(state: SharedState) -> Router {
         )
         .route("/api/time", get(time_footer))
         .route("/api/stream", get(sse_stream))
-        .route("/api/v1/stream", get(sse_stream))
+        // NOTE: /api/v1/stream is owned by agileplus-api (router.rs, T069).
+        // Previously this crate registered an alias (#334), but that caused a
+        // route conflict panic when build_router merged the two routers.
         .route("/api/stream-placeholder", get(stream_placeholder))
         .route(
             "/api/evidence/{feature_id}/{artifact_id}/content",


### PR DESCRIPTION
## **User description**
## Summary

P0 fix: 14 `agileplus-api` integration tests were failing because Axum's `Router::merge` panics on overlapping routes when `agileplus-api::create_router` merges the dashboard router.

Two collisions were present:
- `GET /api/v1/stream` — registered by both api (T069 SSE, owner) and dashboard (alias added in #334)
- `GET /health` — registered by both api (T070 detailed JSON, owner) and dashboard (HTML page)

## Resolution

`agileplus-api` owns these routes per its module rustdoc and traceability tags. Dashboard now:
- Drops the `/api/v1/stream` alias (api owns SSE streaming)
- Moves the HTML health page from `/health` to `/health-page` (api owns `/health` JSON)

## Before / After

- Before: 0/14 `agileplus-api` integration tests passing (all panic at startup)
- After: 14/14 passing; `agileplus-dashboard` tests still 8/8

## Test plan

- [x] `cargo test -p agileplus-api --test api_integration` -> 14 passed
- [x] `cargo test -p agileplus-dashboard` -> 8 passed
- [ ] CI (expected to fail on billing constraint per org policy)

## Notes

Pre-push hook surfaced 4 pre-existing unrelated failures (`agileplus-cli` cli_integration, `agileplus-plane` lib, `agileplus-api`/`agileplus-telemetry` doctests). Confirmed present on `origin/main` independent of this change. Out of scope for this duplicate-route fix; tracked separately.

Generated with Claude Code

<!-- CURSOR_SUMMARY -->

> [!NOTE]
> **Medium Risk**
> Changes public route paths by moving the dashboard HTML health page to `/health-page` and removing the `/api/v1/stream` alias, which can break existing links/clients but reduces startup panics from overlapping routes.
> 
> **Overview**
> Resolves `axum::Router::merge` panics when `agileplus-dashboard` is merged into `agileplus-api` by eliminating overlapping route registrations.
> 
> The dashboard no longer serves `GET /health` (now `GET /health-page`) and drops its `GET /api/v1/stream` alias (leaving only `GET /api/stream`), with inline notes clarifying `agileplus-api` as the owner of the canonical endpoints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ec4ed49b5cf7d4e77ade10f1ec21e9e8102f3a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
Stop dashboard routes from colliding with API routes

### What Changed
- Moved the dashboard HTML health page from `/health` to `/health-page` so it no longer conflicts with the API’s health endpoint
- Removed the dashboard alias at `/api/v1/stream`, leaving the API as the single owner of that stream route
- Prevents router startup panics when the dashboard and API routers are loaded together

### Impact
`✅ Fewer startup crashes`
`✅ More reliable dashboard and API loading`
`✅ Fewer broken route conflicts for integration tests`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=MvCRifh3Y2HFrD6v39LvDuoKSHkGx65ifENOJYqLqzU&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
