### PR TITLE
spec(013): mark phenotype-infrakit-stabilization CANCELLED

### DIFF
--- a/kitty-specs/013-phenotype-infrakit-stabilization/spec.md
+++ b/kitty-specs/013-phenotype-infrakit-stabilization/spec.md
@@ -1,3 +1,7 @@
+status: CANCELLED
+
+> **CANCELLED 2026-04-26** — superseded by Phase 1 libification (memory: `session_2026_03_29_libification.md`) which migrated the consolidation targets (`phenotype-error-core`, `phenotype-health`, `phenotype-config-core`) into **phenoShared/pheno/PhenoKits**. Target repo `KooshaPari/phenotype-infrakit` was archived 2026-04-06 (memory: `reference_archived_repos_locked.md`). Per-repo releases (Authvault, Tokn v0.1.1, PolicyStack v0.1.0, Httpora) shipped independently in 2026-04-25 wave (memory: `reference_session_2026_04_25_releases.md`). Only residual follow-up — verify all phenoShared consumers have no dangling `phenotype-infrakit::*` imports — has been folded into spec 021-polyrepo-ecosystem-stabilization.
+
 # phenotype-infrakit Stabilization
 
 ## Meta


### PR DESCRIPTION
## **User description**
## Summary
- Marks `kitty-specs/013-phenotype-infrakit-stabilization/spec.md` as CANCELLED
- Target repo archived 2026-04-06; consolidation work superseded by Phase 1 libification into phenoShared/pheno/PhenoKits + per-repo release waves
- Residual phenoShared-consumer verify follow-up folded into spec 021

## Context
- Cherry-picked from canonical `main` (commit e076ad3) to unblock 2-ahead/4-behind divergence with `origin/main`
- Companion local commit (a59c681 README RED-rewrite) NOT included — conflicts with merged PR #410; user-gated per push-conflict runbook

## Test plan
- [x] Single-file change (4 lines added to spec.md) — no code paths affected
- [ ] Merge to land non-README local work; README reconciliation handled separately

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that marks a spec as cancelled and records the superseding work; no runtime code or behavior is affected.
> 
> **Overview**
> **Cancels spec 013.** Updates `kitty-specs/013-phenotype-infrakit-stabilization/spec.md` to `status: CANCELLED` and adds a cancellation note explaining it was superseded by Phase 1 libification, the target repo was archived, and remaining follow-up was moved to spec `021-polyrepo-ecosystem-stabilization`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 657f0af2a2e5f00de5eb8277bfcaab79219239d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
Mark spec 013 as cancelled and point to the replacement work

### What Changed
- Marks `phenotype-infrakit` stabilization spec 013 as cancelled
- Adds a cancellation note explaining the work was superseded by Phase 1 libification and that the remaining follow-up moved to spec 021
- Records that the target repo was archived and the related per-repo release work shipped separately

### Impact
`✅ Clearer project status`
`✅ Fewer duplicate follow-up tasks`
`✅ Easier to find the replacement spec`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=4JyEBuNhPg8UBumeGFb3uYoP43j5lHLTmMi_NZtHz9c&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
