### PR TITLE
chore(deny): remove stale RUSTSEC-2025-0134 rustls-pemfile ignore

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -27,8 +27,6 @@ unknown-git = "deny"
 
 [advisories]
 ignore = [
-    # No safe upgrade available - rustls-pemfile deprecated, migration requires async-nats update
-    { id = "RUSTSEC-2025-0134", reason = "No safe upgrade available. rustls-pemfile deprecated, migration requires async-nats update." },
     # No safe upgrade available - gix = "0.71" pinned in Cargo.toml, requires major version bump
     { id = "RUSTSEC-2025-0140", reason = "No safe upgrade available. gix = 0.71 pinned in Cargo.toml, requires breaking API change." },
 ]


### PR DESCRIPTION
## **User description**
Cherry-pick of 2b3909f from spec/013-cancelled branch. Removes stale advisory ignore for RUSTSEC-2025-0134 (rustls-pemfile) — upstream patch landed, ignore no longer needed.

Verified clean via cargo deny check (pre-existing RUSTSEC-2024-0436 paste/utoipa-axum failure is unrelated and unaffected by this change, per commit message).

Part of 2026-04-27 cargo-deny W-94 stale-ignore cleanup wave.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates `cargo-deny` configuration by removing an advisory ignore entry, which may surface the advisory in CI but does not affect runtime behavior.
> 
> **Overview**
> Removes the `cargo-deny` advisories ignore entry for `RUSTSEC-2025-0134` (`rustls-pemfile`), leaving only the existing `RUSTSEC-2025-0140` (`gix`) ignore in `deny.toml`.
> 
> This tightens dependency security checking by allowing `cargo deny` to report `RUSTSEC-2025-0134` again if it reappears.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28f983d3915c4e57f96fb44ef38d9ea98d1cf1d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Remove a stale dependency security ignore**

### What Changed
- Removed the ignored advisory for `RUSTSEC-2025-0134`, so dependency checks can report it again if it returns
- Kept the existing ignore for `RUSTSEC-2025-0140` in place

### Impact
`✅ Tighter dependency security checks`
`✅ Fewer outdated security exemptions`
`✅ Earlier detection of reintroduced advisories`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=eZSpZXA0oKV8L60sGYA0R65nzph9Ni2lUZd9iBV4wyw&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
