### PR TITLE
fix(deps): document paste advisory exception

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -29,4 +29,7 @@ unknown-git = "deny"
 ignore = [
     # No safe upgrade available - gix = "0.71" pinned in Cargo.toml, requires major version bump
     { id = "RUSTSEC-2025-0140", reason = "No safe upgrade available. gix = 0.71 pinned in Cargo.toml, requires breaking API change." },
+    # No safe upgrade available - utoipa-axum 0.2.0 is latest and still depends on paste.
+    # Remove once the OpenAPI route macro stack migrates off utoipa-axum.
+    { id = "RUSTSEC-2024-0436", reason = "No safe upgrade available. utoipa-axum 0.2.0 is latest and pulls paste; requires OpenAPI route macro replacement." },
 ]


### PR DESCRIPTION
## **User description**
## Summary
- add a documented cargo-deny exception for RUSTSEC-2024-0436 (`paste`) pulled by `utoipa-axum`
- record that `utoipa-axum 0.2.0` is currently the latest release and removal requires replacing the OpenAPI route macro stack

## Validation
- `cargo deny check advisories`
- `git diff --check`

Co-authored-by: Codex <noreply@openai.com>

<!-- CURSOR_SUMMARY -->

> [!NOTE]
> **Low Risk**
> Low risk: only updates `cargo-deny` configuration to ignore a specific RustSec advisory, with no runtime or dependency changes. Main risk is reduced visibility of the `paste` vulnerability until the OpenAPI macro stack is replaced.
> 
> **Overview**
> Updates `deny.toml` to **ignore `RUSTSEC-2024-0436`** (the `paste` advisory) and documents that it is currently unavoidable because `utoipa-axum 0.2.0` still depends on it.
> 
> Adds guidance to remove the exception once the OpenAPI route macro stack migrates off `utoipa-axum`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b2b609b6d14f2cff0963492c85b3258ea66f5db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
Document a temporary exception for a known dependency advisory

### What Changed
- Adds a documented exception so dependency advisory checks stop failing on the `paste` RustSec warning
- Explains that `utoipa-axum 0.2.0` is still the latest release and continues to pull in the advisory
- Keeps a note to remove the exception after the OpenAPI route stack moves off `utoipa-axum`

### Impact
`✅ Fewer failing dependency checks`
`✅ Clearer security review notes`
`✅ Easier cleanup when the dependency can be replaced`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=2rx56qYDBwQ5cugk3cZxfBYoE8AMfqcY-Vx1VWudkXw&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
