### PR TITLE
Implement evidence-backed validate policy checks

### DIFF
--- a/crates/agileplus-cli/src/commands/validate.rs
+++ b/crates/agileplus-cli/src/commands/validate.rs
@@ -11,7 +11,6 @@ use chrono::Utc;
 
 use agileplus_domain::domain::audit::{AuditEntry, hash_entry};
 use agileplus_domain::domain::event::Event;
-use agileplus_domain::domain::governance::{GovernanceContract, PolicyCheck};
 use agileplus_domain::domain::state_machine::FeatureState;
 use agileplus_domain::ports::{StoragePort, VcsPort};
 use agileplus_events::{EventStore, compute_hash};
@@ -19,7 +18,7 @@ use agileplus_events::{EventStore, compute_hash};
 mod evidence;
 mod report;
 
-use self::evidence::evaluate_evidence;
+use self::evidence::{evaluate_evidence, evaluate_policies};
 pub use report::{EvidenceCheck, PolicyEvalResult, ValidationReport};
 
 /// Arguments for the `validate` subcommand.
@@ -44,93 +43,6 @@ pub struct ValidateArgs {
     /// Force validation even if not in Implementing state (logs governance exception).
     #[arg(long)]
     pub force: bool,
-}
-
-/// Evaluate active policy rules against evidence.
-async fn evaluate_policies<S: StoragePort>(
-    storage: &S,
-    contract: &GovernanceContract,
-    feature_id: i64,
-) -> Result<Vec<PolicyEvalResult>> {
-    let active_policies = storage
-        .list_active_policies()
-        .await
-        .context("loading active policies")?;
-
-    // Gather policy refs referenced in the contract
-    let referenced: std::collections::HashSet<String> = contract
-        .rules
-        .iter()
-        .flat_map(|r| r.policy_refs.iter().cloned())
-        .collect();
-
-    let mut results = Vec::new();
-
-    for policy in &active_policies {
-        // Check if this policy is referenced by the contract
-        let policy_ref = format!("policy:{}", policy.id);
-        let domain_debug = format!("{:?}", policy.domain).to_lowercase();
-        let is_referenced = referenced.contains(&policy_ref)
-            || referenced.iter().any(|r| r.contains(&domain_debug));
-
-        if !is_referenced && !referenced.is_empty() {
-            continue;
-        }
-
-        let (passed, message) = match &policy.rule.check {
-            PolicyCheck::EvidencePresent { evidence_type } => {
-                // Check if any evidence of this type exists for this feature
-                // We search across all FR evidence — a simple heuristic
-                let ev_type_str = format!("{:?}", evidence_type);
-                // Since StoragePort doesn't have get_evidence_by_type, we list WPs and check
-                (
-                    true,
-                    format!("Evidence type {} check (assumed present)", ev_type_str),
-                )
-            }
-            PolicyCheck::ThresholdMet { metric, min } => {
-                let metrics = storage
-                    .get_metrics_by_feature(feature_id)
-                    .await
-                    .unwrap_or_default();
-                let found = metrics.iter().any(|m| m.command == *metric);
-                (
-                    found,
-                    if found {
-                        format!("Metric '{}' present (threshold >= {})", metric, min)
-                    } else {
-                        format!("Metric '{}' not found (threshold >= {})", metric, min)
-                    },
-                )
-            }
-            PolicyCheck::ManualApproval => {
-                // Cannot auto-approve; fail with instructions
-                (
-                    false,
-                    "Manual approval required — run the approval workflow".to_string(),
-                )
-            }
-            PolicyCheck::Custom { script } => {
-                // Custom scripts not supported in CLI validation; skip
-                (
-                    true,
-                    format!(
-                        "Custom policy skipped: {}",
-                        script.chars().take(60).collect::<String>()
-                    ),
-                )
-            }
-        };
-
-        results.push(PolicyEvalResult {
-            policy_id: policy.id,
-            domain: format!("{:?}", policy.domain),
-            passed,
-            message,
-        });
-    }
-
-    Ok(results)
 }
 
 /// Run the `validate` command.

--- a/crates/agileplus-cli/src/commands/validate/evidence.rs
+++ b/crates/agileplus-cli/src/commands/validate/evidence.rs
@@ -1,32 +1,37 @@
-use anyhow::Result;
+use std::collections::BTreeSet;
 
-use agileplus_domain::domain::governance::{Evidence, GovernanceContract};
+use anyhow::{Context, Result};
+
+use agileplus_domain::domain::governance::{
+    BuiltinPolicy, Evidence, EvidenceRequirement, EvidenceType, GovernanceContract, PolicyCheck,
+};
 use agileplus_domain::ports::StoragePort;
 
-use super::EvidenceCheck;
+use super::{EvidenceCheck, PolicyEvalResult};
 
 /// Evaluate governance evidence requirements against stored evidence.
 pub(crate) async fn evaluate_evidence<S: StoragePort>(
     storage: &S,
     contract: &GovernanceContract,
-    _feature_id: i64,
+    feature_id: i64,
 ) -> Result<(Vec<EvidenceCheck>, Vec<(String, String)>)> {
     let mut results = Vec::new();
     let mut missing = Vec::new();
-    let target_transition_keywords = ["Implementing", "validated", "Validate", "implementing"];
+    let wp_ids = feature_wp_ids(storage, feature_id).await?;
 
     for rule in &contract.rules {
-        let is_validate_rule = target_transition_keywords
-            .iter()
-            .any(|kw| rule.transition.to_lowercase().contains(&kw.to_lowercase()));
-
         for req in &rule.required_evidence {
             let evidence_list = storage
                 .get_evidence_by_fr(&req.fr_id)
                 .await
                 .unwrap_or_default();
 
-            let relevant: Vec<&Evidence> = evidence_list.iter().collect();
+            let relevant: Vec<&Evidence> = evidence_list
+                .iter()
+                .filter(|evidence| {
+                    evidence.evidence_type == req.evidence_type && wp_ids.contains(&evidence.wp_id)
+                })
+                .collect();
             let found = !relevant.is_empty();
 
             let threshold_met = if let (true, Some(threshold)) = (found, &req.threshold) {
@@ -54,8 +59,6 @@ pub(crate) async fn evaluate_evidence<S: StoragePort>(
                 threshold_met,
                 message,
             });
-
-            let _ = is_validate_rule;
         }
     }
 
@@ -86,4 +89,250 @@ pub(crate) fn evaluate_threshold(evidence: &[&Evidence], threshold: &serde_json:
         return critical_count <= max_crit;
     }
     true
+}
+
+/// Evaluate active policy rules and built-in contract policy refs against stored evidence.
+pub(crate) async fn evaluate_policies<S: StoragePort>(
+    storage: &S,
+    contract: &GovernanceContract,
+    feature_id: i64,
+) -> Result<Vec<PolicyEvalResult>> {
+    let active_policies = storage
+        .list_active_policies()
+        .await
+        .context("loading active policies")?;
+
+    let referenced: BTreeSet<String> = contract
+        .rules
+        .iter()
+        .flat_map(|r| r.policy_refs.iter().cloned())
+        .collect();
+
+    let mut results = Vec::new();
+    let mut handled_refs = BTreeSet::new();
+
+    for policy in &active_policies {
+        let matched_refs: Vec<&String> = referenced
+            .iter()
+            .filter(|policy_ref| policy.matches_reference(policy_ref))
+            .collect();
+        let is_referenced = !matched_refs.is_empty() || referenced.is_empty();
+
+        if !is_referenced {
+            continue;
+        }
+
+        let (passed, message) = match &policy.rule.check {
+            PolicyCheck::EvidencePresent { evidence_type } => {
+                evaluate_evidence_policy(storage, contract, feature_id, *evidence_type).await?
+            }
+            PolicyCheck::ThresholdMet { metric, min } => {
+                evaluate_metric_policy(storage, feature_id, metric, *min).await?
+            }
+            PolicyCheck::ManualApproval => {
+                evaluate_evidence_policy(
+                    storage,
+                    contract,
+                    feature_id,
+                    EvidenceType::ManualAttestation,
+                )
+                .await?
+            }
+            PolicyCheck::Custom { script } => (
+                false,
+                format!(
+                    "Custom policy requires an external evaluator: {}",
+                    script.chars().take(60).collect::<String>()
+                ),
+            ),
+        };
+
+        for policy_ref in matched_refs {
+            handled_refs.insert(policy_ref.clone());
+        }
+
+        results.push(PolicyEvalResult {
+            policy_id: policy.id,
+            domain: policy.domain.as_str().to_string(),
+            passed,
+            message,
+        });
+    }
+
+    for policy_ref in referenced.difference(&handled_refs) {
+        if let Some(builtin) = BuiltinPolicy::from_ref(policy_ref) {
+            let (passed, message) =
+                evaluate_evidence_policy(storage, contract, feature_id, builtin.evidence_type)
+                    .await?;
+            results.push(PolicyEvalResult {
+                policy_id: 0,
+                domain: builtin.domain.as_str().to_string(),
+                passed,
+                message: format!("{}: {message}", builtin.label),
+            });
+        } else {
+            results.push(PolicyEvalResult {
+                policy_id: 0,
+                domain: "custom".to_string(),
+                passed: false,
+                message: format!(
+                    "Policy ref '{policy_ref}' has no active policy rule or built-in evaluator"
+                ),
+            });
+        }
+    }
+
+    Ok(results)
+}
+
+async fn evaluate_evidence_policy<S: StoragePort>(
+    storage: &S,
+    contract: &GovernanceContract,
+    feature_id: i64,
+    evidence_type: EvidenceType,
+) -> Result<(bool, String)> {
+    let requirements = requirements_for_evidence_type(contract, evidence_type);
+    let wp_ids = feature_wp_ids(storage, feature_id).await?;
+    if requirements.is_empty() {
+        return Ok((
+            false,
+            format!(
+                "No governance contract requirement declares {} evidence",
+                evidence_type.as_str()
+            ),
+        ));
+    }
+
+    let mut satisfied = 0usize;
+    let mut missing = Vec::new();
+    let mut below_threshold = Vec::new();
+
+    for req in &requirements {
+        let evidence = storage
+            .get_evidence_by_fr(&req.fr_id)
+            .await
+            .with_context(|| format!("loading evidence for {}", req.fr_id))?;
+        let relevant: Vec<_> = evidence
+            .iter()
+            .filter(|ev| ev.evidence_type == evidence_type && wp_ids.contains(&ev.wp_id))
+            .collect();
+
+        if relevant.is_empty() {
+            missing.push(req.fr_id.clone());
+            continue;
+        }
+
+        if let Some(threshold) = &req.threshold {
+            if !evaluate_threshold(&relevant, threshold) {
+                below_threshold.push(req.fr_id.clone());
+                continue;
+            }
+        }
+
+        satisfied += 1;
+    }
+
+    if missing.is_empty() && below_threshold.is_empty() {
+        return Ok((
+            true,
+            format!(
+                "{} evidence satisfied for {satisfied}/{} requirement(s)",
+                evidence_type.as_str(),
+                requirements.len()
+            ),
+        ));
+    }
+
+    let mut failures = Vec::new();
+    if !missing.is_empty() {
+        failures.push(format!("missing evidence for {}", missing.join(", ")));
+    }
+    if !below_threshold.is_empty() {
+        failures.push(format!(
+            "threshold not met for {}",
+            below_threshold.join(", ")
+        ));
+    }
+
+    Ok((
+        false,
+        format!(
+            "{} evidence failed: {}",
+            evidence_type.as_str(),
+            failures.join("; ")
+        ),
+    ))
+}
+
+async fn feature_wp_ids<S: StoragePort>(storage: &S, feature_id: i64) -> Result<BTreeSet<i64>> {
+    storage
+        .list_wps_by_feature(feature_id)
+        .await
+        .map(|wps| wps.into_iter().map(|wp| wp.id).collect())
+        .with_context(|| format!("loading work packages for feature {feature_id}"))
+}
+
+async fn evaluate_metric_policy<S: StoragePort>(
+    storage: &S,
+    feature_id: i64,
+    metric: &str,
+    min: f64,
+) -> Result<(bool, String)> {
+    let metrics = storage
+        .get_metrics_by_feature(feature_id)
+        .await
+        .context("loading metrics for policy evaluation")?;
+    let best = metrics
+        .iter()
+        .filter_map(|m| metric_value(m, metric))
+        .fold(None, |best: Option<f64>, value| {
+            Some(best.map_or(value, |current| current.max(value)))
+        });
+
+    Ok(match best {
+        Some(value) if value >= min => (
+            true,
+            format!("Metric '{metric}' value {value} satisfies minimum {min}"),
+        ),
+        Some(value) => (
+            false,
+            format!("Metric '{metric}' value {value} is below minimum {min}"),
+        ),
+        None => (
+            false,
+            format!("Metric '{metric}' not found for feature {feature_id}"),
+        ),
+    })
+}
+
+fn requirements_for_evidence_type(
+    contract: &GovernanceContract,
+    evidence_type: EvidenceType,
+) -> Vec<&EvidenceRequirement> {
+    contract
+        .rules
+        .iter()
+        .flat_map(|rule| rule.required_evidence.iter())
+        .filter(|req| req.evidence_type == evidence_type)
+        .collect()
+}
+
+fn metric_value(metric: &agileplus_domain::domain::metric::Metric, name: &str) -> Option<f64> {
+    let direct = match name {
+        "duration_ms" => Some(metric.duration_ms as f64),
+        "agent_runs" => Some(metric.agent_runs as f64),
+        "review_cycles" => Some(metric.review_cycles as f64),
+        command if command == metric.command => Some(1.0),
+        _ => None,
+    };
+
+    if direct.is_some() {
+        return direct;
+    }
+
+    metric
+        .metadata
+        .as_ref()
+        .and_then(|metadata| metadata.get(name))
+        .and_then(|value| value.as_f64().or_else(|| value.as_i64().map(|v| v as f64)))
 }

--- a/crates/agileplus-cli/src/commands/validate/tests.rs
+++ b/crates/agileplus-cli/src/commands/validate/tests.rs
@@ -1,7 +1,11 @@
 use super::*;
+use agileplus_domain::domain::feature::Feature;
 use agileplus_domain::domain::governance::{
-    EvidenceRequirement, EvidenceType, GovernanceContract, GovernanceRule,
+    Evidence, EvidenceRequirement, EvidenceType, GovernanceContract, GovernanceRule,
 };
+use agileplus_domain::domain::work_package::WorkPackage;
+use agileplus_domain::ports::StoragePort;
+use agileplus_sqlite::SqliteStorageAdapter;
 use chrono::Utc;
 
 #[allow(dead_code)]
@@ -146,4 +150,126 @@ fn evaluate_threshold_max_critical_fail() {
     };
     let threshold = serde_json::json!({"max_critical": 0});
     assert!(!super::evidence::evaluate_threshold(&[&ev], &threshold));
+}
+
+#[tokio::test]
+async fn builtin_ci_policy_fails_without_matching_evidence() {
+    let db = SqliteStorageAdapter::in_memory().unwrap();
+    let feature_id = create_feature_with_wp(&db).await.0;
+    let contract = contract_with_policy(
+        feature_id,
+        EvidenceType::CiOutput,
+        "FR-CI",
+        "policy:ci-required",
+    );
+
+    let results = super::evidence::evaluate_policies(&db, &contract, feature_id)
+        .await
+        .unwrap();
+
+    assert_eq!(results.len(), 1);
+    assert!(!results[0].passed);
+    assert!(results[0].message.contains("missing evidence"));
+}
+
+#[tokio::test]
+async fn builtin_ci_policy_ignores_wrong_evidence_type() {
+    let db = SqliteStorageAdapter::in_memory().unwrap();
+    let (feature_id, wp_id) = create_feature_with_wp(&db).await;
+    let contract = contract_with_policy(
+        feature_id,
+        EvidenceType::CiOutput,
+        "FR-CI",
+        "policy:ci-required",
+    );
+    create_evidence(&db, wp_id, "FR-CI", EvidenceType::ReviewApproval).await;
+
+    let results = super::evidence::evaluate_policies(&db, &contract, feature_id)
+        .await
+        .unwrap();
+
+    assert_eq!(results.len(), 1);
+    assert!(!results[0].passed);
+    assert!(results[0].message.contains("missing evidence"));
+}
+
+#[tokio::test]
+async fn builtin_ci_policy_passes_with_matching_evidence() {
+    let db = SqliteStorageAdapter::in_memory().unwrap();
+    let (feature_id, wp_id) = create_feature_with_wp(&db).await;
+    let contract = contract_with_policy(
+        feature_id,
+        EvidenceType::CiOutput,
+        "FR-CI",
+        "policy:ci-required",
+    );
+    create_evidence(&db, wp_id, "FR-CI", EvidenceType::CiOutput).await;
+
+    let results = super::evidence::evaluate_policies(&db, &contract, feature_id)
+        .await
+        .unwrap();
+
+    assert_eq!(results.len(), 1);
+    assert!(results[0].passed);
+    assert!(results[0].message.contains("satisfied"));
+}
+
+async fn create_feature_with_wp(db: &SqliteStorageAdapter) -> (i64, i64) {
+    let feature_id = StoragePort::create_feature(
+        db,
+        &Feature::new(
+            "validate-policy-test",
+            "Validate Policy Test",
+            [0u8; 32],
+            None,
+        ),
+    )
+    .await
+    .unwrap();
+    let wp_id =
+        StoragePort::create_work_package(db, &WorkPackage::new(feature_id, "WP", 1, "criteria"))
+            .await
+            .unwrap();
+    (feature_id, wp_id)
+}
+
+async fn create_evidence(
+    db: &SqliteStorageAdapter,
+    wp_id: i64,
+    fr_id: &str,
+    evidence_type: EvidenceType,
+) {
+    let evidence = Evidence {
+        id: 0,
+        wp_id,
+        fr_id: fr_id.to_string(),
+        evidence_type,
+        artifact_path: "artifact.txt".to_string(),
+        metadata: None,
+        created_at: Utc::now(),
+    };
+    StoragePort::create_evidence(db, &evidence).await.unwrap();
+}
+
+fn contract_with_policy(
+    feature_id: i64,
+    evidence_type: EvidenceType,
+    fr_id: &str,
+    policy_ref: &str,
+) -> GovernanceContract {
+    GovernanceContract {
+        id: 1,
+        feature_id,
+        version: 1,
+        rules: vec![GovernanceRule {
+            transition: "Implementing -> Validated".to_string(),
+            required_evidence: vec![EvidenceRequirement {
+                fr_id: fr_id.to_string(),
+                evidence_type,
+                threshold: None,
+            }],
+            policy_refs: vec![policy_ref.to_string()],
+        }],
+        bound_at: Utc::now(),
+    }
 }

--- a/crates/agileplus-domain/src/domain/governance.rs
+++ b/crates/agileplus-domain/src/domain/governance.rs
@@ -17,6 +17,20 @@ pub enum EvidenceType {
     ManualAttestation,
 }
 
+impl EvidenceType {
+    /// Stable storage/reporting key for this evidence type.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::TestResult => "test_result",
+            Self::CiOutput => "ci_output",
+            Self::ReviewApproval => "review_approval",
+            Self::SecurityScan => "security_scan",
+            Self::LintResult => "lint_result",
+            Self::ManualAttestation => "manual_attestation",
+        }
+    }
+}
+
 /// A single evidence requirement attached to a governance rule.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EvidenceRequirement {
@@ -66,6 +80,19 @@ pub enum PolicyDomain {
     Custom,
 }
 
+impl PolicyDomain {
+    /// Stable storage/reporting key for this policy domain.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Security => "security",
+            Self::Quality => "quality",
+            Self::Compliance => "compliance",
+            Self::Performance => "performance",
+            Self::Custom => "custom",
+        }
+    }
+}
+
 /// The definition body of a policy rule.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PolicyDefinition {
@@ -81,6 +108,17 @@ pub enum PolicyCheck {
     ThresholdMet { metric: String, min: f64 },
     ManualApproval,
     Custom { script: String },
+}
+
+impl PolicyCheck {
+    /// Evidence type required by checks that can be satisfied with stored evidence.
+    pub fn required_evidence_type(&self) -> Option<EvidenceType> {
+        match self {
+            Self::EvidencePresent { evidence_type } => Some(*evidence_type),
+            Self::ManualApproval => Some(EvidenceType::ManualAttestation),
+            Self::ThresholdMet { .. } | Self::Custom { .. } => None,
+        }
+    }
 }
 
 /// Outcome of evaluating a policy rule.
@@ -101,4 +139,76 @@ pub struct PolicyRule {
     pub active: bool,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+}
+
+/// A built-in policy reference emitted by generated governance contracts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BuiltinPolicy {
+    pub label: &'static str,
+    pub domain: PolicyDomain,
+    pub evidence_type: EvidenceType,
+}
+
+impl BuiltinPolicy {
+    pub fn from_ref(policy_ref: &str) -> Option<Self> {
+        let (label, domain, evidence_type) = match policy_ref {
+            "policy:ci-required" => (
+                "CI evidence required",
+                PolicyDomain::Quality,
+                EvidenceType::CiOutput,
+            ),
+            "policy:review-required" => (
+                "Review approval required",
+                PolicyDomain::Quality,
+                EvidenceType::ReviewApproval,
+            ),
+            "policy:security-scan-required" => (
+                "Security scan evidence required",
+                PolicyDomain::Security,
+                EvidenceType::SecurityScan,
+            ),
+            "policy:lint-required" => (
+                "Lint evidence required",
+                PolicyDomain::Quality,
+                EvidenceType::LintResult,
+            ),
+            "policy:test-result-required" => (
+                "Test result evidence required",
+                PolicyDomain::Quality,
+                EvidenceType::TestResult,
+            ),
+            "policy:manual-attestation-required" => (
+                "Manual attestation required",
+                PolicyDomain::Compliance,
+                EvidenceType::ManualAttestation,
+            ),
+            _ => return None,
+        };
+        Some(Self {
+            label,
+            domain,
+            evidence_type,
+        })
+    }
+}
+
+impl PolicyRule {
+    /// Stable references that can bind governance contract policy refs to this rule.
+    pub fn reference_keys(&self) -> Vec<String> {
+        let mut keys = vec![
+            format!("policy:{}", self.id),
+            format!("policy:{}", self.domain.as_str()),
+        ];
+
+        if let Some(evidence_type) = self.rule.check.required_evidence_type() {
+            keys.push(format!("policy:{}-required", evidence_type.as_str()));
+        }
+
+        keys
+    }
+
+    /// Whether a governance contract policy ref targets this rule.
+    pub fn matches_reference(&self, policy_ref: &str) -> bool {
+        self.reference_keys().iter().any(|key| key == policy_ref)
+    }
 }

--- a/crates/agileplus-sqlite/src/repository/evidence.rs
+++ b/crates/agileplus-sqlite/src/repository/evidence.rs
@@ -12,14 +12,7 @@ fn map_err(e: rusqlite::Error) -> DomainError {
 }
 
 fn evidence_type_str(t: EvidenceType) -> &'static str {
-    match t {
-        EvidenceType::TestResult => "test_result",
-        EvidenceType::CiOutput => "ci_output",
-        EvidenceType::ReviewApproval => "review_approval",
-        EvidenceType::SecurityScan => "security_scan",
-        EvidenceType::LintResult => "lint_result",
-        EvidenceType::ManualAttestation => "manual_attestation",
-    }
+    t.as_str()
 }
 
 fn evidence_type_from_str(s: &str) -> Result<EvidenceType, DomainError> {

--- a/crates/agileplus-sqlite/src/repository/governance.rs
+++ b/crates/agileplus-sqlite/src/repository/governance.rs
@@ -14,13 +14,7 @@ fn map_err(e: rusqlite::Error) -> DomainError {
 }
 
 fn policy_domain_str(d: PolicyDomain) -> &'static str {
-    match d {
-        PolicyDomain::Security => "security",
-        PolicyDomain::Quality => "quality",
-        PolicyDomain::Compliance => "compliance",
-        PolicyDomain::Performance => "performance",
-        PolicyDomain::Custom => "custom",
-    }
+    d.as_str()
 }
 
 fn policy_domain_from_str(s: &str) -> Result<PolicyDomain, DomainError> {


### PR DESCRIPTION
## **User description**
## Summary
- Replaces placeholder `agileplus validate` policy checks with stored evidence and metric-backed evaluation.
- Maps generated policy refs such as `policy:ci-required` and `policy:review-required` to built-in evaluators.
- Restricts evidence matching to work packages owned by the feature being validated.

## Stack Topology
- Layer: AgilePlus CLI validation path.
- Domain: governance policy/evidence model.
- Storage: SQLite repository serialization remains on stable domain keys.

## Validation
- `cargo test -p agileplus-cli validate::tests --no-default-features`
- `cargo test -p agileplus-sqlite --no-default-features`
- `cargo test -p agileplus-domain --no-default-features`
- `cargo fmt --check`
- `git diff --check`

## Governance
- Spec target: 013 phenotype-infrakit stabilization / governance validation follow-through.
- Direct-to-main branch shape is intentional for this clean Codex worktree PR; `layered-pr-exception` applies.
- No local dirty AgilePlus checkout was modified.

## CI Exception
- No code-level CI exception requested.
- Billing/quota provider statuses may remain non-actionable and are not used as evidence for this implementation.


___

## **CodeAnt-AI Description**
**Make `validate` enforce real policy and evidence checks**

### What Changed
- `validate` now fails when required evidence is missing, wrong, or tied to another feature’s work package
- Built-in policy refs like `policy:ci-required`, `policy:review-required`, and `policy:security-scan-required` now map to the expected evidence checks
- Manual approval policies now require stored manual attestation instead of passing automatically
- Policy and evidence names now use stable stored values, keeping saved data consistent across reads and writes
- Validation tests now cover missing, mismatched, and matching CI evidence

### Impact
`✅ Fewer false validation passes`
`✅ Clearer policy failure messages`
`✅ Tighter evidence checks for feature validation`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=5wCCxThhSA8lJDTWJrmOikTGFFOWtIziJ32WQGQUyQY&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `agileplus validate` pass/fail behavior by replacing placeholder policy checks with real evidence/metric evaluation and stricter evidence scoping, which could block validations that previously passed.
> 
> **Overview**
> `agileplus validate` now evaluates governance `policy_refs` using stored evidence and feature metrics instead of placeholder/assumed passes, and treats unsupported `Custom` policies as failures.
> 
> Evidence matching is tightened to only count artifacts attached to work packages belonging to the feature being validated, and missing/unhandled policy refs are surfaced via built-in mappings (e.g., `policy:ci-required`) or explicit failures.
> 
> The governance domain adds stable string keys (`as_str`) plus built-in policy/ref matching helpers, SQLite repositories switch to these stable keys for serialization, and CLI tests add coverage for built-in CI policy pass/fail cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e59fe1d7bf0f0d66efadd78eec339b8f70b1993d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->