### PR TITLE
chore(deps): remove dead utoipa-axum dep (clears RUSTSEC-2024-0436)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,7 +101,6 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "utoipa",
- "utoipa-axum",
 ]
 
 [[package]]
@@ -1519,12 +1518,12 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.8"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
- "serde_core",
+ "serde",
 ]
 
 [[package]]
@@ -2426,7 +2425,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfef60ebcd45e0fad3007d15b45a305e6a25af9a0fdffbca0b02bf8b0f91f83c"
 dependencies = [
  "bstr",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "memchr",
 ]
 
@@ -4083,9 +4082,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-integer"
@@ -4510,12 +4509,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4922,9 +4915,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "49df843a9161c85bb8aae55f101bc0bac8bcafd637a620d9122fd7e0b2f7422e"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -6033,30 +6026,30 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
  "deranged",
  "itoa",
  "num-conv",
  "powerfmt",
- "serde_core",
+ "serde",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
 dependencies = [
  "num-conv",
  "time-core",
@@ -6700,19 +6693,6 @@ dependencies = [
  "serde",
  "serde_json",
  "utoipa-gen",
-]
-
-[[package]]
-name = "utoipa-axum"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c25bae5bccc842449ec0c5ddc5cbb6a3a1eaeac4503895dc105a1138f8234a0"
-dependencies = [
- "axum",
- "paste",
- "tower-layer",
- "tower-service",
- "utoipa",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,6 @@ sentry = { version = "0.33", features = [
 
 # OpenAPI scaffolding (utoipa). See WP: feat/rest-openapi-scaffold (#138, #118).
 utoipa = { version = "5", features = ["axum_extras", "chrono"] }
-utoipa-axum = "0.2"
 
 # Plugin crates (external from separate repos) were removed in #144:
 # the three git remotes (agileplus-plugin-{core,git,sqlite}) all return 404.

--- a/crates/agileplus-api/Cargo.toml
+++ b/crates/agileplus-api/Cargo.toml
@@ -34,7 +34,6 @@ askama = "0.12"
 
 # OpenAPI scaffolding (utoipa). MVP scope: 5 annotated endpoints; see openapi.yaml at repo root.
 utoipa = { workspace = true }
-utoipa-axum = { workspace = true }
 serde_yaml = "0.9"
 
 [dev-dependencies]

--- a/deny.toml
+++ b/deny.toml
@@ -29,7 +29,4 @@ unknown-git = "deny"
 ignore = [
     # No safe upgrade available - gix = "0.71" pinned in Cargo.toml, requires major version bump
     { id = "RUSTSEC-2025-0140", reason = "No safe upgrade available. gix = 0.71 pinned in Cargo.toml, requires breaking API change." },
-    # No safe upgrade available - utoipa-axum 0.2.0 is latest and still depends on paste.
-    # Remove once the OpenAPI route macro stack migrates off utoipa-axum.
-    { id = "RUSTSEC-2024-0436", reason = "No safe upgrade available. utoipa-axum 0.2.0 is latest and pulls paste; requires OpenAPI route macro replacement." },
 ]


### PR DESCRIPTION
## **User description**
Removes `utoipa-axum = '0.2'` from root Cargo.toml + crates/agileplus-api/Cargo.toml. Source uses 0 utoipa_axum:: imports. utoipa itself preserved (different crate, no paste exposure). Clears RUSTSEC-2024-0436.

<!-- CURSOR_SUMMARY -->

> [!NOTE]
> **Medium Risk**
> Mostly a dependency cleanup, but the lockfile resolves several crates to different (in some cases older) versions including `time` and `quinn-proto`, which could subtly affect runtime behavior.
> 
> **Overview**
> Removes the unused `utoipa-axum` dependency from the workspace and `agileplus-api`, keeping `utoipa` itself for OpenAPI annotations.
> 
> Updates `Cargo.lock` accordingly (dropping `utoipa-axum`/`paste` and shifting a handful of transitive versions), and removes the `RUSTSEC-2024-0436` ignore entry from `deny.toml` now that it is no longer needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc805232f8856c1960af7c157eac5ad01a0a367d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Remove an unused OpenAPI dependency and clear its security warning**

### What Changed
- Removed an OpenAPI helper package that was no longer used by the API
- Kept the main OpenAPI library in place, so API documentation support still works
- Removed the matching security exception now that the dependency is gone

### Impact
`✅ Fewer security warnings in dependency checks`
`✅ Cleaner dependency list`
`✅ Lower risk from unused packages`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=VAgvhrmPlxzcXG5GrvQWY3wHVY6aHoQlfpPZp7wGzy0&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
