### PR TITLE
fix: bind validate policies to explicit refs

### DIFF
--- a/crates/agileplus-cli/src/commands/validate/evidence.rs
+++ b/crates/agileplus-cli/src/commands/validate/evidence.rs
@@ -17,21 +17,11 @@ pub(crate) async fn evaluate_evidence<S: StoragePort>(
 ) -> Result<(Vec<EvidenceCheck>, Vec<(String, String)>)> {
     let mut results = Vec::new();
     let mut missing = Vec::new();
-    let wp_ids = feature_wp_ids(storage, feature_id).await?;
+    let feature_evidence = load_feature_evidence(storage, feature_id).await?;
 
     for rule in &contract.rules {
         for req in &rule.required_evidence {
-            let evidence_list = storage
-                .get_evidence_by_fr(&req.fr_id)
-                .await
-                .unwrap_or_default();
-
-            let relevant: Vec<&Evidence> = evidence_list
-                .iter()
-                .filter(|evidence| {
-                    evidence.evidence_type == req.evidence_type && wp_ids.contains(&evidence.wp_id)
-                })
-                .collect();
+            let relevant = feature_evidence.evidence_for(req.fr_id.as_str(), req.evidence_type);
             let found = !relevant.is_empty();
 
             let threshold_met = if let (true, Some(threshold)) = (found, &req.threshold) {
@@ -108,6 +98,11 @@ pub(crate) async fn evaluate_policies<S: StoragePort>(
         .flat_map(|r| r.policy_refs.iter().cloned())
         .collect();
 
+    if referenced.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let feature_evidence = load_feature_evidence(storage, feature_id).await?;
     let mut results = Vec::new();
     let mut handled_refs = BTreeSet::new();
 
@@ -116,28 +111,23 @@ pub(crate) async fn evaluate_policies<S: StoragePort>(
             .iter()
             .filter(|policy_ref| policy.matches_reference(policy_ref))
             .collect();
-        let is_referenced = !matched_refs.is_empty() || referenced.is_empty();
 
-        if !is_referenced {
+        if matched_refs.is_empty() {
             continue;
         }
 
         let (passed, message) = match &policy.rule.check {
             PolicyCheck::EvidencePresent { evidence_type } => {
-                evaluate_evidence_policy(storage, contract, feature_id, *evidence_type).await?
+                evaluate_evidence_policy(contract, &feature_evidence, *evidence_type)
             }
             PolicyCheck::ThresholdMet { metric, min } => {
                 evaluate_metric_policy(storage, feature_id, metric, *min).await?
             }
-            PolicyCheck::ManualApproval => {
-                evaluate_evidence_policy(
-                    storage,
-                    contract,
-                    feature_id,
-                    EvidenceType::ManualAttestation,
-                )
-                .await?
-            }
+            PolicyCheck::ManualApproval => evaluate_evidence_policy(
+                contract,
+                &feature_evidence,
+                EvidenceType::ManualAttestation,
+            ),
             PolicyCheck::Custom { script } => (
                 false,
                 format!(
@@ -162,8 +152,7 @@ pub(crate) async fn evaluate_policies<S: StoragePort>(
     for policy_ref in referenced.difference(&handled_refs) {
         if let Some(builtin) = BuiltinPolicy::from_ref(policy_ref) {
             let (passed, message) =
-                evaluate_evidence_policy(storage, contract, feature_id, builtin.evidence_type)
-                    .await?;
+                evaluate_evidence_policy(contract, &feature_evidence, builtin.evidence_type);
             results.push(PolicyEvalResult {
                 policy_id: 0,
                 domain: builtin.domain.as_str().to_string(),
@@ -185,22 +174,20 @@ pub(crate) async fn evaluate_policies<S: StoragePort>(
     Ok(results)
 }
 
-async fn evaluate_evidence_policy<S: StoragePort>(
-    storage: &S,
+fn evaluate_evidence_policy(
     contract: &GovernanceContract,
-    feature_id: i64,
+    feature_evidence: &FeatureEvidence,
     evidence_type: EvidenceType,
-) -> Result<(bool, String)> {
+) -> (bool, String) {
     let requirements = requirements_for_evidence_type(contract, evidence_type);
-    let wp_ids = feature_wp_ids(storage, feature_id).await?;
     if requirements.is_empty() {
-        return Ok((
+        return (
             false,
             format!(
                 "No governance contract requirement declares {} evidence",
                 evidence_type.as_str()
             ),
-        ));
+        );
     }
 
     let mut satisfied = 0usize;
@@ -208,14 +195,7 @@ async fn evaluate_evidence_policy<S: StoragePort>(
     let mut below_threshold = Vec::new();
 
     for req in &requirements {
-        let evidence = storage
-            .get_evidence_by_fr(&req.fr_id)
-            .await
-            .with_context(|| format!("loading evidence for {}", req.fr_id))?;
-        let relevant: Vec<_> = evidence
-            .iter()
-            .filter(|ev| ev.evidence_type == evidence_type && wp_ids.contains(&ev.wp_id))
-            .collect();
+        let relevant = feature_evidence.evidence_for(req.fr_id.as_str(), evidence_type);
 
         if relevant.is_empty() {
             missing.push(req.fr_id.clone());
@@ -233,14 +213,14 @@ async fn evaluate_evidence_policy<S: StoragePort>(
     }
 
     if missing.is_empty() && below_threshold.is_empty() {
-        return Ok((
+        return (
             true,
             format!(
                 "{} evidence satisfied for {satisfied}/{} requirement(s)",
                 evidence_type.as_str(),
                 requirements.len()
             ),
-        ));
+        );
     }
 
     let mut failures = Vec::new();
@@ -254,22 +234,48 @@ async fn evaluate_evidence_policy<S: StoragePort>(
         ));
     }
 
-    Ok((
+    (
         false,
         format!(
             "{} evidence failed: {}",
             evidence_type.as_str(),
             failures.join("; ")
         ),
-    ))
+    )
 }
 
-async fn feature_wp_ids<S: StoragePort>(storage: &S, feature_id: i64) -> Result<BTreeSet<i64>> {
-    storage
+struct FeatureEvidence {
+    evidence: Vec<Evidence>,
+}
+
+impl FeatureEvidence {
+    fn evidence_for(&self, fr_id: &str, evidence_type: EvidenceType) -> Vec<&Evidence> {
+        self.evidence
+            .iter()
+            .filter(|ev| ev.fr_id == fr_id && ev.evidence_type == evidence_type)
+            .collect()
+    }
+}
+
+async fn load_feature_evidence<S: StoragePort>(
+    storage: &S,
+    feature_id: i64,
+) -> Result<FeatureEvidence> {
+    let wps = storage
         .list_wps_by_feature(feature_id)
         .await
-        .map(|wps| wps.into_iter().map(|wp| wp.id).collect())
-        .with_context(|| format!("loading work packages for feature {feature_id}"))
+        .with_context(|| format!("loading work packages for feature {feature_id}"))?;
+    let mut evidence = Vec::new();
+
+    for wp in wps {
+        let mut wp_evidence = storage
+            .get_evidence_by_wp(wp.id)
+            .await
+            .with_context(|| format!("loading evidence for work package {}", wp.id))?;
+        evidence.append(&mut wp_evidence);
+    }
+
+    Ok(FeatureEvidence { evidence })
 }
 
 async fn evaluate_metric_policy<S: StoragePort>(

--- a/crates/agileplus-cli/src/commands/validate/tests.rs
+++ b/crates/agileplus-cli/src/commands/validate/tests.rs
@@ -1,7 +1,8 @@
 use super::*;
 use agileplus_domain::domain::feature::Feature;
 use agileplus_domain::domain::governance::{
-    Evidence, EvidenceRequirement, EvidenceType, GovernanceContract, GovernanceRule,
+    Evidence, EvidenceRequirement, EvidenceType, GovernanceContract, GovernanceRule, PolicyCheck,
+    PolicyDefinition, PolicyDomain, PolicyRule,
 };
 use agileplus_domain::domain::work_package::WorkPackage;
 use agileplus_domain::ports::StoragePort;
@@ -214,6 +215,49 @@ async fn builtin_ci_policy_passes_with_matching_evidence() {
     assert!(results[0].message.contains("satisfied"));
 }
 
+#[tokio::test]
+async fn active_policy_matches_generated_ci_ref() {
+    let db = SqliteStorageAdapter::in_memory().unwrap();
+    let (feature_id, wp_id) = create_feature_with_wp(&db).await;
+    let policy_id = create_policy_rule(
+        &db,
+        PolicyDomain::Quality,
+        PolicyCheck::EvidencePresent {
+            evidence_type: EvidenceType::CiOutput,
+        },
+    )
+    .await;
+    let contract = contract_with_policy(
+        feature_id,
+        EvidenceType::CiOutput,
+        "FR-CI",
+        "policy:ci-required",
+    );
+    create_evidence(&db, wp_id, "FR-CI", EvidenceType::CiOutput).await;
+
+    let results = super::evidence::evaluate_policies(&db, &contract, feature_id)
+        .await
+        .unwrap();
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].policy_id, policy_id);
+    assert!(results[0].passed);
+}
+
+#[tokio::test]
+async fn empty_policy_refs_do_not_evaluate_active_policies() {
+    let db = SqliteStorageAdapter::in_memory().unwrap();
+    let feature_id = create_feature_with_wp(&db).await.0;
+    create_policy_rule(&db, PolicyDomain::Compliance, PolicyCheck::ManualApproval).await;
+    let contract = make_contract(feature_id);
+
+    let results = super::evidence::evaluate_policies(&db, &contract, feature_id)
+        .await
+        .unwrap();
+
+    assert!(results.is_empty());
+}
+
 async fn create_feature_with_wp(db: &SqliteStorageAdapter) -> (i64, i64) {
     let feature_id = StoragePort::create_feature(
         db,
@@ -249,6 +293,26 @@ async fn create_evidence(
         created_at: Utc::now(),
     };
     StoragePort::create_evidence(db, &evidence).await.unwrap();
+}
+
+async fn create_policy_rule(
+    db: &SqliteStorageAdapter,
+    domain: PolicyDomain,
+    check: PolicyCheck,
+) -> i64 {
+    let now = Utc::now();
+    let rule = PolicyRule {
+        id: 0,
+        domain,
+        rule: PolicyDefinition {
+            description: "test policy".to_string(),
+            check,
+        },
+        active: true,
+        created_at: now,
+        updated_at: now,
+    };
+    StoragePort::create_policy_rule(db, &rule).await.unwrap()
 }
 
 fn contract_with_policy(

--- a/crates/agileplus-domain/src/domain/governance.rs
+++ b/crates/agileplus-domain/src/domain/governance.rs
@@ -29,6 +29,18 @@ impl EvidenceType {
             Self::ManualAttestation => "manual_attestation",
         }
     }
+
+    /// Stable short slug used in generated governance policy references.
+    pub fn policy_ref_slug(self) -> &'static str {
+        match self {
+            Self::TestResult => "test-result",
+            Self::CiOutput => "ci",
+            Self::ReviewApproval => "review",
+            Self::SecurityScan => "security-scan",
+            Self::LintResult => "lint",
+            Self::ManualAttestation => "manual-attestation",
+        }
+    }
 }
 
 /// A single evidence requirement attached to a governance rule.
@@ -201,7 +213,10 @@ impl PolicyRule {
         ];
 
         if let Some(evidence_type) = self.rule.check.required_evidence_type() {
-            keys.push(format!("policy:{}-required", evidence_type.as_str()));
+            keys.push(format!(
+                "policy:{}-required",
+                evidence_type.policy_ref_slug()
+            ));
         }
 
         keys


### PR DESCRIPTION
## **User description**
## Summary
- Follow-up for merged PR #424 review blockers.
- Bind evidence-backed policy rules to generated policy refs such as `policy:ci-required`.
- Treat empty `policy_refs` as no policy opt-in instead of evaluating every active policy.
- Cache feature-scoped evidence once per validate pass and reuse it for policy checks.

## Stack Topology
- Base: `main`
- Head: `layer/validate-policy-review-blockers`
- Follow-up to: #424

## Validation
- `cargo fmt --check`
- `cargo test -p agileplus-cli policy`
- `cargo test -p agileplus-cli commands::validate`
- `cargo test -p agileplus-domain`

## Governance
- Uses an approved `layer/` branch prefix.
- Addresses unresolved #424 review findings after #424 was merged before it could be updated.

## CI Exception
- `security/snyk (kooshapari)` is reporting an external Snyk PR-check error.
- This matches the existing billing/quota exception path and is tracked with `ci-billing-exception`.


___

## **CodeAnt-AI Description**
**Bind policy checks to the right generated refs and skip policy evaluation when none are declared**

### What Changed
- Policy checks now match the same reference format used by generated governance contracts, so built-in CI and similar rules attach to the intended active policy.
- Contracts with no policy references no longer trigger evaluation of all active policies.
- Evidence for a feature is loaded once per validation run and reused across policy checks, reducing repeated lookups during validation.
- Added coverage for matching generated CI policy refs and for skipping policy evaluation when no policy refs are present.

### Impact
`✅ Correct policy matching for generated governance refs`
`✅ Fewer unnecessary policy evaluations`
`✅ Faster validation on features with many evidence records`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=8x0CxZk9FZ3QZWGH9t3AlSAFNOWaEsQvvNmBGe-lZYI&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the core `validate` policy/evidence evaluation logic and matching semantics, which can alter pass/fail outcomes for governance validation.
> 
> **Overview**
> **Policy evaluation now only runs when explicitly opted-in by the contract.** `evaluate_policies` returns no results when `policy_refs` is empty instead of evaluating all active policies.
> 
> **Policy reference matching is aligned with generated refs.** `EvidenceType` adds `policy_ref_slug()`, and `PolicyRule::reference_keys()` now uses it so active rules match refs like `policy:ci-required`.
> 
> **Evidence lookups are consolidated per feature.** Validation now loads and caches all evidence for a feature’s work packages once (`FeatureEvidence`) and reuses it for evidence requirement checks and evidence-backed policy checks (with added tests covering CI ref matching and the empty-ref behavior).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f955e329dad4cebeba637b59ec28433093055c3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->