### PR TITLE
fix: stabilize main workflow hygiene

### DIFF
--- a/.github/workflows/evidence-capture.yml
+++ b/.github/workflows/evidence-capture.yml
@@ -116,12 +116,14 @@ jobs:
           PASSED_COUNT: ${{ steps.cargo_test.outputs.passed_count }}
           FAILED_COUNT: ${{ steps.cargo_test.outputs.failed_count }}
         run: |
-          echo "## Evidence Bundle Captured" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Metric | Value |" >> "$GITHUB_STEP_SUMMARY"
-          echo "|--------|-------|" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Branch | \`${BRANCH}\` |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Commit | \`${COMMIT_SHA}\` |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Tests passed | ${PASSED_COUNT} |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Tests failed | ${FAILED_COUNT} |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Artifact | \`evidence-bundle-${RUN_NUMBER}\` |" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "## Evidence Bundle Captured"
+            echo ""
+            echo "| Metric | Value |"
+            echo "|--------|-------|"
+            echo "| Branch | \`${BRANCH}\` |"
+            echo "| Commit | \`${COMMIT_SHA}\` |"
+            echo "| Tests passed | ${PASSED_COUNT} |"
+            echo "| Tests failed | ${FAILED_COUNT} |"
+            echo "| Artifact | \`evidence-bundle-${RUN_NUMBER}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/openapi-check.yml
+++ b/.github/workflows/openapi-check.yml
@@ -8,10 +8,9 @@ name: OpenAPI Drift Check
 #
 # NOTE (deferred): While the `agileplus-plugin-core` git dependency
 # (SHA `ba652dec…`) returns HTTP 404, `cargo build` cannot resolve the
-# workspace. During that window the drift-check step is gated off with
-# `if: false` and the workflow short-circuits with a reminder. Once the
-# dep is unpinned or republished, flip the gate to `if: true` (or drop
-# the condition entirely) — no other changes required.
+# workspace. During that window this workflow emits a reminder and exits
+# successfully. Once the dep is unpinned or republished, reintroduce the
+# Rust setup, regeneration, and drift diff steps.
 
 on:
   pull_request:
@@ -35,23 +34,5 @@ jobs:
         run: |
           echo "::notice::OpenAPI drift check is deferred while the"
           echo "::notice::agileplus-plugin-core git dependency (SHA ba652dec...)"
-          echo "::notice::returns HTTP 404. Once resolved, flip \`if: false\`"
-          echo "::notice::on the drift step below to re-enable automated checking."
-
-      - name: Install Rust toolchain
-        if: false  # gated: see header comment
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache cargo
-        if: false  # gated: see header comment
-        uses: Swatinem/rust-cache@v2
-
-      - name: Regenerate openapi.yaml
-        if: false  # gated: see header comment
-        run: |
-          cargo run --bin agileplus-api -- --dump-openapi > /tmp/current.yaml
-
-      - name: Verify no drift
-        if: false  # gated: see header comment
-        run: |
-          git diff --no-index --exit-code openapi.yaml /tmp/current.yaml
+          echo "::notice::returns HTTP 404. Re-enable the drift check after that"
+          echo "::notice::dependency is restored."

--- a/.github/workflows/sentry-error-tracking.yml
+++ b/.github/workflows/sentry-error-tracking.yml
@@ -71,12 +71,14 @@ jobs:
         run: |
           ORG_SLUG="phenotype"
           PROJECT_ID="agileplus"
-          echo "## Sentry Error Dashboard" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "🔗 **View errors**: https://sentry.io/organizations/${ORG_SLUG}/issues/?project=${PROJECT_ID}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Environment**: production" >> $GITHUB_STEP_SUMMARY
-          echo "**Workflow**: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "## Sentry Error Dashboard"
+            echo ""
+            echo "🔗 **View errors**: https://sentry.io/organizations/${ORG_SLUG}/issues/?project=${PROJECT_ID}"
+            echo ""
+            echo "**Environment**: production"
+            echo "**Workflow**: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   integration-with-github-issues:
     name: GitHub-Sentry Integration Verification
@@ -107,15 +109,17 @@ jobs:
 
       - name: Generate integration checklist
         run: |
-          echo "## Sentry-GitHub Integration Checklist" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "- [ ] GitHub authorization granted in Sentry" >> $GITHUB_STEP_SUMMARY
-          echo "- [ ] Auto-issue creation enabled for high severity" >> $GITHUB_STEP_SUMMARY
-          echo "- [ ] Alert labels configured (sentry-critical, error-tracking)" >> $GITHUB_STEP_SUMMARY
-          echo "- [ ] Notification channel selected" >> $GITHUB_STEP_SUMMARY
-          echo "- [ ] Test issue created and verified" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Last checked**: $(date -u +'%Y-%m-%d %H:%M:%S UTC')" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "## Sentry-GitHub Integration Checklist"
+            echo ""
+            echo "- [ ] GitHub authorization granted in Sentry"
+            echo "- [ ] Auto-issue creation enabled for high severity"
+            echo "- [ ] Alert labels configured (sentry-critical, error-tracking)"
+            echo "- [ ] Notification channel selected"
+            echo "- [ ] Test issue created and verified"
+            echo ""
+            echo "**Last checked**: $(date -u +'%Y-%m-%d %H:%M:%S UTC')"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   notify-on-failure:
     name: Notify on Sentry Tracking Issues

--- a/.github/workflows/sync-canary.yml
+++ b/.github/workflows/sync-canary.yml
@@ -28,7 +28,11 @@ jobs:
 
       - name: Prepare local canary ref
         run: |
-          git fetch origin canary:canary || git branch canary origin/canary
+          if git ls-remote --exit-code --heads origin canary >/dev/null 2>&1; then
+            git fetch origin canary:canary
+          else
+            git branch canary "$GITHUB_SHA"
+          fi
 
       - name: Sync canary from main
         run: cargo run -p agileplus-cli --locked -- branch:sync --source main --target canary


### PR DESCRIPTION
## **User description**
## Summary
- initialize the canary branch from the current main commit when it does not already exist
- keep the deferred OpenAPI drift workflow actionlint-clean without `if: false` placeholders
- group workflow summary writes so shellcheck/actionlint stop failing Config Lint

## Validation
- `actionlint .github/workflows/*.yml`

Co-authored-by: Codex <noreply@openai.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only changes; main impact is that the OpenAPI drift check remains intentionally disabled and canary sync behavior changes when the `canary` branch is missing.
> 
> **Overview**
> Improves GitHub Actions workflow hygiene by grouping multi-line `echo` writes into a single redirected block in `evidence-capture.yml` and `sentry-error-tracking.yml`, reducing `shellcheck`/`actionlint` noise.
> 
> Adjusts `sync-canary.yml` to detect whether the remote `canary` branch exists and initialize it from the current `main` SHA if it doesn’t, avoiding fetch/branch failures.
> 
> Simplifies `openapi-check.yml` to **temporarily short-circuit** with notices (removing the placeholder `if: false` gated Rust/OpenAPI regeneration steps) while the `agileplus-plugin-core` dependency is unavailable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 781ff0c60d19b4e5ded07391d4d8a4d8ad73ac83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Stabilize main workflow checks and canary sync**

### What Changed
- Workflow summaries now write as a single block, which keeps CI lint checks from failing on the dashboard and evidence summary steps.
- Canary sync now creates the `canary` branch from the current `main` commit when the branch does not already exist, avoiding branch setup failures.
- The OpenAPI drift workflow now stops early with a notice instead of running disabled placeholder steps while its dependency is unavailable.

### Impact
`✅ Fewer CI workflow failures`
`✅ Reliable canary branch setup`
`✅ Clearer OpenAPI check status`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=w2jiXJ44ixWi2WXkPgYgZbRFuTeVUjaWKC43NUuswQg&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
