### PR TITLE
ci: point reusable workflow callers at top-level paths

### DIFF
--- a/.github/workflows/alert-sync-issues.yml
+++ b/.github/workflows/alert-sync-issues.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   sync:
-    uses: KooshaPari/phenoShared/.github/workflows/reusable/alert-sync-issues.yml@5e6c1f05d696d056b24df431401b4632b01be0d3
+    uses: KooshaPari/phenoShared/.github/workflows/alert-sync-issues.yml@main
     with:
       auto-label: auto-alert-sync
       min_severity: medium

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   deploy:
-    uses: KooshaPari/phenoShared/.github/workflows/reusable/vitepress-pages.yml@0756e815d52f896ccc4f33e8e09a55817c6dd6f8
+    uses: KooshaPari/phenoShared/.github/workflows/vitepress-pages.yml@main
     with:
       concurrency_group: agileplus-vitepress-pages
     permissions:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   release-drafter:
-    uses: KooshaPari/phenoShared/.github/workflows/reusable/release-drafter.yml@main
+    uses: KooshaPari/phenoShared/.github/workflows/reusable-release-drafter.yml@main
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/security-guard-hook-audit.yml
+++ b/.github/workflows/security-guard-hook-audit.yml
@@ -12,4 +12,4 @@ permissions:
 
 jobs:
   guard:
-    uses: KooshaPari/phenoShared/.github/workflows/reusable/security-guard-hook-audit.yml@0756e815d52f896ccc4f33e8e09a55817c6dd6f8
+    uses: KooshaPari/phenoShared/.github/workflows/security-guard-hook-audit.yml@main

--- a/.github/workflows/self-merge-gate.yml
+++ b/.github/workflows/self-merge-gate.yml
@@ -1,7 +1,7 @@
 name: self-merge-gate
 
 # Delegates to phenoShared reusable workflow.
-# See: https://github.com/KooshaPari/phenoShared/blob/main/.github/workflows/reusable/self-merge-gate.yml
+# See: https://github.com/KooshaPari/phenoShared/blob/main/.github/workflows/self-merge-gate.yml
 
 on: [pull_request_review]
 
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   gate:
-    uses: KooshaPari/phenoShared/.github/workflows/reusable/self-merge-gate.yml@main
+    uses: KooshaPari/phenoShared/.github/workflows/self-merge-gate.yml@main

--- a/.github/workflows/tag-automation.yml
+++ b/.github/workflows/tag-automation.yml
@@ -1,7 +1,7 @@
 name: Tag Automation
 
 # Delegates to phenoShared reusable workflow.
-# See: https://github.com/KooshaPari/phenoShared/blob/main/.github/workflows/reusable/tag-automation.yml
+# See: https://github.com/KooshaPari/phenoShared/blob/main/.github/workflows/tag-automation.yml
 
 on:
   push:
@@ -10,6 +10,6 @@ on:
 
 jobs:
   tag:
-    uses: KooshaPari/phenoShared/.github/workflows/reusable/tag-automation.yml@main
+    uses: KooshaPari/phenoShared/.github/workflows/tag-automation.yml@main
     permissions:
       contents: write


### PR DESCRIPTION
## **User description**
## Summary
- point AgilePlus reusable workflow callers at top-level `phenoShared/.github/workflows/*.yml` files
- replace nested `reusable/` workflow paths that GitHub does not schedule for `workflow_call`
- route VitePress Pages deploy through the newly exposed top-level `phenoShared` reusable workflow

## Stack Topology
- Single-layer CI wrapper repair targeting `main`.
- Depends on `phenoShared#127`, which exposed top-level `vitepress-pages.yml`.
- Touches GitHub Actions workflow definitions only; no application code changes.

## Validation
- `actionlint .github/workflows/release-drafter.yml .github/workflows/tag-automation.yml .github/workflows/alert-sync-issues.yml .github/workflows/security-guard-hook-audit.yml .github/workflows/self-merge-gate.yml .github/workflows/deploy.yml`

## Governance
- Direct-to-main PR is intentional because this repairs default-branch workflow-file failures introduced by invalid reusable workflow targets.
- Uses the approved `ci/` branch prefix.
- `layered-pr-exception` is requested because this is a narrow CI repair with no product behavior impact.

## CI Exception
- Kilo/CodeRabbit/Cursor/Semgrep/Socket external checks may queue independently of repository content.
- Repository-owned validation for this patch is actionlint and GitHub Actions workflow scheduling on the PR.

Co-authored-by: Codex <noreply@openai.com>

<!-- CURSOR_SUMMARY -->

> [!NOTE]
> **Medium Risk**
> CI behavior now depends on reusable workflows referenced from `phenoShared@main` (instead of pinned SHAs or old paths), so upstream changes can alter builds/releases without changes in this repo. Scope is limited to GitHub Actions workflow wiring; no application code is touched.
> 
> **Overview**
> Updates this repo’s GitHub Actions workflows to call the **top-level** reusable workflows in `KooshaPari/phenoShared` (e.g., `alert-sync-issues`, `vitepress-pages`, `security-guard-hook-audit`, `self-merge-gate`, `tag-automation`) instead of the prior `reusable/` paths and pinned SHAs.
> 
> Adjusts the release drafter caller to use `reusable-release-drafter.yml@main` and updates inline “See” links accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f284eca772b750afa4366ae3cc9b15599281fd12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Restore GitHub Actions workflows that were pointing at invalid reusable workflow paths**

### What Changed
- Updated several repository workflows to call the reusable workflows from the correct top-level paths so they can be scheduled and run again
- Fixed tag automation, self-merge gating, alert syncing, security hook auditing, and VitePress Pages deploy to use the available workflow locations
- Kept the existing workflow behavior and inputs the same while correcting the targets they run from

### Impact
`✅ Fewer broken CI runs`
`✅ Reliable docs deploys`
`✅ Working release and tag automation`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=pseXw6Qz9LZrwlbo43eg6ld4Hj8By48NsCOEhsJSraU&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
