### PR TITLE
ci(codeql): add Rust CodeQL analysis workflow

### DIFF
--- a/.github/workflows/codeql-rust.yml
+++ b/.github/workflows/codeql-rust.yml
@@ -1,0 +1,33 @@
+name: CodeQL (Rust)
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '17 4 * * 2'
+  workflow_dispatch:
+
+jobs:
+  analyze:
+    name: Analyze (rust)
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: rust
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:rust"


### PR DESCRIPTION
Per memory feedback_codeql_no_rust_default_setup. Adds Tuesday cron + on-demand verification.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change, but it adds an additional CodeQL scan that may duplicate existing workflows and increase CI time/noise.
> 
> **Overview**
> Adds a dedicated GitHub Actions workflow, `codeql-rust.yml`, to run **CodeQL analysis for Rust** on pushes/PRs to `main`, on a weekly Tuesday cron, and via manual dispatch.
> 
> The job checks out the repo, initializes CodeQL for `rust`, runs `autobuild`, and uploads SARIF results with the required `security-events: write` permission.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91005c64d3fc6a292ccd5a12cdc82ab95bb1818f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->