### PR TITLE
chore(hygiene): apply local hygiene and sladge badge changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 [![Release](https://img.shields.io/github/v/release/KooshaPari/AgilePlus?include_prereleases&sort=semver)](https://github.com/KooshaPari/AgilePlus/releases)
 [![License](https://img.shields.io/github/license/KooshaPari/AgilePlus)](LICENSE)
 [![Phenotype](https://img.shields.io/badge/Phenotype-org-blueviolet)](https://github.com/KooshaPari)
+[![AI Slop Inside](https://sladge.net/badge.svg)](https://sladge.net)
 
 **AgilePlus is a local-first, spec-driven agile work-tracking CLI for AI-agent and human teams.** It models features, work packages, and acceptance criteria as versioned specs on disk, with optional sync to GitHub Issues, dashboards, and P2P merge for multi-actor collaboration.
 

--- a/docs/sessions/20260429-sladge-badge-rollout/00_SESSION_OVERVIEW.md
+++ b/docs/sessions/20260429-sladge-badge-rollout/00_SESSION_OVERVIEW.md
@@ -1,0 +1,16 @@
+# Session Overview
+
+## Goal
+
+Add the `sladge` governance badge to AgilePlus without touching the dirty
+canonical checkout.
+
+## Outcome
+
+- Added the `AI Slop Inside` badge beside the existing README badge row.
+- Used an isolated `docs/sladge-badge` worktree to avoid unrelated local churn.
+
+## Validation
+
+- README diff reviewed.
+- Git status checked before commit.

--- a/docs/sessions/20260429-sladge-badge-rollout/01_RESEARCH.md
+++ b/docs/sessions/20260429-sladge-badge-rollout/01_RESEARCH.md
@@ -1,0 +1,13 @@
+# Research
+
+## Findings
+
+- The canonical AgilePlus checkout has broad unrelated local modifications.
+- The projects-landing governance task lists AgilePlus as a likely downstream
+  `sladge` badge candidate once isolated from unrelated README churn.
+- AgilePlus is explicitly an AI-agent and human-team work-tracking CLI, so the
+  badge is relevant governance metadata.
+
+## Decision
+
+Create a clean worktree from `main` and apply the README badge there.

--- a/docs/sessions/20260429-sladge-badge-rollout/02_SPECIFICATIONS.md
+++ b/docs/sessions/20260429-sladge-badge-rollout/02_SPECIFICATIONS.md
@@ -1,0 +1,12 @@
+# Specifications
+
+## Requirements
+
+- Add the `sladge` badge near the top README badge cluster.
+- Do not alter project catalog metadata.
+- Do not stage unrelated canonical checkout changes.
+
+## Acceptance Criteria
+
+- README contains the `https://sladge.net/badge.svg` badge.
+- Commit contains only README and session documentation.

--- a/docs/sessions/20260429-sladge-badge-rollout/03_DAG_WBS.md
+++ b/docs/sessions/20260429-sladge-badge-rollout/03_DAG_WBS.md
@@ -1,0 +1,13 @@
+# DAG WBS
+
+## Work Items
+
+1. Create isolated AgilePlus worktree.
+2. Add README badge.
+3. Add session docs.
+4. Review diff and commit.
+
+## Dependencies
+
+- Item 2 depends on item 1.
+- Item 4 depends on items 2 and 3.

--- a/docs/sessions/20260429-sladge-badge-rollout/04_IMPLEMENTATION_STRATEGY.md
+++ b/docs/sessions/20260429-sladge-badge-rollout/04_IMPLEMENTATION_STRATEGY.md
@@ -1,0 +1,4 @@
+# Implementation Strategy
+
+Keep the change intentionally narrow. The badge is governance metadata, not a
+product feature, so it belongs in the README badge row and session record only.

--- a/docs/sessions/20260429-sladge-badge-rollout/05_KNOWN_ISSUES.md
+++ b/docs/sessions/20260429-sladge-badge-rollout/05_KNOWN_ISSUES.md
@@ -1,0 +1,6 @@
+# Known Issues
+
+## Canonical Checkout Dirty State
+
+The canonical AgilePlus checkout remains dirty. This worktree intentionally
+avoids reconciling that broader state.

--- a/docs/sessions/20260429-sladge-badge-rollout/06_TESTING_STRATEGY.md
+++ b/docs/sessions/20260429-sladge-badge-rollout/06_TESTING_STRATEGY.md
@@ -1,0 +1,8 @@
+# Testing Strategy
+
+## Checks
+
+- Review README diff.
+- Confirm git status only includes README and session docs.
+
+No build is required for this README-only governance badge change.


### PR DESCRIPTION
Consolidated hygiene changes pulled from local canonical drift.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change that adds a README badge and session write-up, with no runtime, build, or data-handling impact.
> 
> **Overview**
> Adds the `sladge` “AI Slop Inside” governance badge to the README’s badge row.
> 
> Introduces a new session record under `docs/sessions/20260429-sladge-badge-rollout/` documenting the goal, decision, implementation strategy, and validation for this badge-only update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32f870c3e76ba0379c29423b1edb844a76ea3416. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added governance metadata badge to the project README
  * Added session documentation including implementation specifications, work breakdown structure, and testing procedures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->