### PR TITLE
spec: add meta.json to consolidation specs

### DIFF
--- a/kitty-specs/consolidate-cache-adapter-crate/meta.json
+++ b/kitty-specs/consolidate-cache-adapter-crate/meta.json
@@ -1,0 +1,10 @@
+{
+  "spec_id": "consolidate-cache-adapter-crate",
+  "slug": "consolidate-cache-adapter-crate",
+  "title": "Consolidate Cache Adapter Crate",
+  "status": "in_progress",
+  "priority": "high",
+  "created_at": "2026-05-02T00:00:00Z",
+  "source_description": "Consolidate `phenotype-cache-adapter` to canonical `phenoShared`",
+  "type": "consolidation"
+}

--- a/kitty-specs/consolidate-event-sourcing-crate/meta.json
+++ b/kitty-specs/consolidate-event-sourcing-crate/meta.json
@@ -1,0 +1,10 @@
+{
+  "spec_id": "consolidate-event-sourcing-crate",
+  "slug": "consolidate-event-sourcing-crate",
+  "title": "Consolidate Event Sourcing Crate",
+  "status": "in_progress",
+  "priority": "high",
+  "created_at": "2026-05-02T00:00:00Z",
+  "source_description": "Consolidate `phenotype-event-sourcing` to canonical `phenoShared`",
+  "type": "consolidation"
+}

--- a/kitty-specs/consolidate-policy-engine-crate/meta.json
+++ b/kitty-specs/consolidate-policy-engine-crate/meta.json
@@ -1,0 +1,10 @@
+{
+  "spec_id": "consolidate-policy-engine-crate",
+  "slug": "consolidate-policy-engine-crate",
+  "title": "Consolidate Policy Engine Crate",
+  "status": "in_progress",
+  "priority": "high",
+  "created_at": "2026-05-02T00:00:00Z",
+  "source_description": "Consolidate `phenotype-policy-engine` to canonical `phenoShared`",
+  "type": "consolidation"
+}

--- a/kitty-specs/consolidate-state-machine-crate/meta.json
+++ b/kitty-specs/consolidate-state-machine-crate/meta.json
@@ -1,0 +1,10 @@
+{
+  "spec_id": "consolidate-state-machine-crate",
+  "slug": "consolidate-state-machine-crate",
+  "title": "Consolidate State Machine Crate",
+  "status": "in_progress",
+  "priority": "high",
+  "created_at": "2026-05-02T00:00:00Z",
+  "source_description": "Consolidate `phenotype-state-machine` to canonical `phenoShared`",
+  "type": "consolidation"
+}

--- a/kitty-specs/eco-012-orgops-capital-ledger/meta.json
+++ b/kitty-specs/eco-012-orgops-capital-ledger/meta.json
@@ -1,0 +1,10 @@
+{
+  "spec_id": "eco-012",
+  "slug": "eco-012-orgops-capital-ledger",
+  "title": "OrgOps Capital Ledger",
+  "status": "in_progress",
+  "priority": "high",
+  "created_at": "2026-05-02T00:00:00Z",
+  "source_description": "OrgOps Capital Ledger — phenotype-capital crate, consumption tracking, budget enforcement, secret lifecycle, browser profiles, git-core worktree management, and AgilePlus CLI integration",
+  "type": "operational"
+}


### PR DESCRIPTION
## Summary
- Add missing `meta.json` to 5 consolidation specs that already had `tasks.md` on `main`:
  - `consolidate-cache-adapter-crate`
  - `consolidate-event-sourcing-crate`
  - `consolidate-policy-engine-crate`
  - `consolidate-state-machine-crate`
  - `eco-012-orgops-capital-ledger`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds metadata JSON files under `kitty-specs` only; no runtime code paths or behavior are changed, so risk is low aside from potential tooling expectations on schema/fields.
> 
> **Overview**
> Adds missing `meta.json` metadata for five existing `kitty-specs` entries (four consolidation specs and `eco-012`). The new files capture basic spec attributes like `spec_id`, `slug`, `title`, `status`, `priority`, timestamps, and `type` to align these specs with the repo’s metadata convention.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c60d15f0694a0ed977d1c858cb2bc45fb583c677. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->