### PR TITLE
fix(deploy): inline workflow for phenotype.space

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,10 +10,50 @@ on:
 
 jobs:
   deploy:
-    uses: KooshaPari/phenoShared/.github/workflows/vitepress-pages.yml@bf9d385002ba36c4bba4ff1b17c49212bea42d74
-    with:
-      concurrency_group: agileplus-vitepress-pages
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pages: write
       id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - name: Clone phenodocs
+        run: |
+          git clone --depth 1 https://github.com/KooshaPari/phenodocs.git /tmp/phenodocs
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+
+      - name: Setup Pages
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b
+
+      - name: Install dependencies
+        working-directory: docs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Link @phenotype/docs from phenodocs
+          mkdir -p docs/node_modules/@phenotype
+          ln -sf /tmp/phenodocs/packages/docs docs/node_modules/@phenotype/docs
+          # Configure npm for GitHub Packages
+          echo "@phenotype:registry=https://npm.pkg.github.com" >> ~/.npmrc
+          echo "//npm.pkg.github.com/:_authToken=\${GITHUB_TOKEN}" >> ~/.npmrc
+          bun install
+
+      - name: Build VitePress site
+        working-directory: docs
+        env:
+          GITHUB_PAGES: true
+          PHENOTYPE_CUSTOM_DOMAIN: "true"
+        run: bun run docs:build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b
+        with:
+          path: docs/docs/.vitepress/dist
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e


### PR DESCRIPTION
Fixes AgilePlus VitePress deployment for phenotype.space custom domain.

Changes:
- Replaced reusable workflow with inline steps
- Clone phenodocs and symlink @phenotype/docs
- Set PHENOTYPE_CUSTOM_DOMAIN=true for root base path
- Fixed artifact path

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it replaces the previously reused deployment workflow with custom inline steps and changes dependency wiring and artifact paths, which could break Pages builds/deploys if any step/path/token handling is incorrect.
> 
> **Overview**
> Replaces the reusable `vitepress-pages.yml` workflow with an inline GitHub Pages deploy job that checks out the repo, sets up Bun/Pages, installs deps, builds, uploads the artifact, and deploys.
> 
> The workflow now clones `KooshaPari/phenodocs` and symlinks `@phenotype/docs` into `docs/node_modules`, configures GitHub Packages auth via `GITHUB_TOKEN`, sets `PHENOTYPE_CUSTOM_DOMAIN="true"` for the build, and updates the uploaded artifact path to `docs/docs/.vitepress/dist`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcb5115c64eabf4821db49daf1e753c68262fc35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->