### PR TITLE
fix(deploy): inline workflow for phenotype.space

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,10 +10,50 @@ on:
 
 jobs:
   deploy:
-    uses: KooshaPari/phenoShared/.github/workflows/vitepress-pages.yml@bf9d385002ba36c4bba4ff1b17c49212bea42d74
-    with:
-      concurrency_group: agileplus-vitepress-pages
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pages: write
       id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - name: Clone phenodocs
+        run: |
+          git clone --depth 1 https://github.com/KooshaPari/phenodocs.git /tmp/phenodocs
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+
+      - name: Setup Pages
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b
+
+      - name: Install dependencies
+        working-directory: docs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Link @phenotype/docs from phenodocs
+          mkdir -p docs/node_modules/@phenotype
+          ln -sf /tmp/phenodocs/packages/docs docs/node_modules/@phenotype/docs
+          # Configure npm for GitHub Packages
+          echo "@phenotype:registry=https://npm.pkg.github.com" >> ~/.npmrc
+          echo "//npm.pkg.github.com/:_authToken=\${GITHUB_TOKEN}" >> ~/.npmrc
+          bun install
+
+      - name: Build VitePress site
+        working-directory: docs
+        env:
+          GITHUB_PAGES: true
+          PHENOTYPE_CUSTOM_DOMAIN: "true"
+        run: bun run docs:build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b
+        with:
+          path: docs/docs/.vitepress/dist
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e


### PR DESCRIPTION
## **User description**
Fixes AgilePlus VitePress deployment for phenotype.space.

Changes:
- Replaced phenoShared reusable workflow with inline steps
- Clone phenodocs and symlink @phenotype/docs for build
- Set PHENOTYPE_CUSTOM_DOMAIN=true for root base path (/assets/)
- Fixed artifact path to docs/docs/.vitepress/dist

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI/deploy wiring; no application runtime or auth logic is modified, though a broken deploy would only affect the docs site.
> 
> **Overview**
> **Replaces the previous sparse checkout and separate docs-branch clone** with a standard repo checkout plus a shallow **phenodocs** clone used to symlink **`@phenotype/docs`** into `docs/node_modules` before **`bun install`** and **`docs:build`**.
> 
> The install step now creates the symlink with **`ln -sf`**, writes GitHub Packages **`.npmrc`** entries (with comments reordering setup), and still builds with **`GITHUB_PAGES`** and **`PHENOTYPE_CUSTOM_DOMAIN=true`** for root-domain asset paths. The Pages artifact upload remains pointed at **`docs/docs/.vitepress/dist`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22945b74dedc71e65d85e0bf0d21cf5852b18a82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Fix the phenotype.space docs deployment**

### What Changed
- The docs site deploy now uses a single inline workflow instead of the previous reusable setup
- The build links in the shared `@phenotype/docs` content before installing and building, so the docs site can compile correctly
- The site is built for the root domain with the correct asset path, and the Pages upload still targets the VitePress output folder

### Impact
`✅ Working docs deploys`
`✅ Fewer broken phenotype.space releases`
`✅ Correct root-domain asset loading`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
