### PR TITLE
fix(deploy): inline workflow for phenotype.space

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,10 +10,60 @@ on:
 
 jobs:
   deploy:
-    uses: KooshaPari/phenoShared/.github/workflows/vitepress-pages.yml@bf9d385002ba36c4bba4ff1b17c49212bea42d74
-    with:
-      concurrency_group: agileplus-vitepress-pages
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pages: write
       id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          sparse-checkout: |
+            .github
+            agileplus
+            kitty-specs
+            .work-audit
+          sparse-checkout-cone-mode: false
+
+      - name: Fetch docs content
+        run: |
+          git clone --depth 1 --branch agileplus/feat/docs-site https://github.com/KooshaPari/AgilePlus.git /tmp/agileplus-docs
+          cp -r /tmp/agileplus-docs/docs .
+
+      - name: Checkout phenodocs
+        run: |
+          git clone --depth 1 https://github.com/KooshaPari/phenodocs.git /tmp/phenodocs
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+
+      - name: Setup Pages
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b
+
+      - name: Install dependencies
+        working-directory: docs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "@phenotype:registry=https://npm.pkg.github.com" >> ~/.npmrc
+          echo "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}" >> ~/.npmrc
+          mkdir -p docs/node_modules/@phenotype
+          ln -s /tmp/phenodocs/packages/docs docs/node_modules/@phenotype/docs
+          bun install
+
+      - name: Build VitePress site
+        working-directory: docs
+        env:
+          GITHUB_PAGES: true
+          PHENOTYPE_CUSTOM_DOMAIN: "true"
+        run: bun run docs:build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b
+        with:
+          path: docs/.vitepress/dist
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b
         with:
-          path: docs/.vitepress/dist
+          path: docs/docs/.vitepress/dist
 
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
Fixes AgilePlus VitePress deployment for phenotype.space.

Changes:
- Inline workflow (no reusable workflow dependency)
- Fetch docs from agileplus/feat/docs-site branch
- Clone phenodocs and symlink @phenotype/docs for build
- Set PHENOTYPE_CUSTOM_DOMAIN=true for root base path (/assets/)
- Fixed artifact path to docs/docs/.vitepress/dist