### PR TITLE
Add web dashboard env ignore

### DIFF
--- a/.agileplus/plane/apps/web/.gitignore
+++ b/.agileplus/plane/apps/web/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+.env
+.env.local
+.env.*.local
+dist/
+.next/
+build/


### PR DESCRIPTION
Adds a minimal app-local .gitignore at the web dashboard path to keep .env files and build artifacts out of the Plane dashboard workspace.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only ignore rules with no runtime, auth, or data-handling changes.
> 
> **Overview**
> Adds a **new `.gitignore`** under the web dashboard app path so local secrets and generated output are not committed from that workspace.
> 
> It ignores **`node_modules/`**, **`.env` / `.env.local` / `.env.*.local`**, and common build dirs (**`dist/`**, **`.next/`**, **`build/`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c50fee435f900318d425d99205979cb7be8329bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->