### PR TITLE
fix: dispatch-mcp deps

### DIFF
--- a/dispatch-mcp/pyproject.toml
+++ b/dispatch-mcp/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
   "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-  "mcp>=1.0.0,<1.2.0",
+  "fastmcp>=2.0.0,<3.0.0",
   "httpx>=0.27.0,<0.29.0",
 ]
 

--- a/dispatch-mcp/src/dispatch_mcp/server.py
+++ b/dispatch-mcp/src/dispatch_mcp/server.py
@@ -9,7 +9,7 @@ from typing import Any
 from urllib.parse import urlparse
 
 import httpx
-from mcp.server.fastmcp import FastMCP
+from fastmcp import FastMCP
 
 mcp = FastMCP("dispatch-mcp")
 _logger = logging.getLogger("dispatch_mcp")


### PR DESCRIPTION
## **User description**
Fix pyproject.toml and server.py

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency and import-only change with no edits to dispatch or OmniRoute logic; risk is mainly install/compat with fastmcp 2.x.
> 
> **Overview**
> **dispatch-mcp** now depends on the standalone **`fastmcp`** package (2.x) instead of pulling **`FastMCP`** through **`mcp`** 1.x.
> 
> `pyproject.toml` swaps `mcp>=1.0.0,<1.2.0` for `fastmcp>=2.0.0,<3.0.0`, and `server.py` imports `FastMCP` from `fastmcp` rather than `mcp.server.fastmcp`. Tool registration and runtime behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c44f1d09bed8d4162dc46ae56a0f9c93e4eb2767. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Use the standalone FastMCP package for dispatch-mcp**

### What Changed
- dispatch-mcp now loads FastMCP from the standalone `fastmcp` package instead of the older `mcp` package
- The app dependency list now installs `fastmcp` directly, which matches the current server import

### Impact
`✅ Fewer startup failures from missing FastMCP imports`
`✅ Smoother installs with the current dispatch-mcp dependencies`
`✅ Lower risk of dependency mismatch during deployment`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
