### PR TITLE
feat(domain): scaffold agileplus-domain aggregate types and port traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,8 +19,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "agileplus-dashboard"
+version = "0.1.0"
+dependencies = [
+ "agileplus-domain",
+ "agileplus-events",
+ "agileplus-fixtures",
+ "agileplus-sqlite",
+ "anyhow",
+ "askama",
+ "async-stream",
+ "axum",
+ "axum-extra",
+ "chrono",
+ "serde",
+ "serde_json",
+ "sysinfo",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "toml",
+ "tower",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "agileplus-domain"
 version = "0.1.0"
+dependencies = [
+ "chrono",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "agileplus-events"
+version = "0.1.0"
+dependencies = [
+ "agileplus-domain",
+ "async-trait",
+ "chrono",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
+name = "agileplus-fixtures"
+version = "0.1.0"
+dependencies = [
+ "agileplus-domain",
+ "chrono",
+ "serde_json",
+]
 
 [[package]]
 name = "agileplus-git"
@@ -38,6 +95,32 @@ dependencies = [
  "tokio",
  "toml",
  "tracing",
+]
+
+[[package]]
+name = "agileplus-sqlite"
+version = "0.1.0"
+dependencies = [
+ "agileplus-domain",
+ "agileplus-events",
+ "async-trait",
+ "chrono",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -100,7 +183,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -111,7 +194,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -127,6 +210,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "askama"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b79091df18a97caea757e28cd2d5fda49c6cd4bd01ddffd7ff01ace0c0ad2c28"
+dependencies = [
+ "askama_derive",
+ "askama_escape",
+ "humansize",
+ "num-traits",
+ "percent-encoding",
+]
+
+[[package]]
+name = "askama_derive"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19fe8d6cb13c4714962c072ea496f3392015f0989b1a2847bb4b2d9effd71d83"
+dependencies = [
+ "askama_parser",
+ "basic-toml",
+ "mime",
+ "mime_guess",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn",
+]
+
+[[package]]
+name = "askama_escape"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "619743e34b5ba4e9703bba34deac3427c72507c7159f5fd030aea8cac0cfe341"
+
+[[package]]
+name = "askama_parser"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acb1161c6b64d1c3d83108213c2a2533a342ac225aabd0bda218278c2ddb00c0"
+dependencies = [
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -163,6 +290,39 @@ dependencies = [
  "tracing",
  "tryhard",
  "url",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -231,6 +391,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-extra"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9963ff19f40c6102c76756ef0a46004c0d58957d87259fc9208ff8441c12ab96"
+dependencies = [
+ "axum",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "headers",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "serde_core",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "axum-macros"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -252,6 +435,15 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "basic-toml"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
@@ -541,7 +733,7 @@ checksum = "6401038de3af44fe74e6fccdb8a5b7db7ba418f480c8e9ad584c6f65c05a27a6"
 dependencies = [
  "derive_more",
  "either",
- "nom",
+ "nom 8.0.0",
  "nom_locate",
  "regex",
  "regex-syntax",
@@ -720,8 +912,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "faster-hex"
@@ -1865,6 +2069,9 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1891,6 +2098,39 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "headers"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
+dependencies = [
+ "base64",
+ "bytes",
+ "headers-core",
+ "http",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
+dependencies = [
+ "http",
+]
 
 [[package]]
 name = "heapless"
@@ -1942,6 +2182,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range-header"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1952,6 +2198,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "humansize"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7"
+dependencies = [
+ "libm",
+]
 
 [[package]]
 name = "humantime"
@@ -2006,7 +2261,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -2232,7 +2487,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2313,6 +2568,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2339,6 +2600,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libredox"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2348,6 +2615,17 @@ dependencies = [
  "libc",
  "plain",
  "redox_syscall 0.7.5",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2410,6 +2688,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2448,6 +2735,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2476,6 +2779,16 @@ dependencies = [
 
 [[package]]
 name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
 version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
@@ -2491,7 +2804,7 @@ checksum = "0b577e2d69827c4740cba2b52efaad1c4cc7c73042860b199710b3575c68438d"
 dependencies = [
  "bytecount",
  "memchr",
- "nom",
+ "nom 8.0.0",
 ]
 
 [[package]]
@@ -2525,6 +2838,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2819,6 +3150,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2900,6 +3251,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2918,7 +3283,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3171,6 +3536,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shell-words"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3250,7 +3624,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3349,6 +3723,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c33cd241af0f2e9e3b5c32163b873b29956890b5342e6745b917ce9d490f4af"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+ "memchr",
+ "ntapi",
+ "rayon",
+ "windows",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3358,7 +3746,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3368,7 +3756,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3420,6 +3808,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -3619,6 +4016,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "http-range-header",
+ "httpdate",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3660,6 +4083,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -3697,6 +4150,12 @@ name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-bom"
@@ -3772,6 +4231,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"
@@ -3938,7 +4403,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3948,16 +4413,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+dependencies = [
+ "windows-core 0.57.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+dependencies = [
+ "windows-implement 0.57.0",
+ "windows-interface 0.57.0",
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link",
- "windows-result",
+ "windows-result 0.4.1",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3965,6 +4463,17 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3990,6 +4499,15 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
@@ -4004,15 +4522,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -4040,21 +4549,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -4092,12 +4586,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -4110,12 +4598,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -4125,12 +4607,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4158,12 +4634,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -4173,12 +4643,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4194,12 +4658,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -4209,12 +4667,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/crates/agileplus-domain/Cargo.toml
+++ b/crates/agileplus-domain/Cargo.toml
@@ -6,3 +6,8 @@ license.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+chrono.workspace = true
+sha2.workspace = true

--- a/crates/agileplus-domain/src/domain/audit.rs
+++ b/crates/agileplus-domain/src/domain/audit.rs
@@ -1,0 +1,45 @@
+//! Audit log types — tamper-evident hash-chained entries.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+/// A reference to an evidence artifact in an audit entry.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EvidenceRef {
+    pub evidence_id: i64,
+    pub fr_id: String,
+}
+
+/// A single entry in the tamper-evident audit chain.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuditEntry {
+    pub id: i64,
+    pub feature_id: i64,
+    pub wp_id: Option<i64>,
+    pub timestamp: DateTime<Utc>,
+    pub actor: String,
+    pub transition: String,
+    pub evidence_refs: Vec<EvidenceRef>,
+    pub prev_hash: [u8; 32],
+    pub hash: [u8; 32],
+    pub event_id: Option<i64>,
+    pub archived_to: Option<String>,
+}
+
+/// Compute the SHA-256 hash of an audit entry (covers all mutable fields).
+pub fn hash_entry(entry: &AuditEntry) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(entry.feature_id.to_be_bytes());
+    if let Some(wp_id) = entry.wp_id {
+        hasher.update(wp_id.to_be_bytes());
+    }
+    hasher.update(entry.timestamp.to_rfc3339().as_bytes());
+    hasher.update(entry.actor.as_bytes());
+    hasher.update(entry.transition.as_bytes());
+    hasher.update(entry.prev_hash);
+    let result = hasher.finalize();
+    let mut hash = [0u8; 32];
+    hash.copy_from_slice(&result[..]);
+    hash
+}

--- a/crates/agileplus-domain/src/domain/backlog.rs
+++ b/crates/agileplus-domain/src/domain/backlog.rs
@@ -1,0 +1,157 @@
+//! Backlog queue types.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::str::FromStr;
+
+/// The intent/category of a backlog item.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Intent {
+    Bug,
+    Feature,
+    Idea,
+    Task,
+}
+
+impl fmt::Display for Intent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            Intent::Bug => "bug",
+            Intent::Feature => "feature",
+            Intent::Idea => "idea",
+            Intent::Task => "task",
+        };
+        write!(f, "{s}")
+    }
+}
+
+impl FromStr for Intent {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "bug" => Ok(Intent::Bug),
+            "feature" => Ok(Intent::Feature),
+            "idea" => Ok(Intent::Idea),
+            "task" => Ok(Intent::Task),
+            _ => Err(format!("unknown Intent: {s}")),
+        }
+    }
+}
+
+/// Priority of a backlog item.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum BacklogPriority {
+    Critical,
+    High,
+    Medium,
+    Low,
+}
+
+impl fmt::Display for BacklogPriority {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            BacklogPriority::Critical => "critical",
+            BacklogPriority::High => "high",
+            BacklogPriority::Medium => "medium",
+            BacklogPriority::Low => "low",
+        };
+        write!(f, "{s}")
+    }
+}
+
+impl FromStr for BacklogPriority {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "critical" => Ok(BacklogPriority::Critical),
+            "high" => Ok(BacklogPriority::High),
+            "medium" => Ok(BacklogPriority::Medium),
+            "low" => Ok(BacklogPriority::Low),
+            _ => Err(format!("unknown BacklogPriority: {s}")),
+        }
+    }
+}
+
+/// Workflow status of a backlog item.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BacklogStatus {
+    New,
+    Triaged,
+    InProgress,
+    Done,
+    Dismissed,
+}
+
+impl fmt::Display for BacklogStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            BacklogStatus::New => "new",
+            BacklogStatus::Triaged => "triaged",
+            BacklogStatus::InProgress => "in_progress",
+            BacklogStatus::Done => "done",
+            BacklogStatus::Dismissed => "dismissed",
+        };
+        write!(f, "{s}")
+    }
+}
+
+impl FromStr for BacklogStatus {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "new" => Ok(BacklogStatus::New),
+            "triaged" => Ok(BacklogStatus::Triaged),
+            "in_progress" => Ok(BacklogStatus::InProgress),
+            "done" => Ok(BacklogStatus::Done),
+            "dismissed" => Ok(BacklogStatus::Dismissed),
+            _ => Err(format!("unknown BacklogStatus: {s}")),
+        }
+    }
+}
+
+/// Sort order for backlog queries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum BacklogSort {
+    Age,
+    Priority,
+    Impact,
+}
+
+impl Default for BacklogSort {
+    fn default() -> Self {
+        BacklogSort::Age
+    }
+}
+
+/// A single backlog item.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BacklogItem {
+    pub id: Option<i64>,
+    pub title: String,
+    pub description: String,
+    pub intent: Intent,
+    pub priority: BacklogPriority,
+    pub status: BacklogStatus,
+    pub source: String,
+    pub feature_slug: Option<String>,
+    pub tags: Vec<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Filter parameters for backlog list queries.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct BacklogFilters {
+    pub intent: Option<Intent>,
+    pub status: Option<BacklogStatus>,
+    pub priority: Option<BacklogPriority>,
+    pub feature_slug: Option<String>,
+    pub source: Option<String>,
+    pub sort: BacklogSort,
+    pub limit: Option<usize>,
+}

--- a/crates/agileplus-domain/src/domain/cycle.rs
+++ b/crates/agileplus-domain/src/domain/cycle.rs
@@ -1,0 +1,83 @@
+//! Cycle (sprint/iteration) aggregate.
+
+use chrono::{DateTime, NaiveDate, Utc};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::str::FromStr;
+
+use super::feature::Feature;
+
+/// Lifecycle state of a cycle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CycleState {
+    Draft,
+    Active,
+    Completed,
+    Cancelled,
+}
+
+impl fmt::Display for CycleState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            CycleState::Draft => "draft",
+            CycleState::Active => "active",
+            CycleState::Completed => "completed",
+            CycleState::Cancelled => "cancelled",
+        };
+        write!(f, "{s}")
+    }
+}
+
+impl FromStr for CycleState {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "draft" => Ok(CycleState::Draft),
+            "active" => Ok(CycleState::Active),
+            "completed" => Ok(CycleState::Completed),
+            "cancelled" => Ok(CycleState::Cancelled),
+            _ => Err(format!("unknown CycleState: {s}")),
+        }
+    }
+}
+
+/// A planning cycle (sprint or iteration).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Cycle {
+    pub id: i64,
+    pub name: String,
+    pub description: Option<String>,
+    pub state: CycleState,
+    pub start_date: NaiveDate,
+    pub end_date: NaiveDate,
+    pub module_scope_id: Option<i64>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Association between a cycle and a feature.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CycleFeature {
+    pub cycle_id: i64,
+    pub feature_id: i64,
+}
+
+/// A cycle with its associated features expanded.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CycleWithFeatures {
+    pub cycle: Cycle,
+    pub features: Vec<Feature>,
+    pub wp_progress: WpProgressSummary,
+}
+
+/// Progress summary for work packages within a cycle.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct WpProgressSummary {
+    pub total: u32,
+    pub planned: u32,
+    pub done: u32,
+    pub in_progress: u32,
+    pub blocked: u32,
+}

--- a/crates/agileplus-domain/src/domain/event.rs
+++ b/crates/agileplus-domain/src/domain/event.rs
@@ -1,0 +1,61 @@
+//! Domain event types — append-only event sourcing primitives.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// An event-sourcing domain event.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Event {
+    pub id: i64,
+    pub entity_type: String,
+    pub entity_id: i64,
+    pub event_type: String,
+    pub payload: serde_json::Value,
+    pub actor: String,
+    pub timestamp: DateTime<Utc>,
+    pub prev_hash: [u8; 32],
+    pub hash: [u8; 32],
+    pub sequence: i64,
+}
+
+impl Event {
+    /// Construct a new event (id/sequence/hashes filled in by the store).
+    pub fn new(
+        entity_type: &str,
+        entity_id: i64,
+        event_type: &str,
+        payload: serde_json::Value,
+        actor: &str,
+    ) -> Self {
+        Self {
+            id: 0,
+            entity_type: entity_type.to_string(),
+            entity_id,
+            event_type: event_type.to_string(),
+            payload,
+            actor: actor.to_string(),
+            timestamp: Utc::now(),
+            prev_hash: [0u8; 32],
+            hash: [0u8; 32],
+            sequence: 0,
+        }
+    }
+}
+
+/// Coarse category of an event for filtering.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum EventKind {
+    Created,
+    Updated,
+    Deleted,
+    StateChanged,
+    Custom(String),
+}
+
+/// Metadata attached to an event that is not part of the payload.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EventMetadata {
+    pub correlation_id: Option<String>,
+    pub causation_id: Option<String>,
+    pub tags: Vec<String>,
+}

--- a/crates/agileplus-domain/src/domain/feature.rs
+++ b/crates/agileplus-domain/src/domain/feature.rs
@@ -1,0 +1,75 @@
+//! Feature aggregate — the central planning unit.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use super::state_machine::FeatureState;
+
+/// A software feature tracked through the planning lifecycle.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Feature {
+    pub id: i64,
+    pub slug: String,
+    pub friendly_name: String,
+    pub state: FeatureState,
+    pub spec_hash: [u8; 32],
+    pub target_branch: String,
+    pub plane_issue_id: Option<String>,
+    pub plane_state_id: Option<String>,
+    pub labels: Vec<String>,
+    pub module_id: Option<i64>,
+    pub project_id: Option<i64>,
+    pub created_at_commit: Option<String>,
+    pub last_modified_commit: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl Feature {
+    /// Attempt a state transition. Returns an error string if the transition is not allowed.
+    pub fn transition(&mut self, target: FeatureState) -> Result<(), String> {
+        use FeatureState::*;
+        let allowed = match self.state {
+            Created => matches!(target, Specified),
+            Specified => matches!(target, Researched),
+            Researched => matches!(target, Planned),
+            Planned => matches!(target, Implementing),
+            Implementing => matches!(target, Validated),
+            Validated => matches!(target, Shipped),
+            Shipped => matches!(target, Retrospected),
+            Retrospected => false,
+        };
+        if allowed {
+            self.state = target;
+            self.updated_at = Utc::now();
+            Ok(())
+        } else {
+            Err(format!(
+                "invalid transition {:?} -> {:?}",
+                self.state, target
+            ))
+        }
+    }
+
+    /// Construct a new Feature with sensible defaults.
+    pub fn new(slug: &str, friendly_name: &str, spec_hash: [u8; 32], target_branch: Option<&str>) -> Self {
+        let now = Utc::now();
+        Self {
+            id: 0,
+            slug: slug.to_string(),
+            friendly_name: friendly_name.to_string(),
+            state: FeatureState::Created,
+            spec_hash,
+            target_branch: target_branch.unwrap_or("main").to_string(),
+            plane_issue_id: None,
+            plane_state_id: None,
+            labels: Vec::new(),
+            module_id: None,
+            project_id: None,
+            created_at_commit: None,
+            last_modified_commit: None,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+}

--- a/crates/agileplus-domain/src/domain/governance.rs
+++ b/crates/agileplus-domain/src/domain/governance.rs
@@ -1,0 +1,108 @@
+//! Governance types — contracts, rules, and evidence.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Policy domain category.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PolicyDomain {
+    Security,
+    Quality,
+    Compliance,
+    Performance,
+    Custom,
+}
+
+impl PolicyDomain {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            PolicyDomain::Security => "security",
+            PolicyDomain::Quality => "quality",
+            PolicyDomain::Compliance => "compliance",
+            PolicyDomain::Performance => "performance",
+            PolicyDomain::Custom => "custom",
+        }
+    }
+}
+
+/// The definition of a policy rule (stored as JSON blob).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PolicyDefinition {
+    pub description: String,
+    #[serde(default)]
+    pub conditions: Vec<String>,
+}
+
+/// An active policy rule in the registry.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PolicyRule {
+    pub id: i64,
+    pub domain: PolicyDomain,
+    pub rule: PolicyDefinition,
+    pub active: bool,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// A governance rule captured inside a contract.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GovernanceRule {
+    pub rule_id: i64,
+    pub description: String,
+}
+
+/// A versioned governance contract bound to a feature.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GovernanceContract {
+    pub id: i64,
+    pub feature_id: i64,
+    pub version: i32,
+    pub rules: Vec<GovernanceRule>,
+    pub bound_at: DateTime<Utc>,
+}
+
+/// Type of evidence artifact.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvidenceType {
+    TestResult,
+    CiOutput,
+    ReviewApproval,
+    SecurityScan,
+    LintResult,
+    ManualAttestation,
+}
+
+impl EvidenceType {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            EvidenceType::TestResult => "test_result",
+            EvidenceType::CiOutput => "ci_output",
+            EvidenceType::ReviewApproval => "review_approval",
+            EvidenceType::SecurityScan => "security_scan",
+            EvidenceType::LintResult => "lint_result",
+            EvidenceType::ManualAttestation => "manual_attestation",
+        }
+    }
+}
+
+/// An evidence artifact attached to a work package.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Evidence {
+    pub id: i64,
+    pub wp_id: i64,
+    pub fr_id: String,
+    pub evidence_type: EvidenceType,
+    pub artifact_path: String,
+    pub metadata: Option<serde_json::Value>,
+    pub created_at: DateTime<Utc>,
+}
+
+/// The result of a policy check.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PolicyCheck {
+    pub rule_id: i64,
+    pub passed: bool,
+    pub message: Option<String>,
+}

--- a/crates/agileplus-domain/src/domain/metric.rs
+++ b/crates/agileplus-domain/src/domain/metric.rs
@@ -1,0 +1,17 @@
+//! Metric type — telemetry attached to features.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// A recorded metric for a feature.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Metric {
+    pub id: i64,
+    pub feature_id: Option<i64>,
+    pub command: String,
+    pub duration_ms: i64,
+    pub agent_runs: i32,
+    pub review_cycles: i32,
+    pub metadata: Option<serde_json::Value>,
+    pub timestamp: DateTime<Utc>,
+}

--- a/crates/agileplus-domain/src/domain/mod.rs
+++ b/crates/agileplus-domain/src/domain/mod.rs
@@ -1,0 +1,15 @@
+//! Domain module — all aggregate types and value objects.
+
+pub mod audit;
+pub mod backlog;
+pub mod cycle;
+pub mod event;
+pub mod feature;
+pub mod governance;
+pub mod metric;
+pub mod module;
+pub mod project;
+pub mod snapshot;
+pub mod state_machine;
+pub mod sync_mapping;
+pub mod work_package;

--- a/crates/agileplus-domain/src/domain/module.rs
+++ b/crates/agileplus-domain/src/domain/module.rs
@@ -1,0 +1,48 @@
+//! Module aggregate — hierarchical grouping of features.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use super::feature::Feature;
+
+/// A module groups features into a logical scope.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Module {
+    pub id: i64,
+    pub slug: String,
+    pub friendly_name: String,
+    pub description: Option<String>,
+    pub parent_module_id: Option<i64>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl Module {
+    /// Derive a URL-safe slug from a human-readable name.
+    pub fn slug_from_name(name: &str) -> String {
+        name.to_lowercase()
+            .chars()
+            .map(|c| if c.is_alphanumeric() { c } else { '-' })
+            .collect::<String>()
+            .split('-')
+            .filter(|s| !s.is_empty())
+            .collect::<Vec<_>>()
+            .join("-")
+    }
+}
+
+/// A module together with its owned features, tagged features, and child modules.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModuleWithFeatures {
+    pub module: Module,
+    pub owned_features: Vec<Feature>,
+    pub tagged_features: Vec<Feature>,
+    pub child_modules: Vec<Module>,
+}
+
+/// Association record linking a feature to a module.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModuleFeatureTag {
+    pub module_id: i64,
+    pub feature_id: i64,
+}

--- a/crates/agileplus-domain/src/domain/project.rs
+++ b/crates/agileplus-domain/src/domain/project.rs
@@ -1,0 +1,15 @@
+//! Project aggregate — top-level organisational unit.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// A project that owns modules, cycles, and features.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Project {
+    pub id: i64,
+    pub slug: String,
+    pub name: String,
+    pub description: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}

--- a/crates/agileplus-domain/src/domain/snapshot.rs
+++ b/crates/agileplus-domain/src/domain/snapshot.rs
@@ -1,0 +1,34 @@
+//! Snapshot type for fast aggregate rehydration.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// A point-in-time snapshot of an aggregate's state.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Snapshot {
+    pub id: i64,
+    pub entity_type: String,
+    pub entity_id: i64,
+    pub state: serde_json::Value,
+    pub event_sequence: i64,
+    pub taken_at: DateTime<Utc>,
+}
+
+impl Snapshot {
+    /// Construct a new snapshot (id filled in by the store).
+    pub fn new(
+        entity_type: &str,
+        entity_id: i64,
+        state: serde_json::Value,
+        event_sequence: i64,
+    ) -> Self {
+        Self {
+            id: 0,
+            entity_type: entity_type.to_string(),
+            entity_id,
+            state,
+            event_sequence,
+            taken_at: Utc::now(),
+        }
+    }
+}

--- a/crates/agileplus-domain/src/domain/state_machine.rs
+++ b/crates/agileplus-domain/src/domain/state_machine.rs
@@ -1,0 +1,53 @@
+//! Feature lifecycle state machine.
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::str::FromStr;
+
+/// States in the feature lifecycle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum FeatureState {
+    Created,
+    Specified,
+    Researched,
+    Planned,
+    Implementing,
+    Validated,
+    Shipped,
+    Retrospected,
+}
+
+impl fmt::Display for FeatureState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            FeatureState::Created => "created",
+            FeatureState::Specified => "specified",
+            FeatureState::Researched => "researched",
+            FeatureState::Planned => "planned",
+            FeatureState::Implementing => "implementing",
+            FeatureState::Validated => "validated",
+            FeatureState::Shipped => "shipped",
+            FeatureState::Retrospected => "retrospected",
+        };
+        write!(f, "{s}")
+    }
+}
+
+impl FromStr for FeatureState {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "created" => Ok(FeatureState::Created),
+            "specified" => Ok(FeatureState::Specified),
+            "researched" => Ok(FeatureState::Researched),
+            "planned" => Ok(FeatureState::Planned),
+            "implementing" => Ok(FeatureState::Implementing),
+            "validated" => Ok(FeatureState::Validated),
+            "shipped" => Ok(FeatureState::Shipped),
+            "retrospected" => Ok(FeatureState::Retrospected),
+            _ => Err(format!("unknown FeatureState: {s}")),
+        }
+    }
+}

--- a/crates/agileplus-domain/src/domain/sync_mapping.rs
+++ b/crates/agileplus-domain/src/domain/sync_mapping.rs
@@ -1,0 +1,38 @@
+//! Sync mapping — links internal entities to external plane issues.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// Direction of a sync operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SyncDirection {
+    Push,
+    Pull,
+    Bidirectional,
+}
+
+impl fmt::Display for SyncDirection {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            SyncDirection::Push => "push",
+            SyncDirection::Pull => "pull",
+            SyncDirection::Bidirectional => "bidirectional",
+        };
+        write!(f, "{s}")
+    }
+}
+
+/// Maps an internal entity to an external plane issue.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SyncMapping {
+    pub id: i64,
+    pub entity_type: String,
+    pub entity_id: i64,
+    pub plane_issue_id: String,
+    pub content_hash: String,
+    pub last_synced_at: DateTime<Utc>,
+    pub sync_direction: SyncDirection,
+    pub conflict_count: i32,
+}

--- a/crates/agileplus-domain/src/domain/work_package.rs
+++ b/crates/agileplus-domain/src/domain/work_package.rs
@@ -1,0 +1,89 @@
+//! Work package types — sub-units of features.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// State of a work package.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum WpState {
+    Planned,
+    Doing,
+    Review,
+    Done,
+    Blocked,
+}
+
+/// State of an associated pull request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PrState {
+    Open,
+    Review,
+    ChangesRequested,
+    Approved,
+    Merged,
+}
+
+/// How one work package depends on another.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DependencyType {
+    Explicit,
+    FileOverlap,
+    Data,
+}
+
+/// A work package — concrete implementation unit under a Feature.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkPackage {
+    pub id: i64,
+    pub feature_id: i64,
+    pub title: String,
+    pub state: WpState,
+    pub sequence: i32,
+    pub file_scope: Vec<String>,
+    pub acceptance_criteria: String,
+    pub agent_id: Option<String>,
+    pub pr_url: Option<String>,
+    pub pr_state: Option<PrState>,
+    pub worktree_path: Option<String>,
+    pub plane_sub_issue_id: Option<String>,
+    pub base_commit: Option<String>,
+    pub head_commit: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Directed dependency between two work packages.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WpDependency {
+    pub wp_id: i64,
+    pub depends_on: i64,
+    pub dep_type: DependencyType,
+}
+
+impl WorkPackage {
+    /// Construct a new WorkPackage with sensible defaults.
+    pub fn new(feature_id: i64, title: &str, sequence: i32, acceptance_criteria: &str) -> Self {
+        let now = chrono::Utc::now();
+        Self {
+            id: 0,
+            feature_id,
+            title: title.to_string(),
+            state: WpState::Planned,
+            sequence,
+            file_scope: Vec::new(),
+            acceptance_criteria: acceptance_criteria.to_string(),
+            agent_id: None,
+            pr_url: None,
+            pr_state: None,
+            worktree_path: None,
+            plane_sub_issue_id: None,
+            base_commit: None,
+            head_commit: None,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+}

--- a/crates/agileplus-domain/src/error.rs
+++ b/crates/agileplus-domain/src/error.rs
@@ -1,0 +1,40 @@
+//! Domain error types.
+
+use thiserror::Error;
+
+/// Top-level domain error.
+#[derive(Debug, Error)]
+pub enum DomainError {
+    #[error("Feature not in module scope: feature '{feature_slug}' not in module '{module_slug}'")]
+    FeatureNotInModuleScope { feature_slug: String, module_slug: String },
+
+    #[error("Module has dependents: {0}")]
+    ModuleHasDependents(String),
+
+    #[error("Cycle not found: {0}")]
+    CycleNotFound(String),
+
+    #[error("Module not found: {0}")]
+    ModuleNotFound(String),
+
+    #[error("Feature not found: {0}")]
+    FeatureNotFound(String),
+
+    #[error("Work package not found: {0}")]
+    WorkPackageNotFound(String),
+
+    #[error("Not found: {0}")]
+    NotFound(String),
+
+    #[error("Not implemented")]
+    NotImplemented,
+
+    #[error("Storage error: {0}")]
+    Storage(String),
+
+    #[error("Validation error: {0}")]
+    Validation(String),
+
+    #[error("Lock poisoned")]
+    LockPoisoned,
+}

--- a/crates/agileplus-domain/src/lib.rs
+++ b/crates/agileplus-domain/src/lib.rs
@@ -1,1 +1,5 @@
-//! `agileplus-domain` workspace crate stub.
+//! `agileplus-domain` — core domain types, error, and port traits.
+
+pub mod domain;
+pub mod error;
+pub mod ports;

--- a/crates/agileplus-domain/src/ports/mod.rs
+++ b/crates/agileplus-domain/src/ports/mod.rs
@@ -1,0 +1,139 @@
+//! Hexagonal-architecture ports — async traits implemented by adapters.
+
+pub mod vcs;
+
+use std::path::{Path, PathBuf};
+
+use crate::domain::{
+    audit::AuditEntry,
+    backlog::{BacklogFilters, BacklogItem, BacklogPriority, BacklogStatus},
+    cycle::{Cycle, CycleFeature, CycleWithFeatures, CycleState},
+    feature::Feature,
+    governance::{Evidence, GovernanceContract, PolicyRule},
+    metric::Metric,
+    module::{Module, ModuleFeatureTag, ModuleWithFeatures},
+    project::Project,
+    state_machine::FeatureState,
+    sync_mapping::SyncMapping,
+    work_package::{WorkPackage, WpDependency, WpState},
+};
+use crate::error::DomainError;
+
+use self::vcs::{BranchInfo, ConflictInfo, FeatureArtifacts, MergeResult, WorktreeInfo};
+
+/// Primary storage port — full CRUD across all domain aggregates.
+pub trait StoragePort: Send + Sync {
+    // --- Features ---
+    async fn create_feature(&self, feature: &Feature) -> Result<i64, DomainError>;
+    async fn get_feature_by_slug(&self, slug: &str) -> Result<Option<Feature>, DomainError>;
+    async fn get_feature_by_id(&self, id: i64) -> Result<Option<Feature>, DomainError>;
+    async fn update_feature_state(&self, id: i64, state: FeatureState) -> Result<(), DomainError>;
+    async fn list_features_by_state(&self, state: FeatureState) -> Result<Vec<Feature>, DomainError>;
+    async fn list_all_features(&self) -> Result<Vec<Feature>, DomainError>;
+
+    // --- Work Packages ---
+    async fn create_work_package(&self, wp: &WorkPackage) -> Result<i64, DomainError>;
+    async fn get_work_package(&self, id: i64) -> Result<Option<WorkPackage>, DomainError>;
+    async fn update_wp_state(&self, id: i64, state: WpState) -> Result<(), DomainError>;
+    async fn list_wps_by_feature(&self, feature_id: i64) -> Result<Vec<WorkPackage>, DomainError>;
+    async fn add_wp_dependency(&self, dep: &WpDependency) -> Result<(), DomainError>;
+    async fn get_wp_dependencies(&self, wp_id: i64) -> Result<Vec<WpDependency>, DomainError>;
+    async fn get_ready_wps(&self, feature_id: i64) -> Result<Vec<WorkPackage>, DomainError>;
+
+    // --- Audit ---
+    async fn append_audit_entry(&self, entry: &AuditEntry) -> Result<i64, DomainError>;
+    async fn get_audit_trail(&self, feature_id: i64) -> Result<Vec<AuditEntry>, DomainError>;
+    async fn get_latest_audit_entry(&self, feature_id: i64) -> Result<Option<AuditEntry>, DomainError>;
+
+    // --- Evidence ---
+    async fn create_evidence(&self, ev: &Evidence) -> Result<i64, DomainError>;
+    async fn get_evidence_by_wp(&self, wp_id: i64) -> Result<Vec<Evidence>, DomainError>;
+    async fn get_evidence_by_fr(&self, fr_id: &str) -> Result<Vec<Evidence>, DomainError>;
+
+    // --- Policy / Governance ---
+    async fn create_policy_rule(&self, rule: &PolicyRule) -> Result<i64, DomainError>;
+    async fn list_active_policies(&self) -> Result<Vec<PolicyRule>, DomainError>;
+    async fn record_metric(&self, metric: &Metric) -> Result<i64, DomainError>;
+    async fn get_metrics_by_feature(&self, feature_id: i64) -> Result<Vec<Metric>, DomainError>;
+    async fn create_governance_contract(&self, contract: &GovernanceContract) -> Result<i64, DomainError>;
+    async fn get_governance_contract(&self, feature_id: i64, version: i32) -> Result<Option<GovernanceContract>, DomainError>;
+    async fn get_latest_governance_contract(&self, feature_id: i64) -> Result<Option<GovernanceContract>, DomainError>;
+
+    // --- Modules ---
+    async fn create_module(&self, module: &Module) -> Result<i64, DomainError>;
+    async fn get_module(&self, id: i64) -> Result<Option<Module>, DomainError>;
+    async fn get_module_by_slug(&self, slug: &str) -> Result<Option<Module>, DomainError>;
+    async fn update_module(&self, id: i64, friendly_name: &str, description: Option<&str>) -> Result<(), DomainError>;
+    async fn delete_module(&self, id: i64) -> Result<(), DomainError>;
+    async fn list_root_modules(&self) -> Result<Vec<Module>, DomainError>;
+    async fn list_child_modules(&self, parent_id: i64) -> Result<Vec<Module>, DomainError>;
+    async fn get_module_with_features(&self, id: i64) -> Result<Option<ModuleWithFeatures>, DomainError>;
+    async fn tag_feature_to_module(&self, tag: &ModuleFeatureTag) -> Result<(), DomainError>;
+    async fn untag_feature_from_module(&self, module_id: i64, feature_id: i64) -> Result<(), DomainError>;
+
+    // --- Cycles ---
+    async fn create_cycle(&self, cycle: &Cycle) -> Result<i64, DomainError>;
+    async fn get_cycle(&self, id: i64) -> Result<Option<Cycle>, DomainError>;
+    async fn update_cycle_state(&self, id: i64, state: CycleState) -> Result<(), DomainError>;
+    async fn list_cycles_by_state(&self, state: CycleState) -> Result<Vec<Cycle>, DomainError>;
+    async fn list_cycles_by_module(&self, module_id: i64) -> Result<Vec<Cycle>, DomainError>;
+    async fn list_all_cycles(&self) -> Result<Vec<Cycle>, DomainError>;
+    async fn get_cycle_with_features(&self, id: i64) -> Result<Option<CycleWithFeatures>, DomainError>;
+    async fn add_feature_to_cycle(&self, entry: &CycleFeature) -> Result<(), DomainError>;
+    async fn remove_feature_from_cycle(&self, cycle_id: i64, feature_id: i64) -> Result<(), DomainError>;
+
+    // --- Sync Mappings ---
+    async fn get_sync_mapping(&self, entity_type: &str, entity_id: i64) -> Result<Option<SyncMapping>, DomainError>;
+    async fn upsert_sync_mapping(&self, mapping: &SyncMapping) -> Result<(), DomainError>;
+    async fn get_sync_mapping_by_plane_id(&self, entity_type: &str, plane_issue_id: &str) -> Result<Option<SyncMapping>, DomainError>;
+    async fn delete_sync_mapping(&self, entity_type: &str, entity_id: i64) -> Result<(), DomainError>;
+
+    // --- Projects ---
+    async fn create_project(&self, project: &Project) -> Result<i64, DomainError>;
+    async fn get_project_by_slug(&self, slug: &str) -> Result<Option<Project>, DomainError>;
+}
+
+/// Content storage port — subset used by the dashboard/content layer.
+pub trait ContentStoragePort: Send + Sync {
+    // Features
+    async fn create_feature(&self, feature: &Feature) -> Result<i64, DomainError>;
+    async fn get_feature_by_slug(&self, slug: &str) -> Result<Option<Feature>, DomainError>;
+    async fn get_feature_by_id(&self, id: i64) -> Result<Option<Feature>, DomainError>;
+    async fn update_feature_state(&self, id: i64, state: FeatureState) -> Result<(), DomainError>;
+    async fn update_feature(&self, feature: &Feature) -> Result<(), DomainError>;
+    async fn list_features_by_state(&self, state: FeatureState) -> Result<Vec<Feature>, DomainError>;
+    async fn list_all_features(&self) -> Result<Vec<Feature>, DomainError>;
+    // Work packages
+    async fn create_work_package(&self, wp: &WorkPackage) -> Result<i64, DomainError>;
+    async fn get_work_package(&self, id: i64) -> Result<Option<WorkPackage>, DomainError>;
+    async fn update_wp_state(&self, id: i64, state: WpState) -> Result<(), DomainError>;
+    async fn update_work_package(&self, wp: &WorkPackage) -> Result<(), DomainError>;
+    async fn list_wps_by_feature(&self, feature_id: i64) -> Result<Vec<WorkPackage>, DomainError>;
+    async fn add_wp_dependency(&self, dep: &WpDependency) -> Result<(), DomainError>;
+    async fn get_wp_dependencies(&self, wp_id: i64) -> Result<Vec<WpDependency>, DomainError>;
+    async fn get_ready_wps(&self, feature_id: i64) -> Result<Vec<WorkPackage>, DomainError>;
+    // Backlog
+    async fn create_backlog_item(&self, item: &BacklogItem) -> Result<i64, DomainError>;
+    async fn get_backlog_item(&self, id: i64) -> Result<Option<BacklogItem>, DomainError>;
+    async fn list_backlog_items(&self, filters: &BacklogFilters) -> Result<Vec<BacklogItem>, DomainError>;
+    async fn update_backlog_status(&self, id: i64, status: BacklogStatus) -> Result<(), DomainError>;
+    async fn update_backlog_priority(&self, id: i64, priority: BacklogPriority) -> Result<(), DomainError>;
+    async fn pop_next_backlog_item(&self) -> Result<Option<BacklogItem>, DomainError>;
+}
+
+/// VCS port — git operations needed by the domain.
+pub trait VcsPort: Send + Sync {
+    async fn create_worktree(&self, feature_slug: &str, wp_id: &str) -> Result<PathBuf, DomainError>;
+    async fn list_worktrees(&self) -> Result<Vec<WorktreeInfo>, DomainError>;
+    async fn cleanup_worktree(&self, worktree_path: &Path) -> Result<(), DomainError>;
+    async fn create_branch(&self, branch_name: &str, base: &str) -> Result<(), DomainError>;
+    async fn list_branches(&self, pattern: Option<&str>, remote: bool) -> Result<Vec<BranchInfo>, DomainError>;
+    async fn delete_branch(&self, branch_name: &str, force: bool, remote: Option<&str>) -> Result<(), DomainError>;
+    async fn checkout_branch(&self, branch_name: &str) -> Result<(), DomainError>;
+    async fn merge_to_target(&self, source: &str, target: &str) -> Result<MergeResult, DomainError>;
+    async fn detect_conflicts(&self, source: &str, target: &str) -> Result<Vec<ConflictInfo>, DomainError>;
+    async fn read_artifact(&self, feature_slug: &str, relative_path: &str) -> Result<String, DomainError>;
+    async fn write_artifact(&self, feature_slug: &str, relative_path: &str, content: &str) -> Result<(), DomainError>;
+    async fn artifact_exists(&self, feature_slug: &str, relative_path: &str) -> Result<bool, DomainError>;
+    async fn scan_feature_artifacts(&self, feature_slug: &str) -> Result<FeatureArtifacts, DomainError>;
+}

--- a/crates/agileplus-domain/src/ports/vcs.rs
+++ b/crates/agileplus-domain/src/ports/vcs.rs
@@ -1,0 +1,43 @@
+//! VCS port value objects.
+
+use serde::{Deserialize, Serialize};
+
+/// Information about a git branch.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BranchInfo {
+    pub name: String,
+    pub commit: String,
+    pub is_remote: bool,
+}
+
+/// Information about a git worktree.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorktreeInfo {
+    pub path: String,
+    pub branch: String,
+    pub commit: String,
+}
+
+/// Result of a merge operation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MergeResult {
+    pub success: bool,
+    pub commit: Option<String>,
+    pub message: Option<String>,
+}
+
+/// A file-level conflict detected during merge analysis.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConflictInfo {
+    pub file_path: String,
+    pub conflict_type: String,
+}
+
+/// Collection of artifacts discovered for a feature.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FeatureArtifacts {
+    pub spec: Option<String>,
+    pub research: Option<String>,
+    pub plan: Option<String>,
+    pub other: Vec<String>,
+}

--- a/crates/agileplus-sqlite/Cargo.toml
+++ b/crates/agileplus-sqlite/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "agileplus-sqlite"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+agileplus-domain = { path = "../agileplus-domain" }
+agileplus-events = { path = "../agileplus-events" }
+rusqlite = { version = "0.32", features = ["bundled"] }
+serde.workspace = true
+serde_json.workspace = true
+chrono.workspace = true
+async-trait = "0.1"
+tokio = { workspace = true, optional = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["full"] }
+
+[features]
+default = []
+async = ["tokio"]

--- a/crates/agileplus-sqlite/src/event_store.rs
+++ b/crates/agileplus-sqlite/src/event_store.rs
@@ -1,0 +1,72 @@
+use agileplus_domain::domain::event::Event;
+use agileplus_events::{EventError, EventStore};
+
+use crate::adapter::SqliteStorageAdapter;
+use crate::repository::events;
+
+#[async_trait::async_trait]
+impl EventStore for SqliteStorageAdapter {
+    async fn append(&self, event: &Event) -> Result<i64, EventError> {
+        let conn = self
+            .lock()
+            .map_err(|e| EventError::StorageError(e.to_string()))?;
+        events::append_event(&conn, event).map_err(|e| EventError::StorageError(e.to_string()))
+    }
+
+    async fn get_events(
+        &self,
+        entity_type: &str,
+        entity_id: i64,
+    ) -> Result<Vec<Event>, EventError> {
+        let conn = self
+            .lock()
+            .map_err(|e| EventError::StorageError(e.to_string()))?;
+        events::get_events(&conn, entity_type, entity_id)
+            .map_err(|e| EventError::StorageError(e.to_string()))
+    }
+
+    async fn get_events_since(
+        &self,
+        entity_type: &str,
+        entity_id: i64,
+        sequence: i64,
+    ) -> Result<Vec<Event>, EventError> {
+        let conn = self
+            .lock()
+            .map_err(|e| EventError::StorageError(e.to_string()))?;
+        events::get_events_since(&conn, entity_type, entity_id, sequence)
+            .map_err(|e| EventError::StorageError(e.to_string()))
+    }
+
+    async fn get_events_by_range(
+        &self,
+        entity_type: &str,
+        entity_id: i64,
+        from: chrono::DateTime<chrono::Utc>,
+        to: chrono::DateTime<chrono::Utc>,
+    ) -> Result<Vec<Event>, EventError> {
+        let conn = self
+            .lock()
+            .map_err(|e| EventError::StorageError(e.to_string()))?;
+        events::get_events_by_range(
+            &conn,
+            entity_type,
+            entity_id,
+            &from.to_rfc3339(),
+            &to.to_rfc3339(),
+        )
+        .map_err(|e| EventError::StorageError(e.to_string()))
+    }
+
+    async fn get_latest_sequence(
+        &self,
+        entity_type: &str,
+        entity_id: i64,
+    ) -> Result<i64, EventError> {
+        let conn = self
+            .lock()
+            .map_err(|e| EventError::StorageError(e.to_string()))?;
+        events::get_latest_sequence(&conn, entity_type, entity_id)
+            .map_err(|e| EventError::StorageError(e.to_string()))
+    }
+}

--- a/crates/agileplus-sqlite/src/lib.rs
+++ b/crates/agileplus-sqlite/src/lib.rs
@@ -1,0 +1,1582 @@
+//! AgilePlus SQLite adapter — persistence layer.
+//!
+//! Implements `StoragePort` using rusqlite with WAL mode and foreign keys.
+//! Traceability: WP06
+
+pub mod migrations;
+pub mod rebuild;
+pub mod repository;
+
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+use rusqlite::Connection;
+
+use agileplus_domain::{
+    domain::{
+        audit::AuditEntry,
+        backlog::{BacklogFilters, BacklogItem, BacklogPriority, BacklogStatus},
+        cycle::{Cycle, CycleFeature, CycleState, CycleWithFeatures},
+        feature::Feature,
+        governance::{Evidence, GovernanceContract, PolicyRule},
+        metric::Metric,
+        module::{Module, ModuleFeatureTag, ModuleWithFeatures},
+        state_machine::FeatureState,
+        work_package::{WorkPackage, WpDependency, WpState},
+    },
+    error::DomainError,
+    ports::{ContentStoragePort, StoragePort},
+};
+
+use agileplus_domain::domain::event::Event;
+use agileplus_events::{EventError, EventStore};
+
+use crate::migrations::MigrationRunner;
+use agileplus_domain::domain::project::Project;
+use agileplus_domain::domain::sync_mapping::SyncMapping;
+
+use crate::repository::{
+    audit, backlog, cycles, events, evidence, features, governance, metrics, modules, projects,
+    sync_mappings, work_packages,
+};
+
+/// SQLite-backed storage adapter.
+///
+/// Uses a single write-serialized connection protected by a Mutex.
+/// WAL mode is enabled to allow concurrent reads; all writes are serialized.
+pub struct SqliteStorageAdapter {
+    conn: Arc<Mutex<Connection>>,
+}
+
+impl SqliteStorageAdapter {
+    /// Open a file-backed database, enable WAL + FK pragma, and run all migrations.
+    pub fn new(db_path: &Path) -> Result<Self, DomainError> {
+        let conn = Connection::open(db_path)
+            .map_err(|e| DomainError::Storage(format!("failed to open db: {e}")))?;
+        Self::configure_and_migrate(conn)
+    }
+
+    /// Open an in-memory database (for tests).
+    pub fn in_memory() -> Result<Self, DomainError> {
+        let conn = Connection::open_in_memory()
+            .map_err(|e| DomainError::Storage(format!("failed to open in-memory db: {e}")))?;
+        Self::configure_and_migrate(conn)
+    }
+
+    fn configure_and_migrate(conn: Connection) -> Result<Self, DomainError> {
+        // Enable WAL mode for concurrent reads
+        conn.execute_batch("PRAGMA journal_mode=WAL;")
+            .map_err(|e| DomainError::Storage(format!("WAL pragma failed: {e}")))?;
+
+        // Enable foreign key enforcement
+        conn.execute_batch("PRAGMA foreign_keys=ON;")
+            .map_err(|e| DomainError::Storage(format!("FK pragma failed: {e}")))?;
+
+        // Run migrations
+        let runner = MigrationRunner::new(&conn);
+        runner.run_all()?;
+
+        Ok(Self {
+            conn: Arc::new(Mutex::new(conn)),
+        })
+    }
+
+    /// Get a locked guard to the connection.
+    fn lock(&self) -> Result<std::sync::MutexGuard<'_, Connection>, DomainError> {
+        self.conn
+            .lock()
+            .map_err(|e| DomainError::Storage(format!("mutex poisoned: {e}")))
+    }
+
+    /// Expose a locked connection guard for benchmarks and test helpers.
+    ///
+    /// This method is intentionally public so that benchmark crates can access
+    /// the underlying rusqlite `Connection` to call repository functions directly
+    /// without going through the async `StoragePort` trait.
+    pub fn conn_for_bench(&self) -> Result<std::sync::MutexGuard<'_, Connection>, DomainError> {
+        self.lock()
+    }
+}
+
+impl StoragePort for SqliteStorageAdapter {
+    // -- Feature CRUD --
+
+    async fn create_feature(&self, feature: &Feature) -> Result<i64, DomainError> {
+        let conn = self.lock()?;
+        features::create_feature(&conn, feature)
+    }
+
+    async fn get_feature_by_slug(&self, slug: &str) -> Result<Option<Feature>, DomainError> {
+        let conn = self.lock()?;
+        features::get_feature_by_slug(&conn, slug)
+    }
+
+    async fn get_feature_by_id(&self, id: i64) -> Result<Option<Feature>, DomainError> {
+        let conn = self.lock()?;
+        features::get_feature_by_id(&conn, id)
+    }
+
+    async fn update_feature_state(&self, id: i64, state: FeatureState) -> Result<(), DomainError> {
+        let conn = self.lock()?;
+        features::update_feature_state(&conn, id, state)
+    }
+
+    async fn list_features_by_state(
+        &self,
+        state: FeatureState,
+    ) -> Result<Vec<Feature>, DomainError> {
+        let conn = self.lock()?;
+        features::list_features_by_state(&conn, state)
+    }
+
+    async fn list_all_features(&self) -> Result<Vec<Feature>, DomainError> {
+        let conn = self.lock()?;
+        features::list_all_features(&conn)
+    }
+
+    // -- Work Package CRUD --
+
+    async fn create_work_package(&self, wp: &WorkPackage) -> Result<i64, DomainError> {
+        let conn = self.lock()?;
+        work_packages::create_work_package(&conn, wp)
+    }
+
+    async fn get_work_package(&self, id: i64) -> Result<Option<WorkPackage>, DomainError> {
+        let conn = self.lock()?;
+        work_packages::get_work_package(&conn, id)
+    }
+
+    async fn update_wp_state(&self, id: i64, state: WpState) -> Result<(), DomainError> {
+        let conn = self.lock()?;
+        work_packages::update_wp_state(&conn, id, state)
+    }
+
+    async fn list_wps_by_feature(&self, feature_id: i64) -> Result<Vec<WorkPackage>, DomainError> {
+        let conn = self.lock()?;
+        work_packages::list_wps_by_feature(&conn, feature_id)
+    }
+
+    async fn add_wp_dependency(&self, dep: &WpDependency) -> Result<(), DomainError> {
+        let conn = self.lock()?;
+        work_packages::add_wp_dependency(&conn, dep)
+    }
+
+    async fn get_wp_dependencies(&self, wp_id: i64) -> Result<Vec<WpDependency>, DomainError> {
+        let conn = self.lock()?;
+        work_packages::get_wp_dependencies(&conn, wp_id)
+    }
+
+    async fn get_ready_wps(&self, feature_id: i64) -> Result<Vec<WorkPackage>, DomainError> {
+        let conn = self.lock()?;
+        work_packages::get_ready_wps(&conn, feature_id)
+    }
+
+    // -- Audit CRUD --
+
+    async fn append_audit_entry(&self, entry: &AuditEntry) -> Result<i64, DomainError> {
+        let conn = self.lock()?;
+        audit::append_audit_entry(&conn, entry)
+    }
+
+    async fn get_audit_trail(&self, feature_id: i64) -> Result<Vec<AuditEntry>, DomainError> {
+        let conn = self.lock()?;
+        audit::get_audit_trail(&conn, feature_id)
+    }
+
+    async fn get_latest_audit_entry(
+        &self,
+        feature_id: i64,
+    ) -> Result<Option<AuditEntry>, DomainError> {
+        let conn = self.lock()?;
+        audit::get_latest_audit_entry(&conn, feature_id)
+    }
+
+    // -- Evidence + Policy + Metric CRUD --
+
+    async fn create_evidence(&self, ev: &Evidence) -> Result<i64, DomainError> {
+        let conn = self.lock()?;
+        evidence::create_evidence(&conn, ev)
+    }
+
+    async fn get_evidence_by_wp(&self, wp_id: i64) -> Result<Vec<Evidence>, DomainError> {
+        let conn = self.lock()?;
+        evidence::get_evidence_by_wp(&conn, wp_id)
+    }
+
+    async fn get_evidence_by_fr(&self, fr_id: &str) -> Result<Vec<Evidence>, DomainError> {
+        let conn = self.lock()?;
+        evidence::get_evidence_by_fr(&conn, fr_id)
+    }
+
+    async fn create_policy_rule(&self, rule: &PolicyRule) -> Result<i64, DomainError> {
+        let conn = self.lock()?;
+        governance::create_policy_rule(&conn, rule)
+    }
+
+    async fn list_active_policies(&self) -> Result<Vec<PolicyRule>, DomainError> {
+        let conn = self.lock()?;
+        governance::list_active_policies(&conn)
+    }
+
+    async fn record_metric(&self, metric: &Metric) -> Result<i64, DomainError> {
+        let conn = self.lock()?;
+        metrics::record_metric(&conn, metric)
+    }
+
+    async fn get_metrics_by_feature(&self, feature_id: i64) -> Result<Vec<Metric>, DomainError> {
+        let conn = self.lock()?;
+        metrics::get_metrics_by_feature(&conn, feature_id)
+    }
+
+    // -- Governance --
+
+    async fn create_governance_contract(
+        &self,
+        contract: &GovernanceContract,
+    ) -> Result<i64, DomainError> {
+        let conn = self.lock()?;
+        governance::create_governance_contract(&conn, contract)
+    }
+
+    async fn get_governance_contract(
+        &self,
+        feature_id: i64,
+        version: i32,
+    ) -> Result<Option<GovernanceContract>, DomainError> {
+        let conn = self.lock()?;
+        governance::get_governance_contract(&conn, feature_id, version)
+    }
+
+    async fn get_latest_governance_contract(
+        &self,
+        feature_id: i64,
+    ) -> Result<Option<GovernanceContract>, DomainError> {
+        let conn = self.lock()?;
+        governance::get_latest_governance_contract(&conn, feature_id)
+    }
+
+    // -- Module CRUD (T007) --
+
+    async fn create_module(&self, module: &Module) -> Result<i64, DomainError> {
+        let conn = self.lock()?;
+        modules::create_module(&conn, module)
+    }
+
+    async fn get_module(&self, id: i64) -> Result<Option<Module>, DomainError> {
+        let conn = self.lock()?;
+        modules::get_module(&conn, id)
+    }
+
+    async fn get_module_by_slug(&self, slug: &str) -> Result<Option<Module>, DomainError> {
+        let conn = self.lock()?;
+        modules::get_module_by_slug(&conn, slug)
+    }
+
+    async fn update_module(
+        &self,
+        id: i64,
+        friendly_name: &str,
+        description: Option<&str>,
+    ) -> Result<(), DomainError> {
+        let conn = self.lock()?;
+        modules::update_module(&conn, id, friendly_name, description)
+    }
+
+    async fn delete_module(&self, id: i64) -> Result<(), DomainError> {
+        let conn = self.lock()?;
+        modules::delete_module(&conn, id)
+    }
+
+    async fn list_root_modules(&self) -> Result<Vec<Module>, DomainError> {
+        let conn = self.lock()?;
+        modules::list_root_modules(&conn)
+    }
+
+    async fn list_child_modules(&self, parent_id: i64) -> Result<Vec<Module>, DomainError> {
+        let conn = self.lock()?;
+        modules::list_child_modules(&conn, parent_id)
+    }
+
+    async fn get_module_with_features(
+        &self,
+        id: i64,
+    ) -> Result<Option<ModuleWithFeatures>, DomainError> {
+        let conn = self.lock()?;
+        modules::get_module_with_features(&conn, id)
+    }
+
+    // -- Cycle CRUD (T008) --
+
+    async fn create_cycle(&self, cycle: &Cycle) -> Result<i64, DomainError> {
+        let conn = self.lock()?;
+        cycles::create_cycle(&conn, cycle)
+    }
+
+    async fn get_cycle(&self, id: i64) -> Result<Option<Cycle>, DomainError> {
+        let conn = self.lock()?;
+        cycles::get_cycle(&conn, id)
+    }
+
+    async fn update_cycle_state(&self, id: i64, state: CycleState) -> Result<(), DomainError> {
+        let conn = self.lock()?;
+        cycles::update_cycle_state(&conn, id, state)
+    }
+
+    async fn list_cycles_by_state(&self, state: CycleState) -> Result<Vec<Cycle>, DomainError> {
+        let conn = self.lock()?;
+        cycles::list_cycles_by_state(&conn, state)
+    }
+
+    async fn list_cycles_by_module(&self, module_id: i64) -> Result<Vec<Cycle>, DomainError> {
+        let conn = self.lock()?;
+        cycles::list_cycles_by_module(&conn, module_id)
+    }
+
+    async fn list_all_cycles(&self) -> Result<Vec<Cycle>, DomainError> {
+        let conn = self.lock()?;
+        cycles::list_all_cycles(&conn)
+    }
+
+    async fn get_cycle_with_features(
+        &self,
+        id: i64,
+    ) -> Result<Option<CycleWithFeatures>, DomainError> {
+        let conn = self.lock()?;
+        cycles::get_cycle_with_features(&conn, id)
+    }
+
+    // -- Join table ops (T009) --
+
+    async fn tag_feature_to_module(&self, tag: &ModuleFeatureTag) -> Result<(), DomainError> {
+        let conn = self.lock()?;
+        modules::tag_feature_to_module(&conn, tag)
+    }
+
+    async fn untag_feature_from_module(
+        &self,
+        module_id: i64,
+        feature_id: i64,
+    ) -> Result<(), DomainError> {
+        let conn = self.lock()?;
+        modules::untag_feature_from_module(&conn, module_id, feature_id)
+    }
+
+    async fn add_feature_to_cycle(&self, entry: &CycleFeature) -> Result<(), DomainError> {
+        let conn = self.lock()?;
+        cycles::add_feature_to_cycle(&conn, entry)
+    }
+
+    async fn remove_feature_from_cycle(
+        &self,
+        cycle_id: i64,
+        feature_id: i64,
+    ) -> Result<(), DomainError> {
+        let conn = self.lock()?;
+        cycles::remove_feature_from_cycle(&conn, cycle_id, feature_id)
+    }
+
+    // -- Sync Mapping CRUD (WP06-T033) --
+
+    async fn get_sync_mapping(
+        &self,
+        entity_type: &str,
+        entity_id: i64,
+    ) -> Result<Option<SyncMapping>, DomainError> {
+        let conn = self.lock()?;
+        sync_mappings::get_sync_mapping(&conn, entity_type, entity_id)
+    }
+
+    async fn upsert_sync_mapping(&self, mapping: &SyncMapping) -> Result<(), DomainError> {
+        let conn = self.lock()?;
+        sync_mappings::upsert_sync_mapping(&conn, mapping)
+    }
+
+    async fn get_sync_mapping_by_plane_id(
+        &self,
+        entity_type: &str,
+        plane_issue_id: &str,
+    ) -> Result<Option<SyncMapping>, DomainError> {
+        let conn = self.lock()?;
+        sync_mappings::get_sync_mapping_by_plane_id(&conn, entity_type, plane_issue_id)
+    }
+
+    async fn delete_sync_mapping(
+        &self,
+        entity_type: &str,
+        entity_id: i64,
+    ) -> Result<(), DomainError> {
+        let conn = self.lock()?;
+        sync_mappings::delete_sync_mapping(&conn, entity_type, entity_id)
+    }
+
+    async fn create_project(&self, project: &Project) -> Result<i64, DomainError> {
+        let conn = self.lock()?;
+        projects::create_project(&conn, project)
+    }
+
+    async fn get_project_by_slug(&self, slug: &str) -> Result<Option<Project>, DomainError> {
+        let conn = self.lock()?;
+        projects::get_project_by_slug(&conn, slug)
+    }
+}
+
+impl ContentStoragePort for SqliteStorageAdapter {
+    async fn create_feature(&self, feature: &Feature) -> Result<i64, DomainError> {
+        let conn = self.lock()?;
+        features::create_feature(&conn, feature)
+    }
+
+    async fn get_feature_by_slug(&self, slug: &str) -> Result<Option<Feature>, DomainError> {
+        let conn = self.lock()?;
+        features::get_feature_by_slug(&conn, slug)
+    }
+
+    async fn get_feature_by_id(&self, id: i64) -> Result<Option<Feature>, DomainError> {
+        let conn = self.lock()?;
+        features::get_feature_by_id(&conn, id)
+    }
+
+    async fn update_feature_state(&self, id: i64, state: FeatureState) -> Result<(), DomainError> {
+        let conn = self.lock()?;
+        features::update_feature_state(&conn, id, state)
+    }
+
+    async fn update_feature(&self, feature: &Feature) -> Result<(), DomainError> {
+        let conn = self.lock()?;
+        features::update_feature(&conn, feature)
+    }
+
+    async fn list_features_by_state(
+        &self,
+        state: FeatureState,
+    ) -> Result<Vec<Feature>, DomainError> {
+        let conn = self.lock()?;
+        features::list_features_by_state(&conn, state)
+    }
+
+    async fn list_all_features(&self) -> Result<Vec<Feature>, DomainError> {
+        let conn = self.lock()?;
+        features::list_all_features(&conn)
+    }
+
+    async fn create_backlog_item(&self, item: &BacklogItem) -> Result<i64, DomainError> {
+        let conn = self.lock()?;
+        backlog::create_backlog_item(&conn, item)
+    }
+
+    async fn get_backlog_item(&self, id: i64) -> Result<Option<BacklogItem>, DomainError> {
+        let conn = self.lock()?;
+        backlog::get_backlog_item(&conn, id)
+    }
+
+    async fn list_backlog_items(
+        &self,
+        filters: &BacklogFilters,
+    ) -> Result<Vec<BacklogItem>, DomainError> {
+        let conn = self.lock()?;
+        backlog::list_backlog_items(&conn, filters)
+    }
+
+    async fn update_backlog_status(
+        &self,
+        id: i64,
+        status: BacklogStatus,
+    ) -> Result<(), DomainError> {
+        let conn = self.lock()?;
+        backlog::update_backlog_status(&conn, id, status)
+    }
+
+    async fn update_backlog_priority(
+        &self,
+        id: i64,
+        priority: BacklogPriority,
+    ) -> Result<(), DomainError> {
+        let conn = self.lock()?;
+        backlog::update_backlog_priority(&conn, id, priority)
+    }
+
+    async fn pop_next_backlog_item(&self) -> Result<Option<BacklogItem>, DomainError> {
+        let conn = self.lock()?;
+        backlog::pop_next_backlog_item(&conn)
+    }
+
+    async fn create_work_package(&self, wp: &WorkPackage) -> Result<i64, DomainError> {
+        let conn = self.lock()?;
+        work_packages::create_work_package(&conn, wp)
+    }
+
+    async fn get_work_package(&self, id: i64) -> Result<Option<WorkPackage>, DomainError> {
+        let conn = self.lock()?;
+        work_packages::get_work_package(&conn, id)
+    }
+
+    async fn update_wp_state(&self, id: i64, state: WpState) -> Result<(), DomainError> {
+        let conn = self.lock()?;
+        work_packages::update_wp_state(&conn, id, state)
+    }
+
+    async fn update_work_package(&self, wp: &WorkPackage) -> Result<(), DomainError> {
+        let conn = self.lock()?;
+        work_packages::update_work_package(&conn, wp)
+    }
+
+    async fn list_wps_by_feature(&self, feature_id: i64) -> Result<Vec<WorkPackage>, DomainError> {
+        let conn = self.lock()?;
+        work_packages::list_wps_by_feature(&conn, feature_id)
+    }
+
+    async fn add_wp_dependency(&self, dep: &WpDependency) -> Result<(), DomainError> {
+        let conn = self.lock()?;
+        work_packages::add_wp_dependency(&conn, dep)
+    }
+
+    async fn get_wp_dependencies(&self, wp_id: i64) -> Result<Vec<WpDependency>, DomainError> {
+        let conn = self.lock()?;
+        work_packages::get_wp_dependencies(&conn, wp_id)
+    }
+
+    async fn get_ready_wps(&self, feature_id: i64) -> Result<Vec<WorkPackage>, DomainError> {
+        let conn = self.lock()?;
+        work_packages::get_ready_wps(&conn, feature_id)
+    }
+}
+
+#[async_trait::async_trait]
+impl EventStore for SqliteStorageAdapter {
+    async fn append(&self, event: &Event) -> Result<i64, EventError> {
+        let conn = self
+            .lock()
+            .map_err(|e| EventError::StorageError(e.to_string()))?;
+        events::append_event(&conn, event).map_err(|e| EventError::StorageError(e.to_string()))
+    }
+
+    async fn get_events(
+        &self,
+        entity_type: &str,
+        entity_id: i64,
+    ) -> Result<Vec<Event>, EventError> {
+        let conn = self
+            .lock()
+            .map_err(|e| EventError::StorageError(e.to_string()))?;
+        events::get_events(&conn, entity_type, entity_id)
+            .map_err(|e| EventError::StorageError(e.to_string()))
+    }
+
+    async fn get_events_since(
+        &self,
+        entity_type: &str,
+        entity_id: i64,
+        sequence: i64,
+    ) -> Result<Vec<Event>, EventError> {
+        let conn = self
+            .lock()
+            .map_err(|e| EventError::StorageError(e.to_string()))?;
+        events::get_events_since(&conn, entity_type, entity_id, sequence)
+            .map_err(|e| EventError::StorageError(e.to_string()))
+    }
+
+    async fn get_events_by_range(
+        &self,
+        entity_type: &str,
+        entity_id: i64,
+        from: chrono::DateTime<chrono::Utc>,
+        to: chrono::DateTime<chrono::Utc>,
+    ) -> Result<Vec<Event>, EventError> {
+        let conn = self
+            .lock()
+            .map_err(|e| EventError::StorageError(e.to_string()))?;
+        events::get_events_by_range(
+            &conn,
+            entity_type,
+            entity_id,
+            &from.to_rfc3339(),
+            &to.to_rfc3339(),
+        )
+        .map_err(|e| EventError::StorageError(e.to_string()))
+    }
+
+    async fn get_latest_sequence(
+        &self,
+        entity_type: &str,
+        entity_id: i64,
+    ) -> Result<i64, EventError> {
+        let conn = self
+            .lock()
+            .map_err(|e| EventError::StorageError(e.to_string()))?;
+        events::get_latest_sequence(&conn, entity_type, entity_id)
+            .map_err(|e| EventError::StorageError(e.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use agileplus_domain::domain::{
+        audit::{AuditEntry, hash_entry},
+        feature::Feature,
+        governance::{
+            Evidence, EvidenceType, GovernanceContract, GovernanceRule, PolicyCheck,
+            PolicyDefinition, PolicyDomain, PolicyRule,
+        },
+        metric::Metric,
+        state_machine::FeatureState,
+        work_package::{DependencyType, WorkPackage, WpDependency, WpState},
+    };
+
+    fn make_adapter() -> SqliteStorageAdapter {
+        SqliteStorageAdapter::in_memory().expect("in-memory adapter")
+    }
+
+    // -- Feature tests --
+
+    #[tokio::test]
+    async fn feature_create_and_get_by_slug() {
+        let db = make_adapter();
+        let f = Feature::new("my-feat", "My Feature", [0u8; 32], None);
+        let id = StoragePort::create_feature(&db, &f).await.unwrap();
+        assert!(id > 0);
+
+        let got = StoragePort::get_feature_by_slug(&db, "my-feat")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(got.id, id);
+        assert_eq!(got.slug, "my-feat");
+        assert_eq!(got.friendly_name, "My Feature");
+        assert_eq!(got.spec_hash, [0u8; 32]);
+        assert_eq!(got.state, FeatureState::Created);
+    }
+
+    #[tokio::test]
+    async fn feature_get_by_id() {
+        let db = make_adapter();
+        let f = Feature::new("feat-id", "Feat", [1u8; 32], None);
+        let id = StoragePort::create_feature(&db, &f).await.unwrap();
+        let got = StoragePort::get_feature_by_id(&db, id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(got.slug, "feat-id");
+    }
+
+    #[tokio::test]
+    async fn feature_update_state() {
+        let db = make_adapter();
+        let f = Feature::new("upd-feat", "Upd", [0u8; 32], None);
+        let id = StoragePort::create_feature(&db, &f).await.unwrap();
+
+        StoragePort::update_feature_state(&db, id, FeatureState::Specified)
+            .await
+            .unwrap();
+        let got = StoragePort::get_feature_by_id(&db, id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(got.state, FeatureState::Specified);
+    }
+
+    #[tokio::test]
+    async fn feature_list_by_state() {
+        let db = make_adapter();
+        let f1 = Feature::new("f1", "F1", [0u8; 32], None);
+        let f2 = Feature::new("f2", "F2", [0u8; 32], None);
+        let id1 = StoragePort::create_feature(&db, &f1).await.unwrap();
+        let _id2 = StoragePort::create_feature(&db, &f2).await.unwrap();
+        StoragePort::update_feature_state(&db, id1, FeatureState::Specified)
+            .await
+            .unwrap();
+
+        let specified = StoragePort::list_features_by_state(&db, FeatureState::Specified)
+            .await
+            .unwrap();
+        assert_eq!(specified.len(), 1);
+        assert_eq!(specified[0].slug, "f1");
+
+        let created = StoragePort::list_features_by_state(&db, FeatureState::Created)
+            .await
+            .unwrap();
+        assert_eq!(created.len(), 1);
+        assert_eq!(created[0].slug, "f2");
+    }
+
+    #[tokio::test]
+    async fn feature_list_all() {
+        let db = make_adapter();
+        StoragePort::create_feature(&db, &Feature::new("aa", "AA", [0u8; 32], None))
+            .await
+            .unwrap();
+        StoragePort::create_feature(&db, &Feature::new("bb", "BB", [0u8; 32], None))
+            .await
+            .unwrap();
+        let all = StoragePort::list_all_features(&db).await.unwrap();
+        assert_eq!(all.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn feature_duplicate_slug_fails() {
+        let db = make_adapter();
+        let f = Feature::new("dup", "Dup", [0u8; 32], None);
+        StoragePort::create_feature(&db, &f).await.unwrap();
+        let result = StoragePort::create_feature(&db, &f).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn feature_not_found_returns_none() {
+        let db = make_adapter();
+        let got = StoragePort::get_feature_by_slug(&db, "no-such-slug")
+            .await
+            .unwrap();
+        assert!(got.is_none());
+        let got2 = StoragePort::get_feature_by_id(&db, 9999).await.unwrap();
+        assert!(got2.is_none());
+    }
+
+    // -- Work Package tests --
+
+    #[tokio::test]
+    async fn wp_create_and_get() {
+        let db = make_adapter();
+        let feat = Feature::new("wp-feat", "WP Feat", [0u8; 32], None);
+        let fid = StoragePort::create_feature(&db, &feat).await.unwrap();
+
+        let mut wp = WorkPackage::new(fid, "Task A", 1, "criteria");
+        wp.file_scope = vec!["src/main.rs".into()];
+        let wp_id = StoragePort::create_work_package(&db, &wp).await.unwrap();
+        assert!(wp_id > 0);
+
+        let got = StoragePort::get_work_package(&db, wp_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(got.title, "Task A");
+        assert_eq!(got.file_scope, vec!["src/main.rs"]);
+        assert_eq!(got.state, WpState::Planned);
+        assert_eq!(got.feature_id, fid);
+    }
+
+    #[tokio::test]
+    async fn wp_update_state() {
+        let db = make_adapter();
+        let fid = StoragePort::create_feature(&db, &Feature::new("f", "F", [0u8; 32], None))
+            .await
+            .unwrap();
+        let wp_id = StoragePort::create_work_package(&db, &WorkPackage::new(fid, "T", 1, "c"))
+            .await
+            .unwrap();
+        StoragePort::update_wp_state(&db, wp_id, WpState::Doing)
+            .await
+            .unwrap();
+        let got = StoragePort::get_work_package(&db, wp_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(got.state, WpState::Doing);
+    }
+
+    #[tokio::test]
+    async fn wp_list_by_feature_ordered_by_sequence() {
+        let db = make_adapter();
+        let fid = StoragePort::create_feature(&db, &Feature::new("f2", "F2", [0u8; 32], None))
+            .await
+            .unwrap();
+        StoragePort::create_work_package(&db, &WorkPackage::new(fid, "B", 2, "c"))
+            .await
+            .unwrap();
+        StoragePort::create_work_package(&db, &WorkPackage::new(fid, "A", 1, "c"))
+            .await
+            .unwrap();
+
+        let wps = StoragePort::list_wps_by_feature(&db, fid).await.unwrap();
+        assert_eq!(wps.len(), 2);
+        assert_eq!(wps[0].sequence, 1);
+        assert_eq!(wps[1].sequence, 2);
+    }
+
+    #[tokio::test]
+    async fn wp_dependencies_and_ready_wps() {
+        let db = make_adapter();
+        let fid = StoragePort::create_feature(&db, &Feature::new("f3", "F3", [0u8; 32], None))
+            .await
+            .unwrap();
+        let wp1 = StoragePort::create_work_package(&db, &WorkPackage::new(fid, "WP1", 1, "c"))
+            .await
+            .unwrap();
+        let wp2 = StoragePort::create_work_package(&db, &WorkPackage::new(fid, "WP2", 2, "c"))
+            .await
+            .unwrap();
+
+        // wp2 depends on wp1
+        StoragePort::add_wp_dependency(
+            &db,
+            &WpDependency {
+                wp_id: wp2,
+                depends_on: wp1,
+                dep_type: DependencyType::Explicit,
+            },
+        )
+        .await
+        .unwrap();
+
+        // Both planned but wp2 has unsatisfied dep -> only wp1 is ready
+        let ready = StoragePort::get_ready_wps(&db, fid).await.unwrap();
+        assert_eq!(ready.len(), 1);
+        assert_eq!(ready[0].id, wp1);
+
+        // Complete wp1
+        StoragePort::update_wp_state(&db, wp1, WpState::Doing)
+            .await
+            .unwrap();
+        StoragePort::update_wp_state(&db, wp1, WpState::Review)
+            .await
+            .unwrap();
+        StoragePort::update_wp_state(&db, wp1, WpState::Done)
+            .await
+            .unwrap();
+
+        // Now wp2 should be ready
+        let ready = StoragePort::get_ready_wps(&db, fid).await.unwrap();
+        assert_eq!(ready.len(), 1);
+        assert_eq!(ready[0].id, wp2);
+    }
+
+    #[tokio::test]
+    async fn wp_get_dependencies() {
+        let db = make_adapter();
+        let fid = StoragePort::create_feature(&db, &Feature::new("fd", "FD", [0u8; 32], None))
+            .await
+            .unwrap();
+        let w1 = StoragePort::create_work_package(&db, &WorkPackage::new(fid, "W1", 1, "c"))
+            .await
+            .unwrap();
+        let w2 = StoragePort::create_work_package(&db, &WorkPackage::new(fid, "W2", 2, "c"))
+            .await
+            .unwrap();
+        StoragePort::add_wp_dependency(
+            &db,
+            &WpDependency {
+                wp_id: w2,
+                depends_on: w1,
+                dep_type: DependencyType::Data,
+            },
+        )
+        .await
+        .unwrap();
+        let deps = StoragePort::get_wp_dependencies(&db, w2).await.unwrap();
+        assert_eq!(deps.len(), 1);
+        assert_eq!(deps[0].depends_on, w1);
+    }
+
+    // -- Audit tests --
+
+    fn make_audit_entry(feature_id: i64, prev_hash: [u8; 32]) -> AuditEntry {
+        let mut entry = AuditEntry {
+            id: 0,
+            feature_id,
+            wp_id: None,
+            timestamp: chrono::Utc::now(),
+            actor: "agent".into(),
+            transition: "created->specified".into(),
+            evidence_refs: vec![],
+            prev_hash,
+            hash: [0u8; 32],
+            event_id: None,
+            archived_to: None,
+        };
+        entry.hash = hash_entry(&entry);
+        entry
+    }
+
+    #[tokio::test]
+    async fn audit_append_and_trail() {
+        let db = make_adapter();
+        let fid = StoragePort::create_feature(&db, &Feature::new("af", "AF", [0u8; 32], None))
+            .await
+            .unwrap();
+
+        let e1 = make_audit_entry(fid, [0u8; 32]);
+        let _id1 = StoragePort::append_audit_entry(&db, &e1).await.unwrap();
+
+        let e2 = make_audit_entry(fid, e1.hash);
+        let _id2 = StoragePort::append_audit_entry(&db, &e2).await.unwrap();
+
+        let e3 = make_audit_entry(fid, e2.hash);
+        StoragePort::append_audit_entry(&db, &e3).await.unwrap();
+
+        let trail = StoragePort::get_audit_trail(&db, fid).await.unwrap();
+        assert_eq!(trail.len(), 3);
+        // Ordered chronologically
+        assert!(trail[0].id <= trail[1].id);
+        assert!(trail[1].id <= trail[2].id);
+    }
+
+    #[tokio::test]
+    async fn audit_wrong_prev_hash_rejected() {
+        let db = make_adapter();
+        let fid = StoragePort::create_feature(&db, &Feature::new("afc", "AFC", [0u8; 32], None))
+            .await
+            .unwrap();
+
+        let e1 = make_audit_entry(fid, [0u8; 32]);
+        StoragePort::append_audit_entry(&db, &e1).await.unwrap();
+
+        // Entry with wrong prev_hash
+        let e_bad = make_audit_entry(fid, [0xFFu8; 32]);
+        let result = StoragePort::append_audit_entry(&db, &e_bad).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn audit_get_latest() {
+        let db = make_adapter();
+        let fid = StoragePort::create_feature(&db, &Feature::new("al", "AL", [0u8; 32], None))
+            .await
+            .unwrap();
+
+        assert!(
+            StoragePort::get_latest_audit_entry(&db, fid)
+                .await
+                .unwrap()
+                .is_none()
+        );
+
+        let e1 = make_audit_entry(fid, [0u8; 32]);
+        StoragePort::append_audit_entry(&db, &e1).await.unwrap();
+
+        let e2 = make_audit_entry(fid, e1.hash);
+        StoragePort::append_audit_entry(&db, &e2).await.unwrap();
+
+        let latest = StoragePort::get_latest_audit_entry(&db, fid)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(latest.hash, e2.hash);
+    }
+
+    // -- Evidence tests --
+
+    #[tokio::test]
+    async fn evidence_create_and_get_by_wp() {
+        let db = make_adapter();
+        let fid = StoragePort::create_feature(&db, &Feature::new("ef", "EF", [0u8; 32], None))
+            .await
+            .unwrap();
+        let wp_id = StoragePort::create_work_package(&db, &WorkPackage::new(fid, "WP", 1, "c"))
+            .await
+            .unwrap();
+
+        let ev = Evidence {
+            id: 0,
+            wp_id,
+            fr_id: "FR-001".into(),
+            evidence_type: EvidenceType::TestResult,
+            artifact_path: "results/test.xml".into(),
+            metadata: Some(serde_json::json!({"pass": 42})),
+            created_at: chrono::Utc::now(),
+        };
+        let ev_id = StoragePort::create_evidence(&db, &ev).await.unwrap();
+        assert!(ev_id > 0);
+
+        let evs = StoragePort::get_evidence_by_wp(&db, wp_id).await.unwrap();
+        assert_eq!(evs.len(), 1);
+        assert_eq!(evs[0].fr_id, "FR-001");
+        assert_eq!(evs[0].evidence_type, EvidenceType::TestResult);
+        assert!(evs[0].metadata.is_some());
+    }
+
+    #[tokio::test]
+    async fn evidence_get_by_fr() {
+        let db = make_adapter();
+        let fid = StoragePort::create_feature(&db, &Feature::new("efr", "EFR", [0u8; 32], None))
+            .await
+            .unwrap();
+        let wp_id = StoragePort::create_work_package(&db, &WorkPackage::new(fid, "WP", 1, "c"))
+            .await
+            .unwrap();
+
+        let ev1 = Evidence {
+            id: 0,
+            wp_id,
+            fr_id: "FR-001".into(),
+            evidence_type: EvidenceType::CiOutput,
+            artifact_path: "ci.log".into(),
+            metadata: None,
+            created_at: chrono::Utc::now(),
+        };
+        let ev2 = Evidence {
+            id: 0,
+            wp_id,
+            fr_id: "FR-002".into(),
+            evidence_type: EvidenceType::LintResult,
+            artifact_path: "lint.log".into(),
+            metadata: None,
+            created_at: chrono::Utc::now(),
+        };
+        StoragePort::create_evidence(&db, &ev1).await.unwrap();
+        StoragePort::create_evidence(&db, &ev2).await.unwrap();
+
+        let fr1 = StoragePort::get_evidence_by_fr(&db, "FR-001")
+            .await
+            .unwrap();
+        assert_eq!(fr1.len(), 1);
+        assert_eq!(fr1[0].fr_id, "FR-001");
+    }
+
+    // -- Policy tests --
+
+    #[tokio::test]
+    async fn policy_create_and_list_active() {
+        let db = make_adapter();
+        let rule = PolicyRule {
+            id: 0,
+            domain: PolicyDomain::Quality,
+            rule: PolicyDefinition {
+                description: "All tests must pass".into(),
+                check: PolicyCheck::ManualApproval,
+            },
+            active: true,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        };
+        let id = StoragePort::create_policy_rule(&db, &rule).await.unwrap();
+        assert!(id > 0);
+
+        let active = StoragePort::list_active_policies(&db).await.unwrap();
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].domain, PolicyDomain::Quality);
+    }
+
+    // -- Governance Contract tests --
+
+    #[tokio::test]
+    async fn governance_contract_create_and_get() {
+        let db = make_adapter();
+        let fid = StoragePort::create_feature(&db, &Feature::new("gc", "GC", [0u8; 32], None))
+            .await
+            .unwrap();
+
+        let contract = GovernanceContract {
+            id: 0,
+            feature_id: fid,
+            version: 1,
+            rules: vec![GovernanceRule {
+                transition: "created->specified".into(),
+                required_evidence: vec![],
+                policy_refs: vec![],
+            }],
+            bound_at: chrono::Utc::now(),
+        };
+        let cid = StoragePort::create_governance_contract(&db, &contract)
+            .await
+            .unwrap();
+        assert!(cid > 0);
+
+        let got = StoragePort::get_governance_contract(&db, fid, 1)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(got.feature_id, fid);
+        assert_eq!(got.version, 1);
+        assert_eq!(got.rules.len(), 1);
+
+        let latest = StoragePort::get_latest_governance_contract(&db, fid)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(latest.version, 1);
+    }
+
+    #[tokio::test]
+    async fn governance_contract_versioning() {
+        let db = make_adapter();
+        let fid = StoragePort::create_feature(&db, &Feature::new("gcv", "GCV", [0u8; 32], None))
+            .await
+            .unwrap();
+
+        let c1 = GovernanceContract {
+            id: 0,
+            feature_id: fid,
+            version: 1,
+            rules: vec![],
+            bound_at: chrono::Utc::now(),
+        };
+        let c2 = GovernanceContract {
+            id: 0,
+            feature_id: fid,
+            version: 2,
+            rules: vec![],
+            bound_at: chrono::Utc::now(),
+        };
+        StoragePort::create_governance_contract(&db, &c1)
+            .await
+            .unwrap();
+        StoragePort::create_governance_contract(&db, &c2)
+            .await
+            .unwrap();
+
+        let latest = StoragePort::get_latest_governance_contract(&db, fid)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(latest.version, 2);
+
+        let v1 = StoragePort::get_governance_contract(&db, fid, 1)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(v1.version, 1);
+    }
+
+    // -- Metrics tests --
+
+    #[tokio::test]
+    async fn metric_record_and_get() {
+        let db = make_adapter();
+        let fid = StoragePort::create_feature(&db, &Feature::new("mf", "MF", [0u8; 32], None))
+            .await
+            .unwrap();
+
+        let m = Metric {
+            id: 0,
+            feature_id: Some(fid),
+            command: "spec-kitty implement".into(),
+            duration_ms: 1234,
+            agent_runs: 3,
+            review_cycles: 1,
+            metadata: Some(serde_json::json!({"model": "claude"})),
+            timestamp: chrono::Utc::now(),
+        };
+        let mid = StoragePort::record_metric(&db, &m).await.unwrap();
+        assert!(mid > 0);
+
+        let ms = StoragePort::get_metrics_by_feature(&db, fid).await.unwrap();
+        assert_eq!(ms.len(), 1);
+        assert_eq!(ms[0].command, "spec-kitty implement");
+        assert_eq!(ms[0].duration_ms, 1234);
+        assert!(ms[0].metadata.is_some());
+    }
+
+    // -- Module tests --
+
+    use agileplus_domain::domain::module::{Module, ModuleFeatureTag};
+
+    #[tokio::test]
+    async fn module_create_and_get() {
+        let db = make_adapter();
+        let m = Module::new("Auth Module", None);
+        let id = StoragePort::create_module(&db, &m).await.unwrap();
+        assert!(id > 0);
+
+        let got = StoragePort::get_module(&db, id).await.unwrap().unwrap();
+        assert_eq!(got.id, id);
+        assert_eq!(got.slug, "auth-module");
+        assert_eq!(got.friendly_name, "Auth Module");
+        assert!(got.parent_module_id.is_none());
+    }
+
+    #[tokio::test]
+    async fn module_get_by_slug() {
+        let db = make_adapter();
+        let m = Module::new("Billing", None);
+        let id = StoragePort::create_module(&db, &m).await.unwrap();
+        let got = StoragePort::get_module_by_slug(&db, "billing")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(got.id, id);
+    }
+
+    #[tokio::test]
+    async fn module_not_found_returns_none() {
+        let db = make_adapter();
+        assert!(StoragePort::get_module(&db, 9999).await.unwrap().is_none());
+        assert!(
+            StoragePort::get_module_by_slug(&db, "no-such")
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn module_update() {
+        let db = make_adapter();
+        let m = Module::new("Old Name", None);
+        let id = StoragePort::create_module(&db, &m).await.unwrap();
+        StoragePort::update_module(&db, id, "New Name", Some("a description"))
+            .await
+            .unwrap();
+        let got = StoragePort::get_module(&db, id).await.unwrap().unwrap();
+        assert_eq!(got.friendly_name, "New Name");
+        assert_eq!(got.slug, "new-name");
+        assert_eq!(got.description.as_deref(), Some("a description"));
+    }
+
+    #[tokio::test]
+    async fn module_delete_simple() {
+        let db = make_adapter();
+        let m = Module::new("Temp", None);
+        let id = StoragePort::create_module(&db, &m).await.unwrap();
+        StoragePort::delete_module(&db, id).await.unwrap();
+        assert!(StoragePort::get_module(&db, id).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn module_delete_with_children_fails() {
+        let db = make_adapter();
+        let parent = Module::new("Parent", None);
+        let pid = StoragePort::create_module(&db, &parent).await.unwrap();
+        let child = Module::new("Child", Some(pid));
+        StoragePort::create_module(&db, &child).await.unwrap();
+
+        let result = StoragePort::delete_module(&db, pid).await;
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            agileplus_domain::error::DomainError::ModuleHasDependents(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn module_delete_with_owned_features_fails() {
+        let db = make_adapter();
+        let m = Module::new("Owner", None);
+        let mid = StoragePort::create_module(&db, &m).await.unwrap();
+        // Create feature and link it via tag
+        let f = Feature::new("feat", "Feat", [0u8; 32], None);
+        let fid = StoragePort::create_feature(&db, &f).await.unwrap();
+        // Manually set module_id via tag so the module owns this feature
+        // (we use the raw feature.module_id path by updating directly)
+        {
+            let conn = db.conn_for_bench().unwrap();
+            conn.execute(
+                "UPDATE features SET module_id = ?1 WHERE id = ?2",
+                rusqlite::params![mid, fid],
+            )
+            .unwrap();
+        }
+
+        let result = StoragePort::delete_module(&db, mid).await;
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            agileplus_domain::error::DomainError::ModuleHasDependents(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn module_list_root_and_children() {
+        let db = make_adapter();
+        let r1 = StoragePort::create_module(&db, &Module::new("Root1", None))
+            .await
+            .unwrap();
+        let r2 = StoragePort::create_module(&db, &Module::new("Root2", None))
+            .await
+            .unwrap();
+        let _ = StoragePort::create_module(&db, &Module::new("Child1", Some(r1)))
+            .await
+            .unwrap();
+
+        let roots = StoragePort::list_root_modules(&db).await.unwrap();
+        assert_eq!(roots.len(), 2);
+
+        let children = StoragePort::list_child_modules(&db, r1).await.unwrap();
+        assert_eq!(children.len(), 1);
+
+        let r2_children = StoragePort::list_child_modules(&db, r2).await.unwrap();
+        assert!(r2_children.is_empty());
+    }
+
+    #[tokio::test]
+    async fn module_tag_and_untag_feature() {
+        let db = make_adapter();
+        let mid = StoragePort::create_module(&db, &Module::new("M", None))
+            .await
+            .unwrap();
+        let fid = StoragePort::create_feature(&db, &Feature::new("f-tag", "FTag", [0u8; 32], None))
+            .await
+            .unwrap();
+
+        let tag = ModuleFeatureTag::new(mid, fid);
+        StoragePort::tag_feature_to_module(&db, &tag).await.unwrap();
+        // Idempotent -- should not fail
+        StoragePort::tag_feature_to_module(&db, &tag).await.unwrap();
+
+        let mwf = StoragePort::get_module_with_features(&db, mid)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(mwf.tagged_features.len(), 1);
+        assert_eq!(mwf.tagged_features[0].id, fid);
+
+        StoragePort::untag_feature_from_module(&db, mid, fid)
+            .await
+            .unwrap();
+        let mwf2 = StoragePort::get_module_with_features(&db, mid)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(mwf2.tagged_features.is_empty());
+    }
+
+    #[tokio::test]
+    async fn module_get_with_features_none_for_missing() {
+        let db = make_adapter();
+        assert!(
+            StoragePort::get_module_with_features(&db, 9999)
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    // -- Cycle tests --
+
+    use agileplus_domain::domain::cycle::{Cycle, CycleFeature, CycleState};
+    use chrono::NaiveDate;
+
+    fn make_date(y: i32, m: u32, d: u32) -> NaiveDate {
+        NaiveDate::from_ymd_opt(y, m, d).expect("valid date")
+    }
+
+    #[tokio::test]
+    async fn cycle_create_and_get() {
+        let db = make_adapter();
+        let c = Cycle::new(
+            "Q1-2026",
+            make_date(2026, 1, 1),
+            make_date(2026, 3, 31),
+            None,
+        )
+        .unwrap();
+        let id = StoragePort::create_cycle(&db, &c).await.unwrap();
+        assert!(id > 0);
+
+        let got = StoragePort::get_cycle(&db, id).await.unwrap().unwrap();
+        assert_eq!(got.id, id);
+        assert_eq!(got.name, "Q1-2026");
+        assert_eq!(got.state, CycleState::Draft);
+        assert!(got.module_scope_id.is_none());
+    }
+
+    #[tokio::test]
+    async fn cycle_not_found_returns_none() {
+        let db = make_adapter();
+        assert!(StoragePort::get_cycle(&db, 9999).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn cycle_update_state() {
+        let db = make_adapter();
+        let c = Cycle::new(
+            "Cycle-A",
+            make_date(2026, 1, 1),
+            make_date(2026, 2, 1),
+            None,
+        )
+        .unwrap();
+        let id = StoragePort::create_cycle(&db, &c).await.unwrap();
+        StoragePort::update_cycle_state(&db, id, CycleState::Active)
+            .await
+            .unwrap();
+        let got = StoragePort::get_cycle(&db, id).await.unwrap().unwrap();
+        assert_eq!(got.state, CycleState::Active);
+    }
+
+    #[tokio::test]
+    async fn cycle_list_by_state() {
+        let db = make_adapter();
+        let c1 = Cycle::new(
+            "Draft-1",
+            make_date(2026, 1, 1),
+            make_date(2026, 2, 1),
+            None,
+        )
+        .unwrap();
+        let c2 = Cycle::new(
+            "Draft-2",
+            make_date(2026, 3, 1),
+            make_date(2026, 4, 1),
+            None,
+        )
+        .unwrap();
+        let id1 = StoragePort::create_cycle(&db, &c1).await.unwrap();
+        let id2 = StoragePort::create_cycle(&db, &c2).await.unwrap();
+        StoragePort::update_cycle_state(&db, id1, CycleState::Active)
+            .await
+            .unwrap();
+
+        let drafts = StoragePort::list_cycles_by_state(&db, CycleState::Draft)
+            .await
+            .unwrap();
+        assert_eq!(drafts.len(), 1);
+        assert_eq!(drafts[0].id, id2);
+
+        let actives = StoragePort::list_cycles_by_state(&db, CycleState::Active)
+            .await
+            .unwrap();
+        assert_eq!(actives.len(), 1);
+        assert_eq!(actives[0].id, id1);
+    }
+
+    #[tokio::test]
+    async fn cycle_list_by_module() {
+        let db = make_adapter();
+        let mid = StoragePort::create_module(&db, &Module::new("ScopeModule", None))
+            .await
+            .unwrap();
+        let c1 = Cycle::new(
+            "Scoped",
+            make_date(2026, 1, 1),
+            make_date(2026, 2, 1),
+            Some(mid),
+        )
+        .unwrap();
+        let c2 = Cycle::new(
+            "Unscoped",
+            make_date(2026, 3, 1),
+            make_date(2026, 4, 1),
+            None,
+        )
+        .unwrap();
+        let id1 = StoragePort::create_cycle(&db, &c1).await.unwrap();
+        StoragePort::create_cycle(&db, &c2).await.unwrap();
+
+        let scoped = StoragePort::list_cycles_by_module(&db, mid).await.unwrap();
+        assert_eq!(scoped.len(), 1);
+        assert_eq!(scoped[0].id, id1);
+    }
+
+    #[tokio::test]
+    async fn cycle_add_and_remove_feature() {
+        let db = make_adapter();
+        let c = Cycle::new("C1", make_date(2026, 1, 1), make_date(2026, 2, 1), None).unwrap();
+        let cid = StoragePort::create_cycle(&db, &c).await.unwrap();
+        let fid =
+            StoragePort::create_feature(&db, &Feature::new("cyc-feat", "CycFeat", [0u8; 32], None))
+                .await
+                .unwrap();
+
+        let entry = CycleFeature::new(cid, fid);
+        StoragePort::add_feature_to_cycle(&db, &entry)
+            .await
+            .unwrap();
+        // Idempotent
+        StoragePort::add_feature_to_cycle(&db, &entry)
+            .await
+            .unwrap();
+
+        let cwf = StoragePort::get_cycle_with_features(&db, cid)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(cwf.features.len(), 1);
+        assert_eq!(cwf.features[0].id, fid);
+
+        StoragePort::remove_feature_from_cycle(&db, cid, fid)
+            .await
+            .unwrap();
+        let cwf2 = StoragePort::get_cycle_with_features(&db, cid)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(cwf2.features.is_empty());
+    }
+
+    #[tokio::test]
+    async fn cycle_with_features_none_for_missing() {
+        let db = make_adapter();
+        assert!(
+            StoragePort::get_cycle_with_features(&db, 9999)
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn cycle_module_scope_enforcement() {
+        let db = make_adapter();
+        let mid = StoragePort::create_module(&db, &Module::new("Scope", None))
+            .await
+            .unwrap();
+        // Cycle scoped to this module
+        let c = Cycle::new(
+            "Scoped-Cycle",
+            make_date(2026, 1, 1),
+            make_date(2026, 2, 1),
+            Some(mid),
+        )
+        .unwrap();
+        let cid = StoragePort::create_cycle(&db, &c).await.unwrap();
+
+        // Feature NOT in module scope
+        let fid =
+            StoragePort::create_feature(&db, &Feature::new("out-of-scope", "OOS", [0u8; 32], None))
+                .await
+                .unwrap();
+        let entry = CycleFeature::new(cid, fid);
+        let result = StoragePort::add_feature_to_cycle(&db, &entry).await;
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            agileplus_domain::error::DomainError::FeatureNotInModuleScope { .. }
+        ));
+
+        // Tag feature to module -- now it should work
+        StoragePort::tag_feature_to_module(&db, &ModuleFeatureTag::new(mid, fid))
+            .await
+            .unwrap();
+        StoragePort::add_feature_to_cycle(&db, &CycleFeature::new(cid, fid))
+            .await
+            .unwrap();
+        let cwf = StoragePort::get_cycle_with_features(&db, cid)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(cwf.features.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn cycle_wp_progress_summary() {
+        let db = make_adapter();
+        let c = Cycle::new(
+            "WP-Prog",
+            make_date(2026, 1, 1),
+            make_date(2026, 2, 1),
+            None,
+        )
+        .unwrap();
+        let cid = StoragePort::create_cycle(&db, &c).await.unwrap();
+        let fid =
+            StoragePort::create_feature(&db, &Feature::new("prog-feat", "Prog", [0u8; 32], None))
+                .await
+                .unwrap();
+        StoragePort::add_feature_to_cycle(&db, &CycleFeature::new(cid, fid))
+            .await
+            .unwrap();
+
+        // Create 2 WPs
+        let _wp1 = StoragePort::create_work_package(&db, &WorkPackage::new(fid, "WP1", 1, "c"))
+            .await
+            .unwrap();
+        let wp2 = StoragePort::create_work_package(&db, &WorkPackage::new(fid, "WP2", 2, "c"))
+            .await
+            .unwrap();
+        StoragePort::update_wp_state(
+            &db,
+            wp2,
+            agileplus_domain::domain::work_package::WpState::Done,
+        )
+        .await
+        .unwrap();
+
+        let cwf = StoragePort::get_cycle_with_features(&db, cid)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(cwf.wp_progress.total, 2);
+        assert_eq!(cwf.wp_progress.planned, 1);
+        assert_eq!(cwf.wp_progress.done, 1);
+    }
+}

--- a/crates/agileplus-sqlite/src/lib/adapter.rs
+++ b/crates/agileplus-sqlite/src/lib/adapter.rs
@@ -1,0 +1,58 @@
+use std::path::Path;
+use std::sync::{Arc, Mutex, MutexGuard};
+
+use rusqlite::Connection;
+
+use agileplus_domain::error::DomainError;
+
+use crate::migrations::MigrationRunner;
+
+/// SQLite-backed storage adapter.
+///
+/// Uses a single write-serialized connection protected by a Mutex.
+/// WAL mode is enabled to allow concurrent reads; all writes are serialized.
+pub struct SqliteStorageAdapter {
+    pub(crate) conn: Arc<Mutex<Connection>>,
+}
+
+impl SqliteStorageAdapter {
+    /// Open a file-backed database, enable WAL + FK pragma, and run all migrations.
+    pub fn new(db_path: &Path) -> Result<Self, DomainError> {
+        let conn = Connection::open(db_path)
+            .map_err(|e| DomainError::Storage(format!("failed to open db: {e}")))?;
+        Self::configure_and_migrate(conn)
+    }
+
+    /// Open an in-memory database (for tests).
+    pub fn in_memory() -> Result<Self, DomainError> {
+        let conn = Connection::open_in_memory()
+            .map_err(|e| DomainError::Storage(format!("failed to open in-memory db: {e}")))?;
+        Self::configure_and_migrate(conn)
+    }
+
+    fn configure_and_migrate(conn: Connection) -> Result<Self, DomainError> {
+        conn.execute_batch("PRAGMA journal_mode=WAL;")
+            .map_err(|e| DomainError::Storage(format!("WAL pragma failed: {e}")))?;
+        conn.execute_batch("PRAGMA foreign_keys=ON;")
+            .map_err(|e| DomainError::Storage(format!("FK pragma failed: {e}")))?;
+
+        let runner = MigrationRunner::new(&conn);
+        runner.run_all()?;
+
+        Ok(Self {
+            conn: Arc::new(Mutex::new(conn)),
+        })
+    }
+
+    /// Get a locked guard to the connection.
+    pub(crate) fn lock(&self) -> Result<MutexGuard<'_, Connection>, DomainError> {
+        self.conn
+            .lock()
+            .map_err(|e| DomainError::Storage(format!("mutex poisoned: {e}")))
+    }
+
+    /// Expose a locked connection guard for benchmarks and test helpers.
+    pub fn conn_for_bench(&self) -> Result<MutexGuard<'_, Connection>, DomainError> {
+        self.lock()
+    }
+}

--- a/crates/agileplus-sqlite/src/lib/content_storage.rs
+++ b/crates/agileplus-sqlite/src/lib/content_storage.rs
@@ -1,0 +1,136 @@
+use crate::repository::{backlog, features, work_packages};
+use crate::lib::adapter::SqliteStorageAdapter;
+use agileplus_domain::{
+    domain::{
+        backlog::{BacklogFilters, BacklogItem, BacklogPriority, BacklogStatus},
+        feature::Feature,
+        state_machine::FeatureState,
+        work_package::{WorkPackage, WpState},
+    },
+    error::DomainError,
+    ports::ContentStoragePort,
+};
+
+impl ContentStoragePort for SqliteStorageAdapter {
+    async fn create_feature(&self, feature: &Feature) -> Result<i64, DomainError> {
+        let conn = self.lock()?;
+        features::create_feature(&conn, feature)
+    }
+
+    async fn get_feature_by_slug(&self, slug: &str) -> Result<Option<Feature>, DomainError> {
+        let conn = self.lock()?;
+        features::get_feature_by_slug(&conn, slug)
+    }
+
+    async fn get_feature_by_id(&self, id: i64) -> Result<Option<Feature>, DomainError> {
+        let conn = self.lock()?;
+        features::get_feature_by_id(&conn, id)
+    }
+
+    async fn update_feature_state(&self, id: i64, state: FeatureState) -> Result<(), DomainError> {
+        let conn = self.lock()?;
+        features::update_feature_state(&conn, id, state)
+    }
+
+    async fn update_feature(&self, feature: &Feature) -> Result<(), DomainError> {
+        let conn = self.lock()?;
+        features::update_feature(&conn, feature)
+    }
+
+    async fn list_features_by_state(
+        &self,
+        state: FeatureState,
+    ) -> Result<Vec<Feature>, DomainError> {
+        let conn = self.lock()?;
+        features::list_features_by_state(&conn, state)
+    }
+
+    async fn list_all_features(&self) -> Result<Vec<Feature>, DomainError> {
+        let conn = self.lock()?;
+        features::list_all_features(&conn)
+    }
+
+    async fn create_backlog_item(&self, item: &BacklogItem) -> Result<i64, DomainError> {
+        let conn = self.lock()?;
+        backlog::create_backlog_item(&conn, item)
+    }
+
+    async fn get_backlog_item(&self, id: i64) -> Result<Option<BacklogItem>, DomainError> {
+        let conn = self.lock()?;
+        backlog::get_backlog_item(&conn, id)
+    }
+
+    async fn list_backlog_items(
+        &self,
+        filters: &BacklogFilters,
+    ) -> Result<Vec<BacklogItem>, DomainError> {
+        let conn = self.lock()?;
+        backlog::list_backlog_items(&conn, filters)
+    }
+
+    async fn update_backlog_status(
+        &self,
+        id: i64,
+        status: BacklogStatus,
+    ) -> Result<(), DomainError> {
+        let conn = self.lock()?;
+        backlog::update_backlog_status(&conn, id, status)
+    }
+
+    async fn update_backlog_priority(
+        &self,
+        id: i64,
+        priority: BacklogPriority,
+    ) -> Result<(), DomainError> {
+        let conn = self.lock()?;
+        backlog::update_backlog_priority(&conn, id, priority)
+    }
+
+    async fn pop_next_backlog_item(&self) -> Result<Option<BacklogItem>, DomainError> {
+        let conn = self.lock()?;
+        backlog::pop_next_backlog_item(&conn)
+    }
+
+    async fn create_work_package(&self, wp: &WorkPackage) -> Result<i64, DomainError> {
+        let conn = self.lock()?;
+        work_packages::create_work_package(&conn, wp)
+    }
+
+    async fn get_work_package(&self, id: i64) -> Result<Option<WorkPackage>, DomainError> {
+        let conn = self.lock()?;
+        work_packages::get_work_package(&conn, id)
+    }
+
+    async fn update_wp_state(&self, id: i64, state: WpState) -> Result<(), DomainError> {
+        let conn = self.lock()?;
+        work_packages::update_wp_state(&conn, id, state)
+    }
+
+    async fn update_work_package(&self, wp: &WorkPackage) -> Result<(), DomainError> {
+        let conn = self.lock()?;
+        work_packages::update_work_package(&conn, wp)
+    }
+
+    async fn list_wps_by_feature(&self, feature_id: i64) -> Result<Vec<WorkPackage>, DomainError> {
+        let conn = self.lock()?;
+        work_packages::list_wps_by_feature(&conn, feature_id)
+    }
+
+    async fn add_wp_dependency(
+        &self,
+        dep: &agileplus_domain::domain::work_package::WpDependency,
+    ) -> Result<(), DomainError> {
+        let conn = self.lock()?;
+        work_packages::add_wp_dependency(&conn, dep)
+    }
+
+    async fn get_wp_dependencies(&self, wp_id: i64) -> Result<Vec<agileplus_domain::domain::work_package::WpDependency>, DomainError> {
+        let conn = self.lock()?;
+        work_packages::get_wp_dependencies(&conn, wp_id)
+    }
+
+    async fn get_ready_wps(&self, feature_id: i64) -> Result<Vec<WorkPackage>, DomainError> {
+        let conn = self.lock()?;
+        work_packages::get_ready_wps(&conn, feature_id)
+    }
+}

--- a/crates/agileplus-sqlite/src/lib/storage_port.rs
+++ b/crates/agileplus-sqlite/src/lib/storage_port.rs
@@ -1,0 +1,320 @@
+use crate::repository::{audit, cycles, features, governance, metrics, modules, projects, sync_mappings, work_packages};
+use crate::lib::adapter::SqliteStorageAdapter;
+use agileplus_domain::{
+    domain::{
+        audit::AuditEntry,
+        feature::Feature,
+        governance::{Evidence, GovernanceContract, PolicyRule},
+        metric::Metric,
+        module::{Module, ModuleFeatureTag, ModuleWithFeatures},
+        state_machine::FeatureState,
+        sync_mapping::SyncMapping,
+        work_package::{WorkPackage, WpDependency, WpState},
+    },
+    error::DomainError,
+    ports::StoragePort,
+};
+
+impl StoragePort for SqliteStorageAdapter {
+    async fn create_feature(&self, feature: &Feature) -> Result<i64, DomainError> {
+        let conn = self.lock()?;
+        features::create_feature(&conn, feature)
+    }
+
+    async fn get_feature_by_slug(&self, slug: &str) -> Result<Option<Feature>, DomainError> {
+        let conn = self.lock()?;
+        features::get_feature_by_slug(&conn, slug)
+    }
+
+    async fn get_feature_by_id(&self, id: i64) -> Result<Option<Feature>, DomainError> {
+        let conn = self.lock()?;
+        features::get_feature_by_id(&conn, id)
+    }
+
+    async fn update_feature_state(&self, id: i64, state: FeatureState) -> Result<(), DomainError> {
+        let conn = self.lock()?;
+        features::update_feature_state(&conn, id, state)
+    }
+
+    async fn list_features_by_state(
+        &self,
+        state: FeatureState,
+    ) -> Result<Vec<Feature>, DomainError> {
+        let conn = self.lock()?;
+        features::list_features_by_state(&conn, state)
+    }
+
+    async fn list_all_features(&self) -> Result<Vec<Feature>, DomainError> {
+        let conn = self.lock()?;
+        features::list_all_features(&conn)
+    }
+
+    async fn create_work_package(&self, wp: &WorkPackage) -> Result<i64, DomainError> {
+        let conn = self.lock()?;
+        work_packages::create_work_package(&conn, wp)
+    }
+
+    async fn get_work_package(&self, id: i64) -> Result<Option<WorkPackage>, DomainError> {
+        let conn = self.lock()?;
+        work_packages::get_work_package(&conn, id)
+    }
+
+    async fn update_wp_state(&self, id: i64, state: WpState) -> Result<(), DomainError> {
+        let conn = self.lock()?;
+        work_packages::update_wp_state(&conn, id, state)
+    }
+
+    async fn list_wps_by_feature(&self, feature_id: i64) -> Result<Vec<WorkPackage>, DomainError> {
+        let conn = self.lock()?;
+        work_packages::list_wps_by_feature(&conn, feature_id)
+    }
+
+    async fn add_wp_dependency(&self, dep: &WpDependency) -> Result<(), DomainError> {
+        let conn = self.lock()?;
+        work_packages::add_wp_dependency(&conn, dep)
+    }
+
+    async fn get_wp_dependencies(&self, wp_id: i64) -> Result<Vec<WpDependency>, DomainError> {
+        let conn = self.lock()?;
+        work_packages::get_wp_dependencies(&conn, wp_id)
+    }
+
+    async fn get_ready_wps(&self, feature_id: i64) -> Result<Vec<WorkPackage>, DomainError> {
+        let conn = self.lock()?;
+        work_packages::get_ready_wps(&conn, feature_id)
+    }
+
+    async fn append_audit_entry(&self, entry: &AuditEntry) -> Result<i64, DomainError> {
+        let conn = self.lock()?;
+        audit::append_audit_entry(&conn, entry)
+    }
+
+    async fn get_audit_trail(&self, feature_id: i64) -> Result<Vec<AuditEntry>, DomainError> {
+        let conn = self.lock()?;
+        audit::get_audit_trail(&conn, feature_id)
+    }
+
+    async fn get_latest_audit_entry(
+        &self,
+        feature_id: i64,
+    ) -> Result<Option<AuditEntry>, DomainError> {
+        let conn = self.lock()?;
+        audit::get_latest_audit_entry(&conn, feature_id)
+    }
+
+    async fn create_evidence(&self, ev: &Evidence) -> Result<i64, DomainError> {
+        let conn = self.lock()?;
+        crate::repository::evidence::create_evidence(&conn, ev)
+    }
+
+    async fn get_evidence_by_wp(&self, wp_id: i64) -> Result<Vec<Evidence>, DomainError> {
+        let conn = self.lock()?;
+        crate::repository::evidence::get_evidence_by_wp(&conn, wp_id)
+    }
+
+    async fn get_evidence_by_fr(&self, fr_id: &str) -> Result<Vec<Evidence>, DomainError> {
+        let conn = self.lock()?;
+        crate::repository::evidence::get_evidence_by_fr(&conn, fr_id)
+    }
+
+    async fn create_policy_rule(&self, rule: &PolicyRule) -> Result<i64, DomainError> {
+        let conn = self.lock()?;
+        governance::create_policy_rule(&conn, rule)
+    }
+
+    async fn list_active_policies(&self) -> Result<Vec<PolicyRule>, DomainError> {
+        let conn = self.lock()?;
+        governance::list_active_policies(&conn)
+    }
+
+    async fn record_metric(&self, metric: &Metric) -> Result<i64, DomainError> {
+        let conn = self.lock()?;
+        metrics::record_metric(&conn, metric)
+    }
+
+    async fn get_metrics_by_feature(&self, feature_id: i64) -> Result<Vec<Metric>, DomainError> {
+        let conn = self.lock()?;
+        metrics::get_metrics_by_feature(&conn, feature_id)
+    }
+
+    async fn create_governance_contract(
+        &self,
+        contract: &GovernanceContract,
+    ) -> Result<i64, DomainError> {
+        let conn = self.lock()?;
+        governance::create_governance_contract(&conn, contract)
+    }
+
+    async fn get_governance_contract(
+        &self,
+        feature_id: i64,
+        version: i32,
+    ) -> Result<Option<GovernanceContract>, DomainError> {
+        let conn = self.lock()?;
+        governance::get_governance_contract(&conn, feature_id, version)
+    }
+
+    async fn get_latest_governance_contract(
+        &self,
+        feature_id: i64,
+    ) -> Result<Option<GovernanceContract>, DomainError> {
+        let conn = self.lock()?;
+        governance::get_latest_governance_contract(&conn, feature_id)
+    }
+
+    async fn create_module(&self, module: &Module) -> Result<i64, DomainError> {
+        let conn = self.lock()?;
+        modules::create_module(&conn, module)
+    }
+
+    async fn get_module(&self, id: i64) -> Result<Option<Module>, DomainError> {
+        let conn = self.lock()?;
+        modules::get_module(&conn, id)
+    }
+
+    async fn get_module_by_slug(&self, slug: &str) -> Result<Option<Module>, DomainError> {
+        let conn = self.lock()?;
+        modules::get_module_by_slug(&conn, slug)
+    }
+
+    async fn update_module(
+        &self,
+        id: i64,
+        friendly_name: &str,
+        description: Option<&str>,
+    ) -> Result<(), DomainError> {
+        let conn = self.lock()?;
+        modules::update_module(&conn, id, friendly_name, description)
+    }
+
+    async fn delete_module(&self, id: i64) -> Result<(), DomainError> {
+        let conn = self.lock()?;
+        modules::delete_module(&conn, id)
+    }
+
+    async fn list_root_modules(&self) -> Result<Vec<Module>, DomainError> {
+        let conn = self.lock()?;
+        modules::list_root_modules(&conn)
+    }
+
+    async fn list_child_modules(&self, parent_id: i64) -> Result<Vec<Module>, DomainError> {
+        let conn = self.lock()?;
+        modules::list_child_modules(&conn, parent_id)
+    }
+
+    async fn get_module_with_features(
+        &self,
+        id: i64,
+    ) -> Result<Option<ModuleWithFeatures>, DomainError> {
+        let conn = self.lock()?;
+        modules::get_module_with_features(&conn, id)
+    }
+
+    async fn create_cycle(&self, cycle: &agileplus_domain::domain::cycle::Cycle) -> Result<i64, DomainError> {
+        let conn = self.lock()?;
+        cycles::create_cycle(&conn, cycle)
+    }
+
+    async fn get_cycle(&self, id: i64) -> Result<Option<agileplus_domain::domain::cycle::Cycle>, DomainError> {
+        let conn = self.lock()?;
+        cycles::get_cycle(&conn, id)
+    }
+
+    async fn update_cycle_state(&self, id: i64, state: agileplus_domain::domain::cycle::CycleState) -> Result<(), DomainError> {
+        let conn = self.lock()?;
+        cycles::update_cycle_state(&conn, id, state)
+    }
+
+    async fn list_cycles_by_state(&self, state: agileplus_domain::domain::cycle::CycleState) -> Result<Vec<agileplus_domain::domain::cycle::Cycle>, DomainError> {
+        let conn = self.lock()?;
+        cycles::list_cycles_by_state(&conn, state)
+    }
+
+    async fn list_cycles_by_module(&self, module_id: i64) -> Result<Vec<agileplus_domain::domain::cycle::Cycle>, DomainError> {
+        let conn = self.lock()?;
+        cycles::list_cycles_by_module(&conn, module_id)
+    }
+
+    async fn list_all_cycles(&self) -> Result<Vec<agileplus_domain::domain::cycle::Cycle>, DomainError> {
+        let conn = self.lock()?;
+        cycles::list_all_cycles(&conn)
+    }
+
+    async fn get_cycle_with_features(
+        &self,
+        id: i64,
+    ) -> Result<Option<agileplus_domain::domain::cycle::CycleWithFeatures>, DomainError> {
+        let conn = self.lock()?;
+        cycles::get_cycle_with_features(&conn, id)
+    }
+
+    async fn tag_feature_to_module(&self, tag: &ModuleFeatureTag) -> Result<(), DomainError> {
+        let conn = self.lock()?;
+        modules::tag_feature_to_module(&conn, tag)
+    }
+
+    async fn untag_feature_from_module(
+        &self,
+        module_id: i64,
+        feature_id: i64,
+    ) -> Result<(), DomainError> {
+        let conn = self.lock()?;
+        modules::untag_feature_from_module(&conn, module_id, feature_id)
+    }
+
+    async fn add_feature_to_cycle(&self, entry: &agileplus_domain::domain::cycle::CycleFeature) -> Result<(), DomainError> {
+        let conn = self.lock()?;
+        cycles::add_feature_to_cycle(&conn, entry)
+    }
+
+    async fn remove_feature_from_cycle(
+        &self,
+        cycle_id: i64,
+        feature_id: i64,
+    ) -> Result<(), DomainError> {
+        let conn = self.lock()?;
+        cycles::remove_feature_from_cycle(&conn, cycle_id, feature_id)
+    }
+
+    async fn get_sync_mapping(
+        &self,
+        entity_type: &str,
+        entity_id: i64,
+    ) -> Result<Option<SyncMapping>, DomainError> {
+        let conn = self.lock()?;
+        sync_mappings::get_sync_mapping(&conn, entity_type, entity_id)
+    }
+
+    async fn upsert_sync_mapping(&self, mapping: &SyncMapping) -> Result<(), DomainError> {
+        let conn = self.lock()?;
+        sync_mappings::upsert_sync_mapping(&conn, mapping)
+    }
+
+    async fn get_sync_mapping_by_plane_id(
+        &self,
+        entity_type: &str,
+        plane_issue_id: &str,
+    ) -> Result<Option<SyncMapping>, DomainError> {
+        let conn = self.lock()?;
+        sync_mappings::get_sync_mapping_by_plane_id(&conn, entity_type, plane_issue_id)
+    }
+
+    async fn delete_sync_mapping(
+        &self,
+        entity_type: &str,
+        entity_id: i64,
+    ) -> Result<(), DomainError> {
+        let conn = self.lock()?;
+        sync_mappings::delete_sync_mapping(&conn, entity_type, entity_id)
+    }
+
+    async fn create_project(&self, project: &agileplus_domain::domain::project::Project) -> Result<i64, DomainError> {
+        let conn = self.lock()?;
+        projects::create_project(&conn, project)
+    }
+
+    async fn get_project_by_slug(&self, slug: &str) -> Result<Option<agileplus_domain::domain::project::Project>, DomainError> {
+        let conn = self.lock()?;
+        projects::get_project_by_slug(&conn, slug)
+    }
+}

--- a/crates/agileplus-sqlite/src/lib/tests/feature_work_packages.rs
+++ b/crates/agileplus-sqlite/src/lib/tests/feature_work_packages.rs
@@ -1,0 +1,402 @@
+use super::*;
+
+#[tokio::test]
+async fn feature_create_and_get_by_slug() {
+    let db = make_adapter();
+    let f = Feature::new("my-feat", "My Feature", [0u8; 32], None);
+    let id = StoragePort::create_feature(&db, &f).await.unwrap();
+    assert!(id > 0);
+ 
+    let got = StoragePort::get_feature_by_slug(&db, "my-feat")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(got.id, id);
+    assert_eq!(got.slug, "my-feat");
+    assert_eq!(got.friendly_name, "My Feature");
+    assert_eq!(got.spec_hash, [0u8; 32]);
+    assert_eq!(got.state, FeatureState::Created);
+}
+
+#[tokio::test]
+async fn feature_get_by_id() {
+    let db = make_adapter();
+    let f = Feature::new("feat-id", "Feat", [1u8; 32], None);
+    let id = StoragePort::create_feature(&db, &f).await.unwrap();
+    let got = StoragePort::get_feature_by_id(&db, id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(got.slug, "feat-id");
+}
+ 
+#[tokio::test]
+async fn feature_update_state() {
+    let db = make_adapter();
+    let f = Feature::new("upd-feat", "Upd", [0u8; 32], None);
+    let id = StoragePort::create_feature(&db, &f).await.unwrap();
+ 
+    StoragePort::update_feature_state(&db, id, FeatureState::Specified)
+        .await
+        .unwrap();
+    let got = StoragePort::get_feature_by_id(&db, id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(got.state, FeatureState::Specified);
+}
+ 
+#[tokio::test]
+async fn feature_update_persists_mutable_fields() {
+    let db = make_adapter();
+    let mut feature = Feature::new("mut-feat", "Mutable Feature", [1u8; 32], Some("main"));
+    let id = StoragePort::create_feature(&db, &feature).await.unwrap();
+    feature.id = id;
+    feature.friendly_name = "Renamed Feature".to_string();
+    feature.target_branch = "release/stable".to_string();
+    feature.spec_hash = [2u8; 32];
+    feature.module_id = None;
+    feature.state = FeatureState::Validated;
+    feature.updated_at = chrono::Utc::now();
+ 
+    ContentStoragePort::update_feature(&db, &feature).await.unwrap();
+ 
+    let got = StoragePort::get_feature_by_id(&db, id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(got.friendly_name, "Renamed Feature");
+    assert_eq!(got.target_branch, "release/stable");
+    assert_eq!(got.spec_hash, [2u8; 32]);
+    assert_eq!(got.module_id, None);
+    assert_eq!(got.state, FeatureState::Validated);
+}
+ 
+#[tokio::test]
+async fn feature_list_by_state() {
+    let db = make_adapter();
+    let f1 = Feature::new("f1", "F1", [0u8; 32], None);
+    let f2 = Feature::new("f2", "F2", [0u8; 32], None);
+    let id1 = StoragePort::create_feature(&db, &f1).await.unwrap();
+    let _id2 = StoragePort::create_feature(&db, &f2).await.unwrap();
+    StoragePort::update_feature_state(&db, id1, FeatureState::Specified)
+        .await
+        .unwrap();
+ 
+    let specified = StoragePort::list_features_by_state(&db, FeatureState::Specified)
+        .await
+        .unwrap();
+    assert_eq!(specified.len(), 1);
+    assert_eq!(specified[0].slug, "f1");
+ 
+    let created = StoragePort::list_features_by_state(&db, FeatureState::Created)
+        .await
+        .unwrap();
+    assert_eq!(created.len(), 1);
+    assert_eq!(created[0].slug, "f2");
+}
+ 
+#[tokio::test]
+async fn feature_list_all() {
+    let db = make_adapter();
+    StoragePort::create_feature(&db, &Feature::new("aa", "AA", [0u8; 32], None))
+        .await
+        .unwrap();
+    StoragePort::create_feature(&db, &Feature::new("bb", "BB", [0u8; 32], None))
+        .await
+        .unwrap();
+    let all = StoragePort::list_all_features(&db).await.unwrap();
+    assert_eq!(all.len(), 2);
+}
+ 
+#[tokio::test]
+async fn feature_duplicate_slug_fails() {
+    let db = make_adapter();
+    let f = Feature::new("dup", "Dup", [0u8; 32], None);
+    StoragePort::create_feature(&db, &f).await.unwrap();
+    let result = StoragePort::create_feature(&db, &f).await;
+    assert!(result.is_err());
+}
+ 
+#[tokio::test]
+async fn feature_not_found_returns_none() {
+    let db = make_adapter();
+    let got = StoragePort::get_feature_by_slug(&db, "no-such-slug")
+        .await
+        .unwrap();
+    assert!(got.is_none());
+    let got2 = StoragePort::get_feature_by_id(&db, 9999).await.unwrap();
+    assert!(got2.is_none());
+}
+ 
+#[tokio::test]
+async fn wp_create_and_get() {
+    let db = make_adapter();
+    let feat = Feature::new("wp-feat", "WP Feat", [0u8; 32], None);
+    let fid = StoragePort::create_feature(&db, &feat).await.unwrap();
+ 
+    let mut wp = WorkPackage::new(fid, "Task A", 1, "criteria");
+    wp.file_scope = vec!["src/main.rs".into()];
+    let wp_id = StoragePort::create_work_package(&db, &wp).await.unwrap();
+    assert!(wp_id > 0);
+ 
+    let got = StoragePort::get_work_package(&db, wp_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(got.title, "Task A");
+    assert_eq!(got.file_scope, vec!["src/main.rs"]);
+    assert_eq!(got.state, WpState::Planned);
+    assert_eq!(got.feature_id, fid);
+}
+ 
+#[tokio::test]
+async fn wp_update_state() {
+    let db = make_adapter();
+    let fid = StoragePort::create_feature(&db, &Feature::new("f", "F", [0u8; 32], None))
+        .await
+        .unwrap();
+    let wp_id = StoragePort::create_work_package(&db, &WorkPackage::new(fid, "T", 1, "c"))
+        .await
+        .unwrap();
+    StoragePort::update_wp_state(&db, wp_id, WpState::Doing).await.unwrap();
+    let got = StoragePort::get_work_package(&db, wp_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(got.state, WpState::Doing);
+}
+ 
+#[tokio::test]
+async fn wp_update_persists_mutable_fields() {
+    let db = make_adapter();
+    let fid = StoragePort::create_feature(&db, &Feature::new("f-upd", "F Upd", [0u8; 32], None))
+        .await
+        .unwrap();
+    let mut wp = WorkPackage::new(fid, "Task", 1, "criteria");
+    wp.file_scope = vec!["src/lib.rs".into()];
+    let wp_id = StoragePort::create_work_package(&db, &wp).await.unwrap();
+    wp.id = wp_id;
+    wp.title = "Updated Task".to_string();
+    wp.sequence = 4;
+    wp.file_scope = vec!["src/main.rs".into(), "src/lib.rs".into()];
+    wp.acceptance_criteria = "Updated criteria".to_string();
+    wp.agent_id = Some("agent-1".to_string());
+    wp.pr_url = Some("https://example.com/pr/7".to_string());
+    wp.worktree_path = Some("/tmp/worktree".to_string());
+    wp.state = WpState::Doing;
+    wp.updated_at = chrono::Utc::now();
+ 
+    ContentStoragePort::update_work_package(&db, &wp).await.unwrap();
+ 
+    let got = StoragePort::get_work_package(&db, wp_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(got.title, "Updated Task");
+    assert_eq!(got.sequence, 4);
+    assert_eq!(got.file_scope, vec!["src/main.rs", "src/lib.rs"]);
+    assert_eq!(got.acceptance_criteria, "Updated criteria");
+    assert_eq!(got.agent_id.as_deref(), Some("agent-1"));
+    assert_eq!(got.pr_url.as_deref(), Some("https://example.com/pr/7"));
+    assert_eq!(got.worktree_path.as_deref(), Some("/tmp/worktree"));
+    assert_eq!(got.state, WpState::Doing);
+}
+ 
+#[tokio::test]
+async fn wp_list_by_feature_ordered_by_sequence() {
+    let db = make_adapter();
+    let fid = StoragePort::create_feature(&db, &Feature::new("f2", "F2", [0u8; 32], None))
+        .await
+        .unwrap();
+    StoragePort::create_work_package(&db, &WorkPackage::new(fid, "B", 2, "c"))
+        .await
+        .unwrap();
+    StoragePort::create_work_package(&db, &WorkPackage::new(fid, "A", 1, "c"))
+        .await
+        .unwrap();
+ 
+    let wps = StoragePort::list_wps_by_feature(&db, fid).await.unwrap();
+    assert_eq!(wps.len(), 2);
+    assert_eq!(wps[0].sequence, 1);
+    assert_eq!(wps[1].sequence, 2);
+}
+ 
+#[tokio::test]
+async fn wp_dependencies_and_ready_wps() {
+    let db = make_adapter();
+    let fid = StoragePort::create_feature(&db, &Feature::new("f3", "F3", [0u8; 32], None))
+        .await
+        .unwrap();
+    let wp1 = StoragePort::create_work_package(&db, &WorkPackage::new(fid, "WP1", 1, "c"))
+        .await
+        .unwrap();
+    let wp2 = StoragePort::create_work_package(&db, &WorkPackage::new(fid, "WP2", 2, "c"))
+        .await
+        .unwrap();
+ 
+    StoragePort::add_wp_dependency(&db, &WpDependency {
+        wp_id: wp2,
+        depends_on: wp1,
+        dep_type: DependencyType::Explicit,
+    })
+    .await
+    .unwrap();
+ 
+    let ready = StoragePort::get_ready_wps(&db, fid).await.unwrap();
+    assert_eq!(ready.len(), 1);
+    assert_eq!(ready[0].id, wp1);
+ 
+    StoragePort::update_wp_state(&db, wp1, WpState::Doing).await.unwrap();
+    StoragePort::update_wp_state(&db, wp1, WpState::Review).await.unwrap();
+    StoragePort::update_wp_state(&db, wp1, WpState::Done).await.unwrap();
+ 
+    let ready = StoragePort::get_ready_wps(&db, fid).await.unwrap();
+    assert_eq!(ready.len(), 1);
+    assert_eq!(ready[0].id, wp2);
+}
+ 
+#[tokio::test]
+async fn wp_get_dependencies() {
+    let db = make_adapter();
+    let fid = StoragePort::create_feature(&db, &Feature::new("fd", "FD", [0u8; 32], None))
+        .await
+        .unwrap();
+    let w1 = StoragePort::create_work_package(&db, &WorkPackage::new(fid, "W1", 1, "c"))
+        .await
+        .unwrap();
+    let w2 = StoragePort::create_work_package(&db, &WorkPackage::new(fid, "W2", 2, "c"))
+        .await
+        .unwrap();
+    StoragePort::add_wp_dependency(&db, &WpDependency {
+        wp_id: w2,
+        depends_on: w1,
+        dep_type: DependencyType::Data,
+    })
+    .await
+    .unwrap();
+    let deps = StoragePort::get_wp_dependencies(&db, w2).await.unwrap();
+    assert_eq!(deps.len(), 1);
+    assert_eq!(deps[0].depends_on, w1);
+}
+ 
+#[tokio::test]
+async fn audit_append_and_trail() {
+    let db = make_adapter();
+    let fid = StoragePort::create_feature(&db, &Feature::new("af", "AF", [0u8; 32], None))
+        .await
+        .unwrap();
+ 
+    let e1 = make_audit_entry(fid, [0u8; 32]);
+    let _id1 = StoragePort::append_audit_entry(&db, &e1).await.unwrap();
+ 
+    let e2 = make_audit_entry(fid, e1.hash);
+    let _id2 = StoragePort::append_audit_entry(&db, &e2).await.unwrap();
+ 
+    let e3 = make_audit_entry(fid, e2.hash);
+    StoragePort::append_audit_entry(&db, &e3).await.unwrap();
+ 
+    let trail = StoragePort::get_audit_trail(&db, fid).await.unwrap();
+    assert_eq!(trail.len(), 3);
+    assert!(trail[0].id <= trail[1].id);
+    assert!(trail[1].id <= trail[2].id);
+}
+ 
+#[tokio::test]
+async fn audit_wrong_prev_hash_rejected() {
+    let db = make_adapter();
+    let fid = StoragePort::create_feature(&db, &Feature::new("afc", "AFC", [0u8; 32], None))
+        .await
+        .unwrap();
+ 
+    let e1 = make_audit_entry(fid, [0u8; 32]);
+    StoragePort::append_audit_entry(&db, &e1).await.unwrap();
+ 
+    let e_bad = make_audit_entry(fid, [0xFFu8; 32]);
+    let result = StoragePort::append_audit_entry(&db, &e_bad).await;
+    assert!(result.is_err());
+}
+ 
+#[tokio::test]
+async fn audit_get_latest() {
+    let db = make_adapter();
+    let fid = StoragePort::create_feature(&db, &Feature::new("al", "AL", [0u8; 32], None))
+        .await
+        .unwrap();
+ 
+    assert!(StoragePort::get_latest_audit_entry(&db, fid).await.unwrap().is_none());
+ 
+    let e1 = make_audit_entry(fid, [0u8; 32]);
+    StoragePort::append_audit_entry(&db, &e1).await.unwrap();
+ 
+    let e2 = make_audit_entry(fid, e1.hash);
+    StoragePort::append_audit_entry(&db, &e2).await.unwrap();
+ 
+    let latest = StoragePort::get_latest_audit_entry(&db, fid).await.unwrap().unwrap();
+    assert_eq!(latest.hash, e2.hash);
+}
+ 
+#[tokio::test]
+async fn evidence_create_and_get_by_wp() {
+    let db = make_adapter();
+    let fid = StoragePort::create_feature(&db, &Feature::new("ef", "EF", [0u8; 32], None))
+        .await
+        .unwrap();
+    let wp_id = StoragePort::create_work_package(&db, &WorkPackage::new(fid, "WP", 1, "c"))
+        .await
+        .unwrap();
+ 
+    let ev = Evidence {
+        id: 0,
+        wp_id,
+        fr_id: "FR-001".into(),
+        evidence_type: EvidenceType::TestResult,
+        artifact_path: "results/test.xml".into(),
+        metadata: Some(serde_json::json!({"pass": 42})),
+        created_at: chrono::Utc::now(),
+    };
+    let ev_id = StoragePort::create_evidence(&db, &ev).await.unwrap();
+    assert!(ev_id > 0);
+ 
+    let evs = StoragePort::get_evidence_by_wp(&db, wp_id).await.unwrap();
+    assert_eq!(evs.len(), 1);
+    assert_eq!(evs[0].fr_id, "FR-001");
+    assert_eq!(evs[0].evidence_type, EvidenceType::TestResult);
+    assert!(evs[0].metadata.is_some());
+}
+ 
+#[tokio::test]
+async fn evidence_get_by_fr() {
+    let db = make_adapter();
+    let fid = StoragePort::create_feature(&db, &Feature::new("efr", "EFR", [0u8; 32], None))
+        .await
+        .unwrap();
+    let wp_id = StoragePort::create_work_package(&db, &WorkPackage::new(fid, "WP", 1, "c"))
+        .await
+        .unwrap();
+ 
+    let ev1 = Evidence {
+        id: 0,
+        wp_id,
+        fr_id: "FR-001".into(),
+        evidence_type: EvidenceType::CiOutput,
+        artifact_path: "ci.log".into(),
+        metadata: None,
+        created_at: chrono::Utc::now(),
+    };
+    let ev2 = Evidence {
+        id: 0,
+        wp_id,
+        fr_id: "FR-002".into(),
+        evidence_type: EvidenceType::LintResult,
+        artifact_path: "lint.log".into(),
+        metadata: None,
+        created_at: chrono::Utc::now(),
+    };
+    StoragePort::create_evidence(&db, &ev1).await.unwrap();
+    StoragePort::create_evidence(&db, &ev2).await.unwrap();
+ 
+    let fr1 = StoragePort::get_evidence_by_fr(&db, "FR-001").await.unwrap();
+    assert_eq!(fr1.len(), 1);
+    assert_eq!(fr1[0].fr_id, "FR-001");
+}

--- a/crates/agileplus-sqlite/src/lib/tests/governance_metrics.rs
+++ b/crates/agileplus-sqlite/src/lib/tests/governance_metrics.rs
@@ -1,0 +1,117 @@
+use super::*;
+
+#[tokio::test]
+async fn policy_create_and_list_active() {
+    let db = make_adapter();
+    let rule = PolicyRule {
+        id: 0,
+        domain: PolicyDomain::Quality,
+        rule: PolicyDefinition {
+            description: "All tests must pass".into(),
+            check: PolicyCheck::ManualApproval,
+        },
+        active: true,
+        created_at: chrono::Utc::now(),
+        updated_at: chrono::Utc::now(),
+    };
+    let id = StoragePort::create_policy_rule(&db, &rule).await.unwrap();
+    assert!(id > 0);
+ 
+    let active = StoragePort::list_active_policies(&db).await.unwrap();
+    assert_eq!(active.len(), 1);
+    assert_eq!(active[0].domain, PolicyDomain::Quality);
+}
+ 
+#[tokio::test]
+async fn governance_contract_create_and_get() {
+    let db = make_adapter();
+    let fid = StoragePort::create_feature(&db, &Feature::new("gc", "GC", [0u8; 32], None))
+        .await
+        .unwrap();
+ 
+    let contract = GovernanceContract {
+        id: 0,
+        feature_id: fid,
+        version: 1,
+        rules: vec![GovernanceRule {
+            transition: "created->specified".into(),
+            required_evidence: vec![],
+            policy_refs: vec![],
+        }],
+        bound_at: chrono::Utc::now(),
+    };
+    let cid = StoragePort::create_governance_contract(&db, &contract).await.unwrap();
+    assert!(cid > 0);
+ 
+    let got = StoragePort::get_governance_contract(&db, fid, 1).await.unwrap().unwrap();
+    assert_eq!(got.feature_id, fid);
+    assert_eq!(got.version, 1);
+    assert_eq!(got.rules.len(), 1);
+ 
+    let latest = StoragePort::get_latest_governance_contract(&db, fid)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(latest.version, 1);
+}
+ 
+#[tokio::test]
+async fn governance_contract_versioning() {
+    let db = make_adapter();
+    let fid = StoragePort::create_feature(&db, &Feature::new("gcv", "GCV", [0u8; 32], None))
+        .await
+        .unwrap();
+ 
+    let c1 = GovernanceContract {
+        id: 0,
+        feature_id: fid,
+        version: 1,
+        rules: vec![],
+        bound_at: chrono::Utc::now(),
+    };
+    let c2 = GovernanceContract {
+        id: 0,
+        feature_id: fid,
+        version: 2,
+        rules: vec![],
+        bound_at: chrono::Utc::now(),
+    };
+    StoragePort::create_governance_contract(&db, &c1).await.unwrap();
+    StoragePort::create_governance_contract(&db, &c2).await.unwrap();
+ 
+    let latest = StoragePort::get_latest_governance_contract(&db, fid)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(latest.version, 2);
+ 
+    let v1 = StoragePort::get_governance_contract(&db, fid, 1).await.unwrap().unwrap();
+    assert_eq!(v1.version, 1);
+}
+ 
+#[tokio::test]
+async fn metric_record_and_get() {
+    let db = make_adapter();
+    let fid = StoragePort::create_feature(&db, &Feature::new("mf", "MF", [0u8; 32], None))
+        .await
+        .unwrap();
+ 
+    let m = Metric {
+        id: 0,
+        feature_id: Some(fid),
+        command: "agileplus implement".into(),
+        duration_ms: 1234,
+        agent_runs: 3,
+        review_cycles: 1,
+        metadata: Some(serde_json::json!({"model": "claude"})),
+        timestamp: chrono::Utc::now(),
+    };
+    let mid = StoragePort::record_metric(&db, &m).await.unwrap();
+    assert!(mid > 0);
+ 
+    let ms = StoragePort::get_metrics_by_feature(&db, fid).await.unwrap();
+    assert_eq!(ms.len(), 1);
+    assert_eq!(ms[0].command, "agileplus implement");
+    assert_eq!(ms[0].duration_ms, 1234);
+    assert!(ms[0].metadata.is_some());
+}

--- a/crates/agileplus-sqlite/src/lib/tests/mod.rs
+++ b/crates/agileplus-sqlite/src/lib/tests/mod.rs
@@ -1,0 +1,43 @@
+use super::*;
+use agileplus_domain::domain::{
+    audit::{AuditEntry, hash_entry},
+    feature::Feature,
+    governance::{
+        Evidence, EvidenceType, GovernanceContract, GovernanceRule, PolicyCheck, PolicyDefinition,
+        PolicyDomain, PolicyRule,
+    },
+    metric::Metric,
+    state_machine::FeatureState,
+    work_package::{DependencyType, WorkPackage, WpDependency, WpState},
+};
+use agileplus_domain::ports::{ContentStoragePort, StoragePort};
+
+mod feature_work_packages;
+mod governance_metrics;
+mod modules_cycles;
+
+fn make_adapter() -> SqliteStorageAdapter {
+    SqliteStorageAdapter::in_memory().expect("in-memory adapter")
+}
+
+fn make_audit_entry(feature_id: i64, prev_hash: [u8; 32]) -> AuditEntry {
+    let mut entry = AuditEntry {
+        id: 0,
+        feature_id,
+        wp_id: None,
+        timestamp: chrono::Utc::now(),
+        actor: "agent".into(),
+        transition: "created->specified".into(),
+        evidence_refs: vec![],
+        prev_hash,
+        hash: [0u8; 32],
+        event_id: None,
+        archived_to: None,
+    };
+    entry.hash = hash_entry(&entry);
+    entry
+}
+
+fn make_date(y: i32, m: u32, d: u32) -> chrono::NaiveDate {
+    chrono::NaiveDate::from_ymd_opt(y, m, d).expect("valid date")
+}

--- a/crates/agileplus-sqlite/src/lib/tests/modules_cycles.rs
+++ b/crates/agileplus-sqlite/src/lib/tests/modules_cycles.rs
@@ -1,0 +1,337 @@
+use super::*;
+use agileplus_domain::domain::cycle::{Cycle, CycleFeature, CycleState};
+use agileplus_domain::domain::module::{Module, ModuleFeatureTag};
+
+#[tokio::test]
+async fn module_create_and_get() {
+    let db = make_adapter();
+    let m = Module::new("Auth Module", None);
+    let id = StoragePort::create_module(&db, &m).await.unwrap();
+    assert!(id > 0);
+ 
+    let got = StoragePort::get_module(&db, id).await.unwrap().unwrap();
+    assert_eq!(got.id, id);
+    assert_eq!(got.slug, "auth-module");
+    assert_eq!(got.friendly_name, "Auth Module");
+    assert!(got.parent_module_id.is_none());
+}
+ 
+#[tokio::test]
+async fn module_get_by_slug() {
+    let db = make_adapter();
+    let m = Module::new("Billing", None);
+    let id = StoragePort::create_module(&db, &m).await.unwrap();
+    let got = StoragePort::get_module_by_slug(&db, "billing").await.unwrap().unwrap();
+    assert_eq!(got.id, id);
+}
+ 
+#[tokio::test]
+async fn module_not_found_returns_none() {
+    let db = make_adapter();
+    assert!(StoragePort::get_module(&db, 9999).await.unwrap().is_none());
+    assert!(StoragePort::get_module_by_slug(&db, "no-such").await.unwrap().is_none());
+}
+ 
+#[tokio::test]
+async fn module_update() {
+    let db = make_adapter();
+    let m = Module::new("Old Name", None);
+    let id = StoragePort::create_module(&db, &m).await.unwrap();
+    StoragePort::update_module(&db, id, "New Name", Some("a description"))
+        .await
+        .unwrap();
+    let got = StoragePort::get_module(&db, id).await.unwrap().unwrap();
+    assert_eq!(got.friendly_name, "New Name");
+    assert_eq!(got.slug, "new-name");
+    assert_eq!(got.description.as_deref(), Some("a description"));
+}
+ 
+#[tokio::test]
+async fn module_delete_simple() {
+    let db = make_adapter();
+    let m = Module::new("Temp", None);
+    let id = StoragePort::create_module(&db, &m).await.unwrap();
+    StoragePort::delete_module(&db, id).await.unwrap();
+    assert!(StoragePort::get_module(&db, id).await.unwrap().is_none());
+}
+ 
+#[tokio::test]
+async fn module_delete_with_children_fails() {
+    let db = make_adapter();
+    let parent = Module::new("Parent", None);
+    let pid = StoragePort::create_module(&db, &parent).await.unwrap();
+    let child = Module::new("Child", Some(pid));
+    StoragePort::create_module(&db, &child).await.unwrap();
+ 
+    let result = StoragePort::delete_module(&db, pid).await;
+    assert!(result.is_err());
+    assert!(matches!(
+        result.unwrap_err(),
+        agileplus_domain::error::DomainError::ModuleHasDependents(_)
+    ));
+}
+ 
+#[tokio::test]
+async fn module_delete_with_owned_features_fails() {
+    let db = make_adapter();
+    let m = Module::new("Owner", None);
+    let mid = StoragePort::create_module(&db, &m).await.unwrap();
+    let f = Feature::new("feat", "Feat", [0u8; 32], None);
+    let fid = StoragePort::create_feature(&db, &f).await.unwrap();
+    let conn = db.conn_for_bench().unwrap();
+    conn.execute(
+        "UPDATE features SET module_id = ?1 WHERE id = ?2",
+        rusqlite::params![mid, fid],
+    )
+    .unwrap();
+    drop(conn);
+ 
+    let result = StoragePort::delete_module(&db, mid).await;
+    assert!(result.is_err());
+    assert!(matches!(
+        result.unwrap_err(),
+        agileplus_domain::error::DomainError::ModuleHasDependents(_)
+    ));
+}
+ 
+#[tokio::test]
+async fn module_list_root_and_children() {
+    let db = make_adapter();
+    let r1 = StoragePort::create_module(&db, &Module::new("Root1", None)).await.unwrap();
+    let r2 = StoragePort::create_module(&db, &Module::new("Root2", None)).await.unwrap();
+    let _ = StoragePort::create_module(&db, &Module::new("Child1", Some(r1)))
+        .await
+        .unwrap();
+ 
+    let roots = StoragePort::list_root_modules(&db).await.unwrap();
+    assert_eq!(roots.len(), 2);
+ 
+    let children = StoragePort::list_child_modules(&db, r1).await.unwrap();
+    assert_eq!(children.len(), 1);
+ 
+    let r2_children = StoragePort::list_child_modules(&db, r2).await.unwrap();
+    assert!(r2_children.is_empty());
+}
+ 
+#[tokio::test]
+async fn module_tag_and_untag_feature() {
+    let db = make_adapter();
+    let mid = StoragePort::create_module(&db, &Module::new("M", None)).await.unwrap();
+    let fid = StoragePort::create_feature(&db, &Feature::new("f-tag", "FTag", [0u8; 32], None))
+        .await
+        .unwrap();
+ 
+    let tag = ModuleFeatureTag::new(mid, fid);
+    StoragePort::tag_feature_to_module(&db, &tag).await.unwrap();
+    StoragePort::tag_feature_to_module(&db, &tag).await.unwrap();
+ 
+    let mwf = StoragePort::get_module_with_features(&db, mid).await.unwrap().unwrap();
+    assert_eq!(mwf.tagged_features.len(), 1);
+    assert_eq!(mwf.tagged_features[0].id, fid);
+ 
+    StoragePort::untag_feature_from_module(&db, mid, fid).await.unwrap();
+    let mwf2 = StoragePort::get_module_with_features(&db, mid).await.unwrap().unwrap();
+    assert!(mwf2.tagged_features.is_empty());
+}
+ 
+#[tokio::test]
+async fn module_get_with_features_none_for_missing() {
+    let db = make_adapter();
+    assert!(StoragePort::get_module_with_features(&db, 9999).await.unwrap().is_none());
+}
+ 
+#[tokio::test]
+async fn cycle_create_and_get() {
+    let db = make_adapter();
+    let c = Cycle::new(
+        "Q1-2026",
+        make_date(2026, 1, 1),
+        make_date(2026, 3, 31),
+        None,
+    )
+    .unwrap();
+    let id = StoragePort::create_cycle(&db, &c).await.unwrap();
+    assert!(id > 0);
+ 
+    let got = StoragePort::get_cycle(&db, id).await.unwrap().unwrap();
+    assert_eq!(got.id, id);
+    assert_eq!(got.name, "Q1-2026");
+    assert_eq!(got.state, CycleState::Draft);
+    assert!(got.module_scope_id.is_none());
+}
+ 
+#[tokio::test]
+async fn cycle_not_found_returns_none() {
+    let db = make_adapter();
+    assert!(StoragePort::get_cycle(&db, 9999).await.unwrap().is_none());
+}
+ 
+#[tokio::test]
+async fn cycle_update_state() {
+    let db = make_adapter();
+    let c = Cycle::new(
+        "Cycle-A",
+        make_date(2026, 1, 1),
+        make_date(2026, 2, 1),
+        None,
+    )
+    .unwrap();
+    let id = StoragePort::create_cycle(&db, &c).await.unwrap();
+    StoragePort::update_cycle_state(&db, id, CycleState::Active).await.unwrap();
+    let got = StoragePort::get_cycle(&db, id).await.unwrap().unwrap();
+    assert_eq!(got.state, CycleState::Active);
+}
+ 
+#[tokio::test]
+async fn cycle_list_by_state() {
+    let db = make_adapter();
+    let c1 = Cycle::new(
+        "Draft-1",
+        make_date(2026, 1, 1),
+        make_date(2026, 2, 1),
+        None,
+    )
+    .unwrap();
+    let c2 = Cycle::new(
+        "Draft-2",
+        make_date(2026, 3, 1),
+        make_date(2026, 4, 1),
+        None,
+    )
+    .unwrap();
+    let id1 = StoragePort::create_cycle(&db, &c1).await.unwrap();
+    let id2 = StoragePort::create_cycle(&db, &c2).await.unwrap();
+    StoragePort::update_cycle_state(&db, id1, CycleState::Active)
+        .await
+        .unwrap();
+ 
+    let drafts = StoragePort::list_cycles_by_state(&db, CycleState::Draft).await.unwrap();
+    assert_eq!(drafts.len(), 1);
+    assert_eq!(drafts[0].id, id2);
+ 
+    let actives = StoragePort::list_cycles_by_state(&db, CycleState::Active).await.unwrap();
+    assert_eq!(actives.len(), 1);
+    assert_eq!(actives[0].id, id1);
+}
+ 
+#[tokio::test]
+async fn cycle_list_by_module() {
+    let db = make_adapter();
+    let mid = StoragePort::create_module(&db, &Module::new("ScopeModule", None))
+        .await
+        .unwrap();
+    let c1 = Cycle::new(
+        "Scoped",
+        make_date(2026, 1, 1),
+        make_date(2026, 2, 1),
+        Some(mid),
+    )
+    .unwrap();
+    let c2 = Cycle::new(
+        "Unscoped",
+        make_date(2026, 3, 1),
+        make_date(2026, 4, 1),
+        None,
+    )
+    .unwrap();
+    let id1 = StoragePort::create_cycle(&db, &c1).await.unwrap();
+    StoragePort::create_cycle(&db, &c2).await.unwrap();
+ 
+    let scoped = StoragePort::list_cycles_by_module(&db, mid).await.unwrap();
+    assert_eq!(scoped.len(), 1);
+    assert_eq!(scoped[0].id, id1);
+}
+ 
+#[tokio::test]
+async fn cycle_add_and_remove_feature() {
+    let db = make_adapter();
+    let c = Cycle::new("C1", make_date(2026, 1, 1), make_date(2026, 2, 1), None).unwrap();
+    let cid = StoragePort::create_cycle(&db, &c).await.unwrap();
+    let fid = StoragePort::create_feature(&db, &Feature::new("cyc-feat", "CycFeat", [0u8; 32], None))
+        .await
+        .unwrap();
+ 
+    let entry = CycleFeature::new(cid, fid);
+    StoragePort::add_feature_to_cycle(&db, &entry).await.unwrap();
+    StoragePort::add_feature_to_cycle(&db, &entry).await.unwrap();
+ 
+    let cwf = StoragePort::get_cycle_with_features(&db, cid).await.unwrap().unwrap();
+    assert_eq!(cwf.features.len(), 1);
+    assert_eq!(cwf.features[0].id, fid);
+ 
+    StoragePort::remove_feature_from_cycle(&db, cid, fid).await.unwrap();
+    let cwf2 = StoragePort::get_cycle_with_features(&db, cid).await.unwrap().unwrap();
+    assert!(cwf2.features.is_empty());
+}
+ 
+#[tokio::test]
+async fn cycle_with_features_none_for_missing() {
+    let db = make_adapter();
+    assert!(StoragePort::get_cycle_with_features(&db, 9999).await.unwrap().is_none());
+}
+ 
+#[tokio::test]
+async fn cycle_module_scope_enforcement() {
+    let db = make_adapter();
+    let mid = StoragePort::create_module(&db, &Module::new("Scope", None)).await.unwrap();
+    let c = Cycle::new(
+        "Scoped-Cycle",
+        make_date(2026, 1, 1),
+        make_date(2026, 2, 1),
+        Some(mid),
+    )
+    .unwrap();
+    let cid = StoragePort::create_cycle(&db, &c).await.unwrap();
+ 
+    let fid = StoragePort::create_feature(&db, &Feature::new("out-of-scope", "OOS", [0u8; 32], None))
+        .await
+        .unwrap();
+    let entry = CycleFeature::new(cid, fid);
+    let result = StoragePort::add_feature_to_cycle(&db, &entry).await;
+    assert!(result.is_err());
+    assert!(matches!(
+        result.unwrap_err(),
+        agileplus_domain::error::DomainError::FeatureNotInModuleScope { .. }
+    ));
+ 
+    StoragePort::tag_feature_to_module(&db, &ModuleFeatureTag::new(mid, fid))
+        .await
+        .unwrap();
+    StoragePort::add_feature_to_cycle(&db, &CycleFeature::new(cid, fid))
+        .await
+        .unwrap();
+    let cwf = StoragePort::get_cycle_with_features(&db, cid).await.unwrap().unwrap();
+    assert_eq!(cwf.features.len(), 1);
+}
+ 
+#[tokio::test]
+async fn cycle_wp_progress_summary() {
+    let db = make_adapter();
+    let c = Cycle::new(
+        "WP-Prog",
+        make_date(2026, 1, 1),
+        make_date(2026, 2, 1),
+        None,
+    )
+    .unwrap();
+    let cid = StoragePort::create_cycle(&db, &c).await.unwrap();
+    let fid = StoragePort::create_feature(&db, &Feature::new("prog-feat", "Prog", [0u8; 32], None))
+        .await
+        .unwrap();
+    StoragePort::add_feature_to_cycle(&db, &CycleFeature::new(cid, fid))
+        .await
+        .unwrap();
+ 
+    let _wp1 = StoragePort::create_work_package(&db, &WorkPackage::new(fid, "WP1", 1, "c"))
+        .await
+        .unwrap();
+    let wp2 = StoragePort::create_work_package(&db, &WorkPackage::new(fid, "WP2", 2, "c"))
+        .await
+        .unwrap();
+    StoragePort::update_wp_state(&db, wp2, WpState::Done).await.unwrap();
+ 
+    let cwf = StoragePort::get_cycle_with_features(&db, cid).await.unwrap().unwrap();
+    assert_eq!(cwf.wp_progress.total, 2);
+    assert_eq!(cwf.wp_progress.planned, 1);
+    assert_eq!(cwf.wp_progress.done, 1);
+}

--- a/crates/agileplus-sqlite/src/migrations/001_create_features.sql
+++ b/crates/agileplus-sqlite/src/migrations/001_create_features.sql
@@ -1,0 +1,16 @@
+-- UP
+CREATE TABLE IF NOT EXISTS features (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    slug         TEXT    UNIQUE NOT NULL,
+    friendly_name TEXT   NOT NULL,
+    state        TEXT    NOT NULL CHECK(state IN (
+                     'created','specified','researched','planned',
+                     'implementing','validated','shipped','retrospected')),
+    spec_hash    BLOB    NOT NULL,
+    target_branch TEXT   NOT NULL DEFAULT 'main',
+    created_at   TEXT    NOT NULL,
+    updated_at   TEXT    NOT NULL
+);
+
+-- DOWN
+DROP TABLE IF EXISTS features;

--- a/crates/agileplus-sqlite/src/migrations/002_create_work_packages.sql
+++ b/crates/agileplus-sqlite/src/migrations/002_create_work_packages.sql
@@ -1,0 +1,21 @@
+-- UP
+CREATE TABLE IF NOT EXISTS work_packages (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    feature_id          INTEGER NOT NULL REFERENCES features(id) ON DELETE CASCADE,
+    title               TEXT    NOT NULL,
+    state               TEXT    NOT NULL CHECK(state IN (
+                            'planned','doing','review','done','blocked')),
+    sequence            INTEGER NOT NULL DEFAULT 0,
+    file_scope          TEXT    NOT NULL DEFAULT '[]',
+    acceptance_criteria TEXT    NOT NULL DEFAULT '',
+    agent_id            TEXT,
+    pr_url              TEXT,
+    pr_state            TEXT    CHECK(pr_state IN (
+                            'open','review','changes_requested','approved','merged') OR pr_state IS NULL),
+    worktree_path       TEXT,
+    created_at          TEXT    NOT NULL,
+    updated_at          TEXT    NOT NULL
+);
+
+-- DOWN
+DROP TABLE IF EXISTS work_packages;

--- a/crates/agileplus-sqlite/src/migrations/003_create_governance_contracts.sql
+++ b/crates/agileplus-sqlite/src/migrations/003_create_governance_contracts.sql
@@ -1,0 +1,12 @@
+-- UP
+CREATE TABLE IF NOT EXISTS governance_contracts (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    feature_id INTEGER NOT NULL REFERENCES features(id) ON DELETE CASCADE,
+    version    INTEGER NOT NULL DEFAULT 1,
+    rules      TEXT    NOT NULL DEFAULT '[]',
+    bound_at   TEXT    NOT NULL,
+    UNIQUE(feature_id, version)
+);
+
+-- DOWN
+DROP TABLE IF EXISTS governance_contracts;

--- a/crates/agileplus-sqlite/src/migrations/004_create_audit_log.sql
+++ b/crates/agileplus-sqlite/src/migrations/004_create_audit_log.sql
@@ -1,0 +1,15 @@
+-- UP
+CREATE TABLE IF NOT EXISTS audit_log (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    feature_id    INTEGER NOT NULL REFERENCES features(id) ON DELETE CASCADE,
+    wp_id         INTEGER REFERENCES work_packages(id) ON DELETE SET NULL,
+    timestamp     TEXT    NOT NULL,
+    actor         TEXT    NOT NULL,
+    transition    TEXT    NOT NULL,
+    evidence_refs TEXT    NOT NULL DEFAULT '[]',
+    prev_hash     BLOB    NOT NULL,
+    hash          BLOB    NOT NULL
+);
+
+-- DOWN
+DROP TABLE IF EXISTS audit_log;

--- a/crates/agileplus-sqlite/src/migrations/005_create_evidence.sql
+++ b/crates/agileplus-sqlite/src/migrations/005_create_evidence.sql
@@ -1,0 +1,15 @@
+-- UP
+CREATE TABLE IF NOT EXISTS evidence (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    wp_id         INTEGER NOT NULL REFERENCES work_packages(id) ON DELETE CASCADE,
+    fr_id         TEXT    NOT NULL,
+    evidence_type TEXT    NOT NULL CHECK(evidence_type IN (
+                      'test_result','ci_output','review_approval',
+                      'security_scan','lint_result','manual_attestation')),
+    artifact_path TEXT    NOT NULL,
+    metadata      TEXT,
+    created_at    TEXT    NOT NULL
+);
+
+-- DOWN
+DROP TABLE IF EXISTS evidence;

--- a/crates/agileplus-sqlite/src/migrations/006_create_policy_rules.sql
+++ b/crates/agileplus-sqlite/src/migrations/006_create_policy_rules.sql
@@ -1,0 +1,13 @@
+-- UP
+CREATE TABLE IF NOT EXISTS policy_rules (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    domain     TEXT    NOT NULL CHECK(domain IN (
+                   'security','quality','compliance','performance','custom')),
+    rule       TEXT    NOT NULL,
+    active     INTEGER NOT NULL DEFAULT 1 CHECK(active IN (0, 1)),
+    created_at TEXT    NOT NULL,
+    updated_at TEXT    NOT NULL
+);
+
+-- DOWN
+DROP TABLE IF EXISTS policy_rules;

--- a/crates/agileplus-sqlite/src/migrations/007_create_metrics.sql
+++ b/crates/agileplus-sqlite/src/migrations/007_create_metrics.sql
@@ -1,0 +1,14 @@
+-- UP
+CREATE TABLE IF NOT EXISTS metrics (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    feature_id     INTEGER REFERENCES features(id) ON DELETE SET NULL,
+    command        TEXT    NOT NULL,
+    duration_ms    INTEGER NOT NULL DEFAULT 0,
+    agent_runs     INTEGER NOT NULL DEFAULT 0,
+    review_cycles  INTEGER NOT NULL DEFAULT 0,
+    metadata       TEXT,
+    timestamp      TEXT    NOT NULL
+);
+
+-- DOWN
+DROP TABLE IF EXISTS metrics;

--- a/crates/agileplus-sqlite/src/migrations/008_create_wp_dependencies.sql
+++ b/crates/agileplus-sqlite/src/migrations/008_create_wp_dependencies.sql
@@ -1,0 +1,10 @@
+-- UP
+CREATE TABLE IF NOT EXISTS wp_dependencies (
+    wp_id      INTEGER NOT NULL REFERENCES work_packages(id) ON DELETE CASCADE,
+    depends_on INTEGER NOT NULL REFERENCES work_packages(id) ON DELETE CASCADE,
+    dep_type   TEXT    NOT NULL CHECK(dep_type IN ('explicit','file_overlap','data')),
+    PRIMARY KEY (wp_id, depends_on)
+);
+
+-- DOWN
+DROP TABLE IF EXISTS wp_dependencies;

--- a/crates/agileplus-sqlite/src/migrations/009_create_indexes.sql
+++ b/crates/agileplus-sqlite/src/migrations/009_create_indexes.sql
@@ -1,0 +1,29 @@
+-- UP
+CREATE INDEX IF NOT EXISTS idx_features_state      ON features(state);
+CREATE INDEX IF NOT EXISTS idx_features_slug       ON features(slug);
+CREATE INDEX IF NOT EXISTS idx_wp_feature_id       ON work_packages(feature_id);
+CREATE INDEX IF NOT EXISTS idx_wp_state            ON work_packages(state);
+CREATE INDEX IF NOT EXISTS idx_audit_feature_id    ON audit_log(feature_id);
+CREATE INDEX IF NOT EXISTS idx_audit_timestamp     ON audit_log(timestamp);
+CREATE INDEX IF NOT EXISTS idx_evidence_wp_id      ON evidence(wp_id);
+CREATE INDEX IF NOT EXISTS idx_evidence_fr_id      ON evidence(fr_id);
+CREATE INDEX IF NOT EXISTS idx_policy_domain       ON policy_rules(domain);
+CREATE INDEX IF NOT EXISTS idx_policy_active       ON policy_rules(active);
+CREATE INDEX IF NOT EXISTS idx_metrics_feature_id  ON metrics(feature_id);
+CREATE INDEX IF NOT EXISTS idx_metrics_timestamp   ON metrics(timestamp);
+CREATE INDEX IF NOT EXISTS idx_governance_feature  ON governance_contracts(feature_id);
+
+-- DOWN
+DROP INDEX IF EXISTS idx_features_state;
+DROP INDEX IF EXISTS idx_features_slug;
+DROP INDEX IF EXISTS idx_wp_feature_id;
+DROP INDEX IF EXISTS idx_wp_state;
+DROP INDEX IF EXISTS idx_audit_feature_id;
+DROP INDEX IF EXISTS idx_audit_timestamp;
+DROP INDEX IF EXISTS idx_evidence_wp_id;
+DROP INDEX IF EXISTS idx_evidence_fr_id;
+DROP INDEX IF EXISTS idx_policy_domain;
+DROP INDEX IF EXISTS idx_policy_active;
+DROP INDEX IF EXISTS idx_metrics_feature_id;
+DROP INDEX IF EXISTS idx_metrics_timestamp;
+DROP INDEX IF EXISTS idx_governance_feature;

--- a/crates/agileplus-sqlite/src/migrations/010_create_events.sql
+++ b/crates/agileplus-sqlite/src/migrations/010_create_events.sql
@@ -1,0 +1,22 @@
+-- UP
+CREATE TABLE IF NOT EXISTS events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    entity_type TEXT NOT NULL,
+    entity_id INTEGER NOT NULL,
+    event_type TEXT NOT NULL,
+    payload TEXT NOT NULL,
+    actor TEXT NOT NULL,
+    timestamp TEXT NOT NULL,
+    prev_hash BLOB NOT NULL,
+    hash BLOB NOT NULL,
+    sequence INTEGER NOT NULL,
+    UNIQUE(entity_type, entity_id, sequence)
+);
+
+CREATE INDEX IF NOT EXISTS idx_events_entity ON events(entity_type, entity_id, sequence);
+CREATE INDEX IF NOT EXISTS idx_events_timestamp ON events(timestamp);
+CREATE INDEX IF NOT EXISTS idx_events_type ON events(event_type);
+CREATE INDEX IF NOT EXISTS idx_events_actor ON events(actor);
+
+-- DOWN
+DROP TABLE IF EXISTS events;

--- a/crates/agileplus-sqlite/src/migrations/011_create_snapshots.sql
+++ b/crates/agileplus-sqlite/src/migrations/011_create_snapshots.sql
@@ -1,0 +1,16 @@
+-- UP
+CREATE TABLE IF NOT EXISTS snapshots (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    entity_type TEXT NOT NULL,
+    entity_id INTEGER NOT NULL,
+    state TEXT NOT NULL,
+    event_sequence INTEGER NOT NULL,
+    created_at TEXT NOT NULL,
+    UNIQUE(entity_type, entity_id, event_sequence)
+);
+
+CREATE INDEX IF NOT EXISTS idx_snapshots_entity ON snapshots(entity_type, entity_id, event_sequence DESC);
+CREATE INDEX IF NOT EXISTS idx_snapshots_time ON snapshots(created_at);
+
+-- DOWN
+DROP TABLE IF EXISTS snapshots;

--- a/crates/agileplus-sqlite/src/migrations/012_create_sync_mappings.sql
+++ b/crates/agileplus-sqlite/src/migrations/012_create_sync_mappings.sql
@@ -1,0 +1,20 @@
+-- UP
+CREATE TABLE IF NOT EXISTS sync_mappings (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    entity_type TEXT NOT NULL,
+    entity_id INTEGER NOT NULL,
+    plane_issue_id TEXT NOT NULL,
+    content_hash TEXT NOT NULL,
+    last_synced_at TEXT NOT NULL,
+    sync_direction TEXT NOT NULL,
+    conflict_count INTEGER NOT NULL DEFAULT 0,
+    UNIQUE(entity_type, entity_id),
+    UNIQUE(plane_issue_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_sync_entity ON sync_mappings(entity_type, entity_id);
+CREATE INDEX IF NOT EXISTS idx_sync_plane_id ON sync_mappings(plane_issue_id);
+CREATE INDEX IF NOT EXISTS idx_sync_time ON sync_mappings(last_synced_at);
+
+-- DOWN
+DROP TABLE IF EXISTS sync_mappings;

--- a/crates/agileplus-sqlite/src/migrations/013_create_api_keys.sql
+++ b/crates/agileplus-sqlite/src/migrations/013_create_api_keys.sql
@@ -1,0 +1,16 @@
+-- UP
+CREATE TABLE IF NOT EXISTS api_keys (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    key_hash BLOB NOT NULL UNIQUE,
+    name TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    last_used_at TEXT,
+    revoked INTEGER NOT NULL DEFAULT 0,
+    metadata TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_api_keys_hash ON api_keys(key_hash);
+CREATE INDEX IF NOT EXISTS idx_api_keys_active ON api_keys(revoked, created_at);
+
+-- DOWN
+DROP TABLE IF EXISTS api_keys;

--- a/crates/agileplus-sqlite/src/migrations/014_create_device_nodes.sql
+++ b/crates/agileplus-sqlite/src/migrations/014_create_device_nodes.sql
@@ -1,0 +1,18 @@
+-- UP
+CREATE TABLE IF NOT EXISTS device_nodes (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    device_id TEXT NOT NULL UNIQUE,
+    tailscale_ip TEXT,
+    hostname TEXT NOT NULL,
+    last_seen TEXT NOT NULL,
+    sync_vector TEXT NOT NULL,
+    platform_version TEXT NOT NULL,
+    metadata TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_devices_id ON device_nodes(device_id);
+CREATE INDEX IF NOT EXISTS idx_devices_hostname ON device_nodes(hostname);
+CREATE INDEX IF NOT EXISTS idx_devices_lastseen ON device_nodes(last_seen);
+
+-- DOWN
+DROP TABLE IF EXISTS device_nodes;

--- a/crates/agileplus-sqlite/src/migrations/015_modules_cycles.sql
+++ b/crates/agileplus-sqlite/src/migrations/015_modules_cycles.sql
@@ -1,0 +1,65 @@
+-- UP
+
+CREATE TABLE modules (
+    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    slug             TEXT    NOT NULL,
+    friendly_name    TEXT    NOT NULL,
+    description      TEXT,
+    parent_module_id INTEGER REFERENCES modules(id) ON DELETE RESTRICT,
+    created_at       TEXT    NOT NULL,
+    updated_at       TEXT    NOT NULL,
+    UNIQUE (parent_module_id, slug)
+);
+
+CREATE INDEX idx_modules_parent ON modules(parent_module_id);
+
+CREATE TABLE module_feature_tags (
+    module_id   INTEGER NOT NULL REFERENCES modules(id)  ON DELETE CASCADE,
+    feature_id  INTEGER NOT NULL REFERENCES features(id) ON DELETE CASCADE,
+    created_at  TEXT    NOT NULL,
+    PRIMARY KEY (module_id, feature_id)
+);
+
+CREATE INDEX idx_module_feature_tags_feature ON module_feature_tags(feature_id);
+
+ALTER TABLE features ADD COLUMN module_id INTEGER REFERENCES modules(id) ON DELETE SET NULL;
+
+CREATE INDEX idx_features_module ON features(module_id);
+
+CREATE TABLE cycles (
+    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    name             TEXT    NOT NULL UNIQUE,
+    description      TEXT,
+    state            TEXT    NOT NULL DEFAULT 'Draft',
+    start_date       TEXT    NOT NULL,
+    end_date         TEXT    NOT NULL,
+    module_scope_id  INTEGER REFERENCES modules(id) ON DELETE SET NULL,
+    created_at       TEXT    NOT NULL,
+    updated_at       TEXT    NOT NULL,
+    CHECK (end_date > start_date)
+);
+
+CREATE INDEX idx_cycles_state        ON cycles(state);
+CREATE INDEX idx_cycles_module_scope ON cycles(module_scope_id);
+
+CREATE TABLE cycle_features (
+    cycle_id    INTEGER NOT NULL REFERENCES cycles(id)   ON DELETE CASCADE,
+    feature_id  INTEGER NOT NULL REFERENCES features(id) ON DELETE CASCADE,
+    added_at    TEXT    NOT NULL,
+    PRIMARY KEY (cycle_id, feature_id)
+);
+
+CREATE INDEX idx_cycle_features_feature ON cycle_features(feature_id);
+
+-- DOWN
+
+DROP INDEX IF EXISTS idx_cycle_features_feature;
+DROP TABLE IF EXISTS cycle_features;
+DROP INDEX IF EXISTS idx_cycles_module_scope;
+DROP INDEX IF EXISTS idx_cycles_state;
+DROP TABLE IF EXISTS cycles;
+DROP INDEX IF EXISTS idx_features_module;
+DROP INDEX IF EXISTS idx_module_feature_tags_feature;
+DROP TABLE IF EXISTS module_feature_tags;
+DROP INDEX IF EXISTS idx_modules_parent;
+DROP TABLE IF EXISTS modules;

--- a/crates/agileplus-sqlite/src/migrations/016_create_backlog_items.sql
+++ b/crates/agileplus-sqlite/src/migrations/016_create_backlog_items.sql
@@ -1,0 +1,24 @@
+-- UP
+CREATE TABLE IF NOT EXISTS backlog_items (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    title TEXT NOT NULL,
+    description TEXT NOT NULL DEFAULT '',
+    intent TEXT NOT NULL,
+    priority TEXT NOT NULL,
+    status TEXT NOT NULL,
+    source TEXT NOT NULL,
+    feature_slug TEXT,
+    tags_json TEXT NOT NULL DEFAULT '[]',
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_backlog_items_status_priority_created
+    ON backlog_items(status, priority, created_at);
+CREATE INDEX IF NOT EXISTS idx_backlog_items_intent
+    ON backlog_items(intent);
+CREATE INDEX IF NOT EXISTS idx_backlog_items_feature_slug
+    ON backlog_items(feature_slug);
+
+-- DOWN
+DROP TABLE IF EXISTS backlog_items;

--- a/crates/agileplus-sqlite/src/migrations/016_git_bindings.sql
+++ b/crates/agileplus-sqlite/src/migrations/016_git_bindings.sql
@@ -1,0 +1,39 @@
+-- Git provenance bindings for entities
+CREATE TABLE IF NOT EXISTS git_bindings (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    entity_type TEXT NOT NULL,
+    entity_id TEXT NOT NULL,
+    commit_sha TEXT NOT NULL,
+    branch TEXT,
+    event_type TEXT NOT NULL,
+    timestamp TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(entity_type, entity_id, commit_sha, event_type)
+);
+
+CREATE INDEX IF NOT EXISTS idx_git_bindings_entity ON git_bindings(entity_type, entity_id);
+CREATE INDEX IF NOT EXISTS idx_git_bindings_commit ON git_bindings(commit_sha);
+
+-- Worktree claims for multi-agent coordination
+CREATE TABLE IF NOT EXISTS worktree_claims (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    path TEXT NOT NULL,
+    agent_id TEXT NOT NULL,
+    session_id TEXT NOT NULL,
+    wp_id TEXT NOT NULL,
+    branch TEXT NOT NULL,
+    heartbeat TEXT NOT NULL DEFAULT (datetime('now')),
+    status TEXT NOT NULL DEFAULT 'active' CHECK(status IN ('active', 'stale', 'released')),
+    file_scope TEXT, -- JSON array of file paths
+    UNIQUE(path, status) -- Only one active claim per path
+);
+
+CREATE INDEX IF NOT EXISTS idx_worktree_claims_agent ON worktree_claims(agent_id);
+CREATE INDEX IF NOT EXISTS idx_worktree_claims_status ON worktree_claims(status);
+
+-- Add git provenance columns to features
+ALTER TABLE features ADD COLUMN created_at_commit TEXT;
+ALTER TABLE features ADD COLUMN last_modified_commit TEXT;
+
+-- Add git provenance columns to work_packages
+ALTER TABLE work_packages ADD COLUMN base_commit TEXT;
+ALTER TABLE work_packages ADD COLUMN head_commit TEXT;

--- a/crates/agileplus-sqlite/src/migrations/017_create_projects.sql
+++ b/crates/agileplus-sqlite/src/migrations/017_create_projects.sql
@@ -1,0 +1,15 @@
+-- UP
+CREATE TABLE IF NOT EXISTS projects (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    slug        TEXT    NOT NULL UNIQUE,
+    name        TEXT    NOT NULL,
+    description TEXT    NOT NULL DEFAULT '',
+    created_at  TEXT    NOT NULL,
+    updated_at  TEXT    NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_projects_slug ON projects (slug);
+
+-- DOWN
+DROP INDEX IF EXISTS idx_projects_slug;
+DROP TABLE IF EXISTS projects;

--- a/crates/agileplus-sqlite/src/migrations/mod.rs
+++ b/crates/agileplus-sqlite/src/migrations/mod.rs
@@ -1,0 +1,189 @@
+//! Migration system for agileplus-sqlite.
+//!
+//! Migrations are embedded as SQL files and applied in order on startup.
+//! Applied migrations are tracked in the `_migrations` meta table.
+
+use rusqlite::{Connection, Result as SqlResult};
+
+use agileplus_domain::error::DomainError;
+
+// Embedded SQL migrations
+const MIGRATION_001: &str = include_str!("001_create_features.sql");
+const MIGRATION_002: &str = include_str!("002_create_work_packages.sql");
+const MIGRATION_003: &str = include_str!("003_create_governance_contracts.sql");
+const MIGRATION_004: &str = include_str!("004_create_audit_log.sql");
+const MIGRATION_005: &str = include_str!("005_create_evidence.sql");
+const MIGRATION_006: &str = include_str!("006_create_policy_rules.sql");
+const MIGRATION_007: &str = include_str!("007_create_metrics.sql");
+const MIGRATION_008: &str = include_str!("008_create_wp_dependencies.sql");
+const MIGRATION_009: &str = include_str!("009_create_indexes.sql");
+const MIGRATION_010: &str = include_str!("010_create_events.sql");
+const MIGRATION_011: &str = include_str!("011_create_snapshots.sql");
+const MIGRATION_012: &str = include_str!("012_create_sync_mappings.sql");
+const MIGRATION_013: &str = include_str!("013_create_api_keys.sql");
+const MIGRATION_014: &str = include_str!("014_create_device_nodes.sql");
+const MIGRATION_015: &str = include_str!("015_modules_cycles.sql");
+const MIGRATION_017: &str = include_str!("017_create_projects.sql");
+
+/// All migrations in order: (name, up_sql, down_sql)
+const MIGRATIONS: &[(&str, &str)] = &[
+    ("001_create_features", MIGRATION_001),
+    ("002_create_work_packages", MIGRATION_002),
+    ("003_create_governance_contracts", MIGRATION_003),
+    ("004_create_audit_log", MIGRATION_004),
+    ("005_create_evidence", MIGRATION_005),
+    ("006_create_policy_rules", MIGRATION_006),
+    ("007_create_metrics", MIGRATION_007),
+    ("008_create_wp_dependencies", MIGRATION_008),
+    ("009_create_indexes", MIGRATION_009),
+    ("010_create_events", MIGRATION_010),
+    ("011_create_snapshots", MIGRATION_011),
+    ("012_create_sync_mappings", MIGRATION_012),
+    ("013_create_api_keys", MIGRATION_013),
+    ("014_create_device_nodes", MIGRATION_014),
+    ("015_modules_cycles", MIGRATION_015),
+    ("017_create_projects", MIGRATION_017),
+];
+
+/// Parse the UP section from a migration SQL file.
+fn parse_up(sql: &str) -> &str {
+    // Format is:
+    //   -- UP
+    //   <sql>
+    //   -- DOWN
+    //   <sql>
+    if let Some(up_start) = sql.find("-- UP") {
+        let after_up = &sql[up_start + 5..];
+        if let Some(down_start) = after_up.find("-- DOWN") {
+            return after_up[..down_start].trim();
+        }
+        return after_up.trim();
+    }
+    sql.trim()
+}
+
+/// Parse the DOWN section from a migration SQL file.
+fn parse_down(sql: &str) -> &str {
+    if let Some(down_start) = sql.find("-- DOWN") {
+        return sql[down_start + 7..].trim();
+    }
+    ""
+}
+
+fn map_err(e: rusqlite::Error) -> DomainError {
+    DomainError::Storage(e.to_string())
+}
+
+/// Runs database schema migrations.
+pub struct MigrationRunner<'a> {
+    conn: &'a Connection,
+}
+
+impl<'a> MigrationRunner<'a> {
+    pub fn new(conn: &'a Connection) -> Self {
+        Self { conn }
+    }
+
+    /// Create the migrations tracking table if it doesn't exist.
+    fn ensure_meta_table(&self) -> Result<(), DomainError> {
+        self.conn
+            .execute_batch(
+                "CREATE TABLE IF NOT EXISTS _migrations (
+                    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                    name       TEXT    UNIQUE NOT NULL,
+                    applied_at TEXT    NOT NULL
+                );",
+            )
+            .map_err(map_err)
+    }
+
+    /// Check whether a migration has already been applied.
+    fn is_applied(&self, name: &str) -> SqlResult<bool> {
+        let count: i64 = self.conn.query_row(
+            "SELECT COUNT(*) FROM _migrations WHERE name = ?1",
+            rusqlite::params![name],
+            |row| row.get(0),
+        )?;
+        Ok(count > 0)
+    }
+
+    /// Apply all pending migrations in order.
+    pub fn run_all(&self) -> Result<(), DomainError> {
+        self.ensure_meta_table()?;
+
+        for (name, sql) in MIGRATIONS {
+            if self.is_applied(name).map_err(map_err)? {
+                continue;
+            }
+
+            let up_sql = parse_up(sql);
+            self.conn
+                .execute_batch(up_sql)
+                .map_err(|e| DomainError::Storage(format!("migration {name} failed: {e}")))?;
+
+            let now = chrono::Utc::now().to_rfc3339();
+            self.conn
+                .execute(
+                    "INSERT INTO _migrations (name, applied_at) VALUES (?1, ?2)",
+                    rusqlite::params![name, now],
+                )
+                .map_err(map_err)?;
+        }
+
+        Ok(())
+    }
+
+    /// Roll back the most recently applied migration.
+    pub fn rollback_last(&self) -> Result<(), DomainError> {
+        self.ensure_meta_table()?;
+
+        let last_name: Option<String> = self
+            .conn
+            .query_row(
+                "SELECT name FROM _migrations ORDER BY id DESC LIMIT 1",
+                [],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(map_err)?;
+
+        let Some(name) = last_name else {
+            return Ok(()); // Nothing to roll back
+        };
+
+        // Find the migration SQL
+        let migration = MIGRATIONS.iter().find(|(n, _)| *n == name.as_str());
+        if let Some((_, sql)) = migration {
+            let down_sql = parse_down(sql);
+            if !down_sql.is_empty() {
+                self.conn
+                    .execute_batch(down_sql)
+                    .map_err(|e| DomainError::Storage(format!("rollback of {name} failed: {e}")))?;
+            }
+        }
+
+        self.conn
+            .execute(
+                "DELETE FROM _migrations WHERE name = ?1",
+                rusqlite::params![name],
+            )
+            .map_err(map_err)?;
+
+        Ok(())
+    }
+}
+
+/// Extension trait to add `.optional()` on rusqlite query results.
+trait OptionalExt<T> {
+    fn optional(self) -> SqlResult<Option<T>>;
+}
+
+impl<T> OptionalExt<T> for SqlResult<T> {
+    fn optional(self) -> SqlResult<Option<T>> {
+        match self {
+            Ok(v) => Ok(Some(v)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+}

--- a/crates/agileplus-sqlite/src/rebuild.rs
+++ b/crates/agileplus-sqlite/src/rebuild.rs
@@ -1,0 +1,501 @@
+//! rebuild_from_git — reconstruct SQLite state from git artifacts (FR-017).
+
+use agileplus_domain::{
+    domain::{
+        audit::{AuditEntry, EvidenceRef, hash_entry},
+        feature::Feature,
+        state_machine::FeatureState,
+    },
+    error::DomainError,
+    ports::VcsPort,
+};
+
+use crate::SqliteStorageAdapter;
+
+/// Summary of what was restored during a rebuild.
+#[derive(Debug, Default)]
+pub struct RebuildReport {
+    pub features_restored: usize,
+    pub wps_restored: usize,
+    pub audit_entries_restored: usize,
+    pub evidence_restored: usize,
+}
+
+/// Git meta.json schema (minimal — matches what spec-kitty would write).
+#[derive(Debug, serde::Deserialize)]
+struct MetaJson {
+    slug: String,
+    friendly_name: String,
+    state: String,
+    spec_hash: String,
+    #[serde(default = "default_branch")]
+    target_branch: String,
+    created_at: String,
+    updated_at: String,
+}
+
+fn default_branch() -> String {
+    "main".into()
+}
+
+/// A line from audit/chain.jsonl.
+#[derive(Debug, serde::Deserialize)]
+struct AuditLine {
+    #[allow(dead_code)]
+    feature_id: i64,
+    wp_id: Option<i64>,
+    timestamp: String,
+    actor: String,
+    transition: String,
+    #[serde(default)]
+    evidence_refs: Vec<EvidenceRef>,
+    prev_hash: String,
+    hash: String,
+}
+
+fn hex_to_32(s: &str) -> Result<[u8; 32], DomainError> {
+    if s.len() != 64 {
+        return Err(DomainError::Storage(format!(
+            "expected 64-char hex, got {}",
+            s.len()
+        )));
+    }
+    let mut out = [0u8; 32];
+    for (i, b) in out.iter_mut().enumerate() {
+        *b = u8::from_str_radix(&s[i * 2..i * 2 + 2], 16)
+            .map_err(|e| DomainError::Storage(format!("hex parse error: {e}")))?;
+    }
+    Ok(out)
+}
+
+impl SqliteStorageAdapter {
+    /// Rebuild SQLite from git artifacts via the VCS port.
+    ///
+    /// This clears all existing data and reconstructs from scratch within a
+    /// single transaction. If any error occurs, the database is left unchanged.
+    #[allow(clippy::await_holding_lock)] // Guard is explicitly dropped before any .await
+    pub async fn rebuild_from_git<V: VcsPort>(
+        &self,
+        vcs: &V,
+        feature_slugs: &[&str],
+    ) -> Result<RebuildReport, DomainError> {
+        let mut report = RebuildReport::default();
+
+        // Lock the connection and do everything in a single transaction.
+        // The guard is explicitly dropped below before any `.await`.
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| DomainError::Storage(e.to_string()))?;
+
+        conn.execute_batch("BEGIN;")
+            .map_err(|e| DomainError::Storage(e.to_string()))?;
+
+        // Clear existing data
+        conn.execute_batch(
+            "DELETE FROM wp_dependencies;
+             DELETE FROM evidence;
+             DELETE FROM audit_log;
+             DELETE FROM governance_contracts;
+             DELETE FROM policy_rules;
+             DELETE FROM metrics;
+             DELETE FROM work_packages;
+             DELETE FROM features;",
+        )
+        .map_err(|e| {
+            let _ = conn.execute_batch("ROLLBACK;");
+            DomainError::Storage(format!("clear failed: {e}"))
+        })?;
+
+        drop(conn); // Release lock before async VCS calls
+
+        // Process each feature
+        for slug in feature_slugs {
+            match self.restore_feature::<V>(vcs, slug, &mut report).await {
+                Ok(()) => {}
+                Err(e) => {
+                    // Rollback the transaction
+                    let conn = self
+                        .conn
+                        .lock()
+                        .map_err(|e| DomainError::Storage(e.to_string()))?;
+                    let _ = conn.execute_batch("ROLLBACK;");
+                    return Err(e);
+                }
+            }
+        }
+
+        // Commit
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| DomainError::Storage(e.to_string()))?;
+        conn.execute_batch("COMMIT;")
+            .map_err(|e| DomainError::Storage(format!("commit failed: {e}")))?;
+
+        Ok(report)
+    }
+
+    async fn restore_feature<V: VcsPort>(
+        &self,
+        vcs: &V,
+        slug: &str,
+        report: &mut RebuildReport,
+    ) -> Result<(), DomainError> {
+        // Read meta.json
+        let meta_content = match vcs.read_artifact(slug, "meta.json").await {
+            Ok(c) => c,
+            Err(_) => return Ok(()), // Feature has no meta.json, skip
+        };
+
+        let meta: MetaJson = serde_json::from_str(&meta_content)
+            .map_err(|e| DomainError::Storage(format!("meta.json parse error for {slug}: {e}")))?;
+
+        let spec_hash = hex_to_32(&meta.spec_hash)?;
+        let created_at = meta
+            .created_at
+            .parse::<chrono::DateTime<chrono::Utc>>()
+            .map_err(|e| DomainError::Storage(e.to_string()))?;
+        let updated_at = meta
+            .updated_at
+            .parse::<chrono::DateTime<chrono::Utc>>()
+            .map_err(|e| DomainError::Storage(e.to_string()))?;
+        let state = meta
+            .state
+            .parse::<FeatureState>()
+            .map_err(|e| DomainError::Storage(format!("invalid state: {e}")))?;
+
+        let feature = Feature {
+            id: 0,
+            slug: meta.slug.clone(),
+            friendly_name: meta.friendly_name,
+            state,
+            spec_hash,
+            target_branch: meta.target_branch,
+            plane_issue_id: None,
+            plane_state_id: None,
+            labels: Vec::new(),
+            module_id: None,
+            project_id: None,
+            created_at,
+            updated_at,
+            created_at_commit: None,
+            last_modified_commit: None,
+        };
+
+        let feature_id = {
+            let conn = self
+                .conn
+                .lock()
+                .map_err(|e| DomainError::Storage(e.to_string()))?;
+            crate::repository::features::create_feature(&conn, &feature)?
+        };
+        report.features_restored += 1;
+
+        // Read audit chain
+        if let Ok(chain_content) = vcs.read_artifact(slug, "audit/chain.jsonl").await {
+            let mut prev_hash = [0u8; 32];
+            for (i, line) in chain_content.lines().enumerate() {
+                let line = line.trim();
+                if line.is_empty() {
+                    continue;
+                }
+                let al: AuditLine = serde_json::from_str(line).map_err(|e| {
+                    DomainError::Storage(format!("chain.jsonl line {i} parse error: {e}"))
+                })?;
+
+                let entry_prev_hash = hex_to_32(&al.prev_hash)?;
+                let entry_hash = hex_to_32(&al.hash)?;
+
+                // Verify chain integrity
+                if i > 0 && entry_prev_hash != prev_hash {
+                    return Err(DomainError::Storage(format!(
+                        "audit chain broken at line {i} for feature {slug}"
+                    )));
+                }
+
+                let timestamp = al
+                    .timestamp
+                    .parse::<chrono::DateTime<chrono::Utc>>()
+                    .map_err(|e| DomainError::Storage(e.to_string()))?;
+
+                let entry = AuditEntry {
+                    id: 0,
+                    feature_id,
+                    wp_id: al.wp_id,
+                    timestamp,
+                    actor: al.actor,
+                    transition: al.transition,
+                    evidence_refs: al.evidence_refs,
+                    prev_hash: entry_prev_hash,
+                    hash: entry_hash,
+                    event_id: None,
+                    archived_to: None,
+                };
+
+                // Verify self-hash
+                let computed = hash_entry(&entry);
+                if computed != entry_hash {
+                    return Err(DomainError::Storage(format!(
+                        "audit entry {i} hash mismatch for feature {slug}"
+                    )));
+                }
+
+                {
+                    let conn = self
+                        .conn
+                        .lock()
+                        .map_err(|e| DomainError::Storage(e.to_string()))?;
+                    // Insert directly (bypass chain check since we already verified above)
+                    let evidence_refs_json = serde_json::to_string(&entry.evidence_refs)
+                        .map_err(|e| DomainError::Storage(e.to_string()))?;
+                    conn.execute(
+                        "INSERT INTO audit_log
+                         (feature_id, wp_id, timestamp, actor, transition, evidence_refs, prev_hash, hash)
+                         VALUES (?1,?2,?3,?4,?5,?6,?7,?8)",
+                        rusqlite::params![
+                            entry.feature_id,
+                            entry.wp_id,
+                            entry.timestamp.to_rfc3339(),
+                            entry.actor,
+                            entry.transition,
+                            evidence_refs_json,
+                            entry.prev_hash.as_slice(),
+                            entry.hash.as_slice(),
+                        ],
+                    )
+                    .map_err(|e| DomainError::Storage(e.to_string()))?;
+                }
+
+                prev_hash = entry_hash;
+                report.audit_entries_restored += 1;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::path::{Path, PathBuf};
+
+    use agileplus_domain::{
+        domain::audit::hash_entry,
+        error::DomainError,
+        ports::{
+            StoragePort, VcsPort,
+            vcs::{ConflictInfo, FeatureArtifacts, MergeResult, WorktreeInfo},
+        },
+    };
+
+    use super::*;
+    use crate::SqliteStorageAdapter;
+
+    /// A simple in-memory VcsPort mock.
+    struct MockVcs {
+        artifacts: HashMap<String, String>,
+    }
+
+    impl MockVcs {
+        fn new() -> Self {
+            Self {
+                artifacts: HashMap::new(),
+            }
+        }
+
+        fn add(&mut self, slug: &str, path: &str, content: &str) {
+            self.artifacts
+                .insert(format!("{slug}/{path}"), content.to_string());
+        }
+    }
+
+    impl VcsPort for MockVcs {
+        async fn create_worktree(
+            &self,
+            _feature_slug: &str,
+            _wp_id: &str,
+        ) -> Result<PathBuf, DomainError> {
+            Err(DomainError::NotImplemented)
+        }
+
+        async fn list_worktrees(&self) -> Result<Vec<WorktreeInfo>, DomainError> {
+            Err(DomainError::NotImplemented)
+        }
+
+        async fn cleanup_worktree(&self, _worktree_path: &Path) -> Result<(), DomainError> {
+            Err(DomainError::NotImplemented)
+        }
+
+        async fn create_branch(&self, _branch_name: &str, _base: &str) -> Result<(), DomainError> {
+            Err(DomainError::NotImplemented)
+        }
+
+        async fn checkout_branch(&self, _branch_name: &str) -> Result<(), DomainError> {
+            Err(DomainError::NotImplemented)
+        }
+
+        async fn merge_to_target(
+            &self,
+            _source: &str,
+            _target: &str,
+        ) -> Result<MergeResult, DomainError> {
+            Err(DomainError::NotImplemented)
+        }
+
+        async fn detect_conflicts(
+            &self,
+            _source: &str,
+            _target: &str,
+        ) -> Result<Vec<ConflictInfo>, DomainError> {
+            Err(DomainError::NotImplemented)
+        }
+
+        async fn read_artifact(
+            &self,
+            feature_slug: &str,
+            relative_path: &str,
+        ) -> Result<String, DomainError> {
+            let key = format!("{feature_slug}/{relative_path}");
+            self.artifacts
+                .get(&key)
+                .cloned()
+                .ok_or(DomainError::NotFound(key))
+        }
+
+        async fn write_artifact(
+            &self,
+            _feature_slug: &str,
+            _relative_path: &str,
+            _content: &str,
+        ) -> Result<(), DomainError> {
+            Err(DomainError::NotImplemented)
+        }
+
+        async fn artifact_exists(
+            &self,
+            _feature_slug: &str,
+            _relative_path: &str,
+        ) -> Result<bool, DomainError> {
+            Err(DomainError::NotImplemented)
+        }
+
+        async fn scan_feature_artifacts(
+            &self,
+            _feature_slug: &str,
+        ) -> Result<FeatureArtifacts, DomainError> {
+            Err(DomainError::NotImplemented)
+        }
+    }
+
+    fn make_chain_jsonl(feature_id: i64) -> String {
+        let now = chrono::Utc::now();
+
+        // Entry 1: genesis
+        let mut e1 = AuditEntry {
+            id: 0,
+            feature_id,
+            wp_id: None,
+            timestamp: now,
+            actor: "system".into(),
+            transition: "created".into(),
+            evidence_refs: vec![],
+            prev_hash: [0u8; 32],
+            hash: [0u8; 32],
+            event_id: None,
+            archived_to: None,
+        };
+        e1.hash = hash_entry(&e1);
+
+        // Entry 2
+        let mut e2 = AuditEntry {
+            id: 0,
+            feature_id,
+            wp_id: None,
+            timestamp: now,
+            actor: "agent".into(),
+            transition: "created->specified".into(),
+            evidence_refs: vec![],
+            prev_hash: e1.hash,
+            hash: [0u8; 32],
+            event_id: None,
+            archived_to: None,
+        };
+        e2.hash = hash_entry(&e2);
+
+        let hex = |b: [u8; 32]| b.iter().map(|x| format!("{x:02x}")).collect::<String>();
+
+        // Note: feature_id in JSON must match the one passed (will be 1 since fresh db)
+        // Use feature_id=1 since rebuild sets it from the db insert
+        let line1 = serde_json::json!({
+            "feature_id": 1i64,
+            "wp_id": null,
+            "timestamp": now.to_rfc3339(),
+            "actor": "system",
+            "transition": "created",
+            "evidence_refs": [],
+            "prev_hash": hex([0u8; 32]),
+            "hash": hex(e1.hash),
+        });
+        let line2 = serde_json::json!({
+            "feature_id": 1i64,
+            "wp_id": null,
+            "timestamp": now.to_rfc3339(),
+            "actor": "agent",
+            "transition": "created->specified",
+            "evidence_refs": [],
+            "prev_hash": hex(e1.hash),
+            "hash": hex(e2.hash),
+        });
+
+        format!("{}\n{}\n", line1, line2)
+    }
+
+    #[tokio::test]
+    async fn rebuild_from_fixtures() {
+        let now = chrono::Utc::now();
+        let slug = "test-feature";
+
+        let meta = serde_json::json!({
+            "slug": slug,
+            "friendly_name": "Test Feature",
+            "state": "specified",
+            "spec_hash": "a".repeat(64),
+            "target_branch": "main",
+            "created_at": now.to_rfc3339(),
+            "updated_at": now.to_rfc3339(),
+        });
+
+        let mut mock = MockVcs::new();
+        mock.add(slug, "meta.json", &meta.to_string());
+        mock.add(slug, "audit/chain.jsonl", &make_chain_jsonl(1));
+
+        let db = SqliteStorageAdapter::in_memory().unwrap();
+        let report = db.rebuild_from_git(&mock, &[slug]).await.unwrap();
+
+        assert_eq!(report.features_restored, 1);
+        assert_eq!(report.audit_entries_restored, 2);
+
+        let feat = StoragePort::get_feature_by_slug(&db, slug)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(feat.slug, slug);
+        assert_eq!(
+            feat.state,
+            agileplus_domain::domain::state_machine::FeatureState::Specified
+        );
+    }
+
+    #[tokio::test]
+    async fn rebuild_skips_missing_meta() {
+        let mock = MockVcs::new(); // No artifacts
+        let db = SqliteStorageAdapter::in_memory().unwrap();
+        let report = db
+            .rebuild_from_git(&mock, &["no-such-feature"])
+            .await
+            .unwrap();
+        assert_eq!(report.features_restored, 0);
+    }
+}

--- a/crates/agileplus-sqlite/src/rebuild/tests.rs
+++ b/crates/agileplus-sqlite/src/rebuild/tests.rs
@@ -1,0 +1,230 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use agileplus_domain::{
+    domain::audit::hash_entry,
+    error::DomainError,
+    ports::{
+        ContentStoragePort, StoragePort, VcsPort,
+        vcs::{BranchInfo, ConflictInfo, FeatureArtifacts, MergeResult, WorktreeInfo},
+    },
+};
+
+use super::*;
+use crate::SqliteStorageAdapter;
+
+/// A simple in-memory VcsPort mock.
+struct MockVcs {
+    artifacts: HashMap<String, String>,
+}
+
+impl MockVcs {
+    fn new() -> Self {
+        Self {
+            artifacts: HashMap::new(),
+        }
+    }
+
+    fn add(&mut self, slug: &str, path: &str, content: &str) {
+        self.artifacts
+            .insert(format!("{slug}/{path}"), content.to_string());
+    }
+}
+
+impl VcsPort for MockVcs {
+    async fn create_worktree(
+        &self,
+        _feature_slug: &str,
+        _wp_id: &str,
+    ) -> Result<PathBuf, DomainError> {
+        Err(DomainError::NotImplemented)
+    }
+
+    async fn list_worktrees(&self) -> Result<Vec<WorktreeInfo>, DomainError> {
+        Err(DomainError::NotImplemented)
+    }
+
+    async fn cleanup_worktree(&self, _worktree_path: &Path) -> Result<(), DomainError> {
+        Err(DomainError::NotImplemented)
+    }
+
+    async fn create_branch(&self, _branch_name: &str, _base: &str) -> Result<(), DomainError> {
+        Err(DomainError::NotImplemented)
+    }
+
+    async fn list_branches(
+        &self,
+        _pattern: Option<&str>,
+        _remote: bool,
+    ) -> Result<Vec<BranchInfo>, DomainError> {
+        Err(DomainError::NotImplemented)
+    }
+
+    async fn delete_branch(
+        &self,
+        _branch_name: &str,
+        _force: bool,
+        _remote: Option<&str>,
+    ) -> Result<(), DomainError> {
+        Err(DomainError::NotImplemented)
+    }
+
+    async fn checkout_branch(&self, _branch_name: &str) -> Result<(), DomainError> {
+        Err(DomainError::NotImplemented)
+    }
+
+    async fn merge_to_target(
+        &self,
+        _source: &str,
+        _target: &str,
+    ) -> Result<MergeResult, DomainError> {
+        Err(DomainError::NotImplemented)
+    }
+
+    async fn detect_conflicts(
+        &self,
+        _source: &str,
+        _target: &str,
+    ) -> Result<Vec<ConflictInfo>, DomainError> {
+        Err(DomainError::NotImplemented)
+    }
+
+    async fn read_artifact(
+        &self,
+        feature_slug: &str,
+        relative_path: &str,
+    ) -> Result<String, DomainError> {
+        let key = format!("{feature_slug}/{relative_path}");
+        self.artifacts
+            .get(&key)
+            .cloned()
+            .ok_or_else(|| DomainError::NotFound(key))
+    }
+
+    async fn write_artifact(
+        &self,
+        _feature_slug: &str,
+        _relative_path: &str,
+        _content: &str,
+    ) -> Result<(), DomainError> {
+        Err(DomainError::NotImplemented)
+    }
+
+    async fn artifact_exists(
+        &self,
+        _feature_slug: &str,
+        _relative_path: &str,
+    ) -> Result<bool, DomainError> {
+        Err(DomainError::NotImplemented)
+    }
+
+    async fn scan_feature_artifacts(
+        &self,
+        _feature_slug: &str,
+    ) -> Result<FeatureArtifacts, DomainError> {
+        Err(DomainError::NotImplemented)
+    }
+}
+
+fn make_chain_jsonl(feature_id: i64) -> String {
+    let now = chrono::Utc::now();
+
+    let mut e1 = AuditEntry {
+        id: 0,
+        feature_id,
+        wp_id: None,
+        timestamp: now,
+        actor: "system".into(),
+        transition: "created".into(),
+        evidence_refs: vec![],
+        prev_hash: [0u8; 32],
+        hash: [0u8; 32],
+        event_id: None,
+        archived_to: None,
+    };
+    e1.hash = hash_entry(&e1);
+
+    let mut e2 = AuditEntry {
+        id: 0,
+        feature_id,
+        wp_id: None,
+        timestamp: now,
+        actor: "agent".into(),
+        transition: "created->specified".into(),
+        evidence_refs: vec![],
+        prev_hash: e1.hash,
+        hash: [0u8; 32],
+        event_id: None,
+        archived_to: None,
+    };
+    e2.hash = hash_entry(&e2);
+
+    let hex = |b: [u8; 32]| b.iter().map(|x| format!("{x:02x}")).collect::<String>();
+
+    let line1 = serde_json::json!({
+        "feature_id": 1i64,
+        "wp_id": null,
+        "timestamp": now.to_rfc3339(),
+        "actor": "system",
+        "transition": "created",
+        "evidence_refs": [],
+        "prev_hash": hex([0u8; 32]),
+        "hash": hex(e1.hash),
+    });
+    let line2 = serde_json::json!({
+        "feature_id": 1i64,
+        "wp_id": null,
+        "timestamp": now.to_rfc3339(),
+        "actor": "agent",
+        "transition": "created->specified",
+        "evidence_refs": [],
+        "prev_hash": hex(e1.hash),
+        "hash": hex(e2.hash),
+    });
+
+    format!("{}\n{}\n", line1, line2)
+}
+
+#[tokio::test]
+async fn rebuild_from_fixtures() {
+    let now = chrono::Utc::now();
+    let slug = "test-feature";
+
+    let meta = serde_json::json!({
+        "slug": slug,
+        "friendly_name": "Test Feature",
+        "state": "specified",
+        "spec_hash": "a".repeat(64),
+        "target_branch": "main",
+        "created_at": now.to_rfc3339(),
+        "updated_at": now.to_rfc3339(),
+    });
+
+    let mut mock = MockVcs::new();
+    mock.add(slug, "meta.json", &meta.to_string());
+    mock.add(slug, "audit/chain.jsonl", &make_chain_jsonl(1));
+
+    let db = SqliteStorageAdapter::in_memory().unwrap();
+    let report = db.rebuild_from_git(&mock, &[slug]).await.unwrap();
+
+    assert_eq!(report.features_restored, 1);
+    assert_eq!(report.audit_entries_restored, 2);
+
+    let feat = StoragePort::get_feature_by_slug(&db, slug).await.unwrap().unwrap();
+    assert_eq!(feat.slug, slug);
+    assert_eq!(
+        feat.state,
+        agileplus_domain::domain::state_machine::FeatureState::Specified
+    );
+}
+
+#[tokio::test]
+async fn rebuild_skips_missing_meta() {
+    let mock = MockVcs::new();
+    let db = SqliteStorageAdapter::in_memory().unwrap();
+    let report = db
+        .rebuild_from_git(&mock, &["no-such-feature"])
+        .await
+        .unwrap();
+    assert_eq!(report.features_restored, 0);
+}

--- a/crates/agileplus-sqlite/src/repository/audit.rs
+++ b/crates/agileplus-sqlite/src/repository/audit.rs
@@ -1,0 +1,150 @@
+//! Audit repository — CRUD for the `audit_log` table.
+
+use rusqlite::{Connection, Row, params};
+
+use agileplus_domain::{
+    domain::audit::{AuditEntry, EvidenceRef},
+    error::DomainError,
+};
+
+fn map_err(e: rusqlite::Error) -> DomainError {
+    DomainError::Storage(e.to_string())
+}
+
+fn row_to_audit_entry(row: &Row<'_>) -> rusqlite::Result<AuditEntry> {
+    let id: i64 = row.get(0)?;
+    let feature_id: i64 = row.get(1)?;
+    let wp_id: Option<i64> = row.get(2)?;
+    let timestamp_s: String = row.get(3)?;
+    let actor: String = row.get(4)?;
+    let transition: String = row.get(5)?;
+    let evidence_refs_json: String = row.get(6)?;
+    let prev_hash_bytes: Vec<u8> = row.get(7)?;
+    let hash_bytes: Vec<u8> = row.get(8)?;
+
+    let timestamp = timestamp_s
+        .parse::<chrono::DateTime<chrono::Utc>>()
+        .map_err(|e| {
+            rusqlite::Error::FromSqlConversionFailure(
+                3,
+                rusqlite::types::Type::Text,
+                Box::new(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    e.to_string(),
+                )),
+            )
+        })?;
+
+    let evidence_refs: Vec<EvidenceRef> =
+        serde_json::from_str(&evidence_refs_json).unwrap_or_default();
+
+    let mut prev_hash = [0u8; 32];
+    if prev_hash_bytes.len() == 32 {
+        prev_hash.copy_from_slice(&prev_hash_bytes);
+    }
+
+    let mut hash = [0u8; 32];
+    if hash_bytes.len() == 32 {
+        hash.copy_from_slice(&hash_bytes);
+    }
+
+    Ok(AuditEntry {
+        id,
+        feature_id,
+        wp_id,
+        timestamp,
+        actor,
+        transition,
+        evidence_refs,
+        prev_hash,
+        hash,
+        event_id: None,
+        archived_to: None,
+    })
+}
+
+/// Append an audit entry. Performs a defense-in-depth chain check.
+pub fn append_audit_entry(conn: &Connection, entry: &AuditEntry) -> Result<i64, DomainError> {
+    // Defense-in-depth: verify prev_hash matches latest entry's hash
+    let latest = get_latest_audit_entry(conn, entry.feature_id)?;
+    if let Some(ref latest) = latest {
+        if entry.prev_hash != latest.hash {
+            return Err(DomainError::Storage(
+                "audit chain broken: prev_hash does not match latest entry hash".into(),
+            ));
+        }
+    } else {
+        // First entry: prev_hash should be all zeros
+        if entry.prev_hash != [0u8; 32] {
+            return Err(DomainError::Storage(
+                "audit chain broken: first entry prev_hash must be all zeros".into(),
+            ));
+        }
+    }
+
+    let evidence_refs_json = serde_json::to_string(&entry.evidence_refs)
+        .map_err(|e| DomainError::Storage(e.to_string()))?;
+
+    conn.execute(
+        "INSERT INTO audit_log
+         (feature_id, wp_id, timestamp, actor, transition, evidence_refs, prev_hash, hash)
+         VALUES (?1,?2,?3,?4,?5,?6,?7,?8)",
+        params![
+            entry.feature_id,
+            entry.wp_id,
+            entry.timestamp.to_rfc3339(),
+            entry.actor,
+            entry.transition,
+            evidence_refs_json,
+            entry.prev_hash.as_slice(),
+            entry.hash.as_slice(),
+        ],
+    )
+    .map_err(map_err)?;
+
+    Ok(conn.last_insert_rowid())
+}
+
+pub fn get_audit_trail(conn: &Connection, feature_id: i64) -> Result<Vec<AuditEntry>, DomainError> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT id,feature_id,wp_id,timestamp,actor,transition,evidence_refs,prev_hash,hash
+             FROM audit_log WHERE feature_id = ?1 ORDER BY id ASC",
+        )
+        .map_err(map_err)?;
+
+    let rows = stmt
+        .query_map(params![feature_id], row_to_audit_entry)
+        .map_err(map_err)?;
+
+    rows.collect::<rusqlite::Result<Vec<_>>>().map_err(map_err)
+}
+
+pub fn get_latest_audit_entry(
+    conn: &Connection,
+    feature_id: i64,
+) -> Result<Option<AuditEntry>, DomainError> {
+    conn.query_row(
+        "SELECT id,feature_id,wp_id,timestamp,actor,transition,evidence_refs,prev_hash,hash
+         FROM audit_log WHERE feature_id = ?1 ORDER BY id DESC LIMIT 1",
+        params![feature_id],
+        row_to_audit_entry,
+    )
+    .optional()
+    .map_err(map_err)
+}
+
+/// Extension trait to add `.optional()` on rusqlite query results.
+trait OptionalExt<T> {
+    fn optional(self) -> rusqlite::Result<Option<T>>;
+}
+
+impl<T> OptionalExt<T> for rusqlite::Result<T> {
+    fn optional(self) -> rusqlite::Result<Option<T>> {
+        match self {
+            Ok(v) => Ok(Some(v)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+}

--- a/crates/agileplus-sqlite/src/repository/backlog.rs
+++ b/crates/agileplus-sqlite/src/repository/backlog.rs
@@ -1,0 +1,293 @@
+//! Repository operations for backlog queue items.
+
+use rusqlite::{Connection, Row, params, params_from_iter, types::Value};
+
+use agileplus_domain::{
+    domain::backlog::{
+        BacklogFilters, BacklogItem, BacklogPriority, BacklogSort, BacklogStatus, Intent,
+    },
+    error::DomainError,
+};
+
+fn map_err(e: rusqlite::Error) -> DomainError {
+    DomainError::Storage(e.to_string())
+}
+
+fn intent_str(intent: Intent) -> &'static str {
+    match intent {
+        Intent::Bug => "bug",
+        Intent::Feature => "feature",
+        Intent::Idea => "idea",
+        Intent::Task => "task",
+    }
+}
+
+fn intent_from_str(s: &str) -> Result<Intent, DomainError> {
+    s.parse::<Intent>()
+        .map_err(|e| DomainError::Storage(format!("invalid backlog intent: {e}")))
+}
+
+fn priority_str(priority: BacklogPriority) -> &'static str {
+    match priority {
+        BacklogPriority::Critical => "critical",
+        BacklogPriority::High => "high",
+        BacklogPriority::Medium => "medium",
+        BacklogPriority::Low => "low",
+    }
+}
+
+fn priority_from_str(s: &str) -> Result<BacklogPriority, DomainError> {
+    s.parse::<BacklogPriority>()
+        .map_err(|e| DomainError::Storage(format!("invalid backlog priority: {e}")))
+}
+
+fn status_str(status: BacklogStatus) -> &'static str {
+    match status {
+        BacklogStatus::New => "new",
+        BacklogStatus::Triaged => "triaged",
+        BacklogStatus::InProgress => "in_progress",
+        BacklogStatus::Done => "done",
+        BacklogStatus::Dismissed => "dismissed",
+    }
+}
+
+fn status_from_str(s: &str) -> Result<BacklogStatus, DomainError> {
+    s.parse::<BacklogStatus>()
+        .map_err(|e| DomainError::Storage(format!("invalid backlog status: {e}")))
+}
+
+fn row_to_backlog(row: &Row<'_>) -> rusqlite::Result<BacklogItem> {
+    let id: i64 = row.get(0)?;
+    let title: String = row.get(1)?;
+    let description: String = row.get(2)?;
+    let intent_s: String = row.get(3)?;
+    let priority_s: String = row.get(4)?;
+    let status_s: String = row.get(5)?;
+    let source: String = row.get(6)?;
+    let feature_slug: Option<String> = row.get(7)?;
+    let tags_json: String = row.get(8)?;
+    let created_at_s: String = row.get(9)?;
+    let updated_at_s: String = row.get(10)?;
+
+    let intent = intent_from_str(&intent_s).map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(
+            3,
+            rusqlite::types::Type::Text,
+            Box::new(std::io::Error::other(e.to_string())),
+        )
+    })?;
+    let priority = priority_from_str(&priority_s).map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(
+            4,
+            rusqlite::types::Type::Text,
+            Box::new(std::io::Error::other(e.to_string())),
+        )
+    })?;
+    let status = status_from_str(&status_s).map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(
+            5,
+            rusqlite::types::Type::Text,
+            Box::new(std::io::Error::other(e.to_string())),
+        )
+    })?;
+
+    let tags: Vec<String> = serde_json::from_str(&tags_json).unwrap_or_default();
+    let created_at = created_at_s
+        .parse::<chrono::DateTime<chrono::Utc>>()
+        .map_err(|e| {
+            rusqlite::Error::FromSqlConversionFailure(
+                9,
+                rusqlite::types::Type::Text,
+                Box::new(std::io::Error::other(e.to_string())),
+            )
+        })?;
+    let updated_at = updated_at_s
+        .parse::<chrono::DateTime<chrono::Utc>>()
+        .map_err(|e| {
+            rusqlite::Error::FromSqlConversionFailure(
+                10,
+                rusqlite::types::Type::Text,
+                Box::new(std::io::Error::other(e.to_string())),
+            )
+        })?;
+
+    Ok(BacklogItem {
+        id: Some(id),
+        title,
+        description,
+        intent,
+        priority,
+        status,
+        source,
+        feature_slug,
+        tags,
+        created_at,
+        updated_at,
+    })
+}
+
+pub fn create_backlog_item(conn: &Connection, item: &BacklogItem) -> Result<i64, DomainError> {
+    let tags_json =
+        serde_json::to_string(&item.tags).map_err(|e| DomainError::Storage(e.to_string()))?;
+    conn.execute(
+        "INSERT INTO backlog_items
+         (title, description, intent, priority, status, source, feature_slug, tags_json, created_at, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+        params![
+            item.title,
+            item.description,
+            intent_str(item.intent),
+            priority_str(item.priority),
+            status_str(item.status),
+            item.source,
+            item.feature_slug,
+            tags_json,
+            item.created_at.to_rfc3339(),
+            item.updated_at.to_rfc3339(),
+        ],
+    )
+    .map_err(map_err)?;
+    Ok(conn.last_insert_rowid())
+}
+
+pub fn get_backlog_item(conn: &Connection, id: i64) -> Result<Option<BacklogItem>, DomainError> {
+    conn.query_row(
+        "SELECT id, title, description, intent, priority, status, source, feature_slug, tags_json, created_at, updated_at
+         FROM backlog_items WHERE id = ?1",
+        params![id],
+        row_to_backlog,
+    )
+    .optional()
+    .map_err(map_err)
+}
+
+pub fn list_backlog_items(
+    conn: &Connection,
+    filters: &BacklogFilters,
+) -> Result<Vec<BacklogItem>, DomainError> {
+    let mut sql = String::from(
+        "SELECT id, title, description, intent, priority, status, source, feature_slug, tags_json, created_at, updated_at
+         FROM backlog_items WHERE 1=1",
+    );
+    let mut values: Vec<Value> = Vec::new();
+
+    if let Some(intent) = filters.intent {
+        sql.push_str(" AND intent = ?");
+        values.push(Value::Text(intent_str(intent).to_string()));
+    }
+    if let Some(status) = filters.status {
+        sql.push_str(" AND status = ?");
+        values.push(Value::Text(status_str(status).to_string()));
+    }
+    if let Some(priority) = filters.priority {
+        sql.push_str(" AND priority = ?");
+        values.push(Value::Text(priority_str(priority).to_string()));
+    }
+    if let Some(ref feature_slug) = filters.feature_slug {
+        sql.push_str(" AND feature_slug = ?");
+        values.push(Value::Text(feature_slug.clone()));
+    }
+    if let Some(ref source) = filters.source {
+        sql.push_str(" AND source = ?");
+        values.push(Value::Text(source.clone()));
+    }
+
+    match filters.sort {
+        BacklogSort::Age => sql.push_str(" ORDER BY created_at ASC"),
+        BacklogSort::Impact | BacklogSort::Priority => {
+            sql.push_str(
+                " ORDER BY CASE priority
+                    WHEN 'critical' THEN 0
+                    WHEN 'high' THEN 1
+                    WHEN 'medium' THEN 2
+                    ELSE 3
+                 END ASC, created_at ASC",
+            );
+        }
+    }
+
+    if let Some(limit) = filters.limit {
+        sql.push_str(" LIMIT ?");
+        values.push(Value::Integer(limit as i64));
+    }
+
+    let mut stmt = conn.prepare(&sql).map_err(map_err)?;
+    let rows = stmt
+        .query_map(params_from_iter(values), row_to_backlog)
+        .map_err(map_err)?;
+    rows.collect::<rusqlite::Result<Vec<_>>>().map_err(map_err)
+}
+
+pub fn update_backlog_status(
+    conn: &Connection,
+    id: i64,
+    status: BacklogStatus,
+) -> Result<(), DomainError> {
+    let now = chrono::Utc::now().to_rfc3339();
+    conn.execute(
+        "UPDATE backlog_items SET status = ?1, updated_at = ?2 WHERE id = ?3",
+        params![status_str(status), now, id],
+    )
+    .map_err(map_err)?;
+    Ok(())
+}
+
+pub fn update_backlog_priority(
+    conn: &Connection,
+    id: i64,
+    priority: BacklogPriority,
+) -> Result<(), DomainError> {
+    let now = chrono::Utc::now().to_rfc3339();
+    conn.execute(
+        "UPDATE backlog_items SET priority = ?1, updated_at = ?2 WHERE id = ?3",
+        params![priority_str(priority), now, id],
+    )
+    .map_err(map_err)?;
+    Ok(())
+}
+
+pub fn pop_next_backlog_item(conn: &Connection) -> Result<Option<BacklogItem>, DomainError> {
+    let next = conn
+        .query_row(
+            "SELECT id, title, description, intent, priority, status, source, feature_slug, tags_json, created_at, updated_at
+             FROM backlog_items
+             WHERE status = 'new'
+             ORDER BY CASE priority
+                 WHEN 'critical' THEN 0
+                 WHEN 'high' THEN 1
+                 WHEN 'medium' THEN 2
+                 ELSE 3
+             END ASC, created_at ASC
+             LIMIT 1",
+            [],
+            row_to_backlog,
+        )
+        .optional()
+        .map_err(map_err)?;
+
+    if let Some(mut item) = next {
+        let id = item
+            .id
+            .ok_or_else(|| DomainError::Storage("backlog item missing id".to_string()))?;
+        update_backlog_status(conn, id, BacklogStatus::Triaged)?;
+        item.status = BacklogStatus::Triaged;
+        item.updated_at = chrono::Utc::now();
+        Ok(Some(item))
+    } else {
+        Ok(None)
+    }
+}
+
+trait OptionalExt<T> {
+    fn optional(self) -> rusqlite::Result<Option<T>>;
+}
+
+impl<T> OptionalExt<T> for rusqlite::Result<T> {
+    fn optional(self) -> rusqlite::Result<Option<T>> {
+        match self {
+            Ok(v) => Ok(Some(v)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+}

--- a/crates/agileplus-sqlite/src/repository/cycles/mappers.rs
+++ b/crates/agileplus-sqlite/src/repository/cycles/mappers.rs
@@ -1,0 +1,127 @@
+use rusqlite::Row;
+
+use agileplus_domain::domain::{cycle::Cycle, feature::Feature, state_machine::FeatureState};
+
+fn parse_datetime(
+    value: &str,
+    idx: usize,
+) -> Result<chrono::DateTime<chrono::Utc>, rusqlite::Error> {
+    value.parse::<chrono::DateTime<chrono::Utc>>().map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(
+            idx,
+            rusqlite::types::Type::Text,
+            Box::new(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                e.to_string(),
+            )),
+        )
+    })
+}
+
+pub(super) fn row_to_cycle(row: &Row<'_>) -> rusqlite::Result<Cycle> {
+    let id: i64 = row.get(0)?;
+    let name: String = row.get(1)?;
+    let description: Option<String> = row.get(2)?;
+    let state_str: String = row.get(3)?;
+    let start_date_str: String = row.get(4)?;
+    let end_date_str: String = row.get(5)?;
+    let module_scope_id: Option<i64> = row.get(6)?;
+    let created_at_str: String = row.get(7)?;
+    let updated_at_str: String = row.get(8)?;
+
+    let state = state_str
+        .parse::<agileplus_domain::domain::cycle::CycleState>()
+        .map_err(|e| {
+            rusqlite::Error::FromSqlConversionFailure(
+                3,
+                rusqlite::types::Type::Text,
+                Box::new(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    e.to_string(),
+                )),
+            )
+        })?;
+
+    let start_date =
+        chrono::NaiveDate::parse_from_str(&start_date_str, "%Y-%m-%d").map_err(|e| {
+            rusqlite::Error::FromSqlConversionFailure(
+                4,
+                rusqlite::types::Type::Text,
+                Box::new(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    e.to_string(),
+                )),
+            )
+        })?;
+
+    let end_date = chrono::NaiveDate::parse_from_str(&end_date_str, "%Y-%m-%d").map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(
+            5,
+            rusqlite::types::Type::Text,
+            Box::new(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                e.to_string(),
+            )),
+        )
+    })?;
+
+    let created_at = parse_datetime(&created_at_str, 7)?;
+    let updated_at = parse_datetime(&updated_at_str, 8)?;
+
+    Ok(Cycle {
+        id,
+        name,
+        description,
+        state,
+        start_date,
+        end_date,
+        module_scope_id,
+        created_at,
+        updated_at,
+    })
+}
+
+pub(super) fn row_to_feature(row: &Row<'_>) -> rusqlite::Result<Feature> {
+    let id: i64 = row.get(0)?;
+    let slug: String = row.get(1)?;
+    let friendly_name: String = row.get(2)?;
+    let state_str: String = row.get(3)?;
+    let spec_hash_bytes: Vec<u8> = row.get(4)?;
+    let target_branch: String = row.get(5)?;
+    let created_at_str: String = row.get(6)?;
+    let updated_at_str: String = row.get(7)?;
+
+    let state = state_str.parse::<FeatureState>().map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(
+            3,
+            rusqlite::types::Type::Text,
+            Box::new(std::io::Error::new(std::io::ErrorKind::InvalidData, e)),
+        )
+    })?;
+
+    let mut spec_hash = [0u8; 32];
+    if spec_hash_bytes.len() == 32 {
+        spec_hash.copy_from_slice(&spec_hash_bytes);
+    }
+
+    let created_at = parse_datetime(&created_at_str, 6)?;
+    let updated_at = parse_datetime(&updated_at_str, 7)?;
+
+    Ok(Feature {
+        id,
+        slug,
+        friendly_name,
+        state,
+        spec_hash,
+        target_branch,
+        plane_issue_id: None,
+        plane_state_id: None,
+        labels: Vec::new(),
+        module_id: None,
+        project_id: None,
+        created_at_commit: None,
+        last_modified_commit: None,
+        created_at,
+        updated_at,
+    })
+}

--- a/crates/agileplus-sqlite/src/repository/cycles/mod.rs
+++ b/crates/agileplus-sqlite/src/repository/cycles/mod.rs
@@ -1,0 +1,231 @@
+//! Cycle repository -- CRUD operations for the `cycles` table and `cycle_features`.
+//!
+//! Traces to: FR-C01, FR-C02, FR-C03, FR-C04, FR-C05, FR-C07
+
+use rusqlite::{Connection, OptionalExtension, params};
+
+use agileplus_domain::{
+    domain::cycle::{Cycle, CycleFeature, CycleState, CycleWithFeatures},
+    error::DomainError,
+};
+
+use crate::repository::features::map_err;
+
+mod mappers;
+mod progress;
+
+use mappers::{row_to_cycle, row_to_feature};
+use progress::compute_wp_progress;
+
+// ---------------------------------------------------------------------------
+// Cycle CRUD
+// ---------------------------------------------------------------------------
+
+pub fn create_cycle(conn: &Connection, cycle: &Cycle) -> Result<i64, DomainError> {
+    let now = chrono::Utc::now().to_rfc3339();
+    conn.execute(
+        "INSERT INTO cycles (name, description, state, start_date, end_date, module_scope_id, created_at, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+        params![
+            cycle.name,
+            cycle.description,
+            cycle.state.to_string(),
+            cycle.start_date.format("%Y-%m-%d").to_string(),
+            cycle.end_date.format("%Y-%m-%d").to_string(),
+            cycle.module_scope_id,
+            now,
+            now,
+        ],
+    )
+    .map_err(map_err)?;
+    Ok(conn.last_insert_rowid())
+}
+
+pub fn get_cycle(conn: &Connection, id: i64) -> Result<Option<Cycle>, DomainError> {
+    conn.query_row(
+        "SELECT id, name, description, state, start_date, end_date, module_scope_id,
+                created_at, updated_at
+         FROM cycles WHERE id = ?1",
+        params![id],
+        row_to_cycle,
+    )
+    .optional()
+    .map_err(map_err)
+}
+
+pub fn update_cycle_state(
+    conn: &Connection,
+    id: i64,
+    state: CycleState,
+) -> Result<(), DomainError> {
+    let now = chrono::Utc::now().to_rfc3339();
+    let rows = conn
+        .execute(
+            "UPDATE cycles SET state = ?1, updated_at = ?2 WHERE id = ?3",
+            params![state.to_string(), now, id],
+        )
+        .map_err(map_err)?;
+    if rows == 0 {
+        return Err(DomainError::CycleNotFound(id.to_string()));
+    }
+    Ok(())
+}
+
+pub fn list_cycles_by_state(
+    conn: &Connection,
+    state: CycleState,
+) -> Result<Vec<Cycle>, DomainError> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, name, description, state, start_date, end_date, module_scope_id,
+                    created_at, updated_at
+             FROM cycles WHERE state = ?1 ORDER BY start_date",
+        )
+        .map_err(map_err)?;
+    let rows = stmt
+        .query_map(params![state.to_string()], row_to_cycle)
+        .map_err(map_err)?;
+    rows.collect::<rusqlite::Result<Vec<_>>>().map_err(map_err)
+}
+
+pub fn list_cycles_by_module(conn: &Connection, module_id: i64) -> Result<Vec<Cycle>, DomainError> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, name, description, state, start_date, end_date, module_scope_id,
+                    created_at, updated_at
+             FROM cycles WHERE module_scope_id = ?1 ORDER BY start_date",
+        )
+        .map_err(map_err)?;
+    let rows = stmt
+        .query_map(params![module_id], row_to_cycle)
+        .map_err(map_err)?;
+    rows.collect::<rusqlite::Result<Vec<_>>>().map_err(map_err)
+}
+
+/// List every cycle regardless of state.
+pub fn list_all_cycles(conn: &Connection) -> Result<Vec<Cycle>, DomainError> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, name, description, state, start_date, end_date, module_scope_id,
+                    created_at, updated_at
+             FROM cycles ORDER BY start_date",
+        )
+        .map_err(map_err)?;
+    let rows = stmt.query_map([], row_to_cycle).map_err(map_err)?;
+    rows.collect::<rusqlite::Result<Vec<_>>>().map_err(map_err)
+}
+
+/// Load a cycle with its assigned features and compute a `WpProgressSummary`.
+pub fn get_cycle_with_features(
+    conn: &Connection,
+    id: i64,
+) -> Result<Option<CycleWithFeatures>, DomainError> {
+    let cycle = match get_cycle(conn, id)? {
+        Some(c) => c,
+        None => return Ok(None),
+    };
+
+    // Load assigned features.
+    let mut stmt = conn
+        .prepare(
+            "SELECT f.id, f.slug, f.friendly_name, f.state, f.spec_hash, f.target_branch,
+                    f.created_at, f.updated_at
+             FROM features f
+             INNER JOIN cycle_features cf ON f.id = cf.feature_id
+             WHERE cf.cycle_id = ?1
+             ORDER BY f.created_at",
+        )
+        .map_err(map_err)?;
+    let features = stmt
+        .query_map(params![id], row_to_feature)
+        .map_err(map_err)?
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .map_err(map_err)?;
+
+    // Compute WP progress summary for all features in this cycle.
+    let wp_progress = compute_wp_progress(conn, id)?;
+
+    Ok(Some(CycleWithFeatures {
+        cycle,
+        features,
+        wp_progress,
+    }))
+}
+
+// ---------------------------------------------------------------------------
+// Cycle-feature join ops
+// ---------------------------------------------------------------------------
+
+/// Add a feature to a cycle. Enforces module_scope_id validation if set.
+/// Idempotent (INSERT OR IGNORE).
+pub fn add_feature_to_cycle(conn: &Connection, entry: &CycleFeature) -> Result<(), DomainError> {
+    // Check if the cycle has a module scope restriction.
+    let module_scope_id: Option<i64> = conn
+        .query_row(
+            "SELECT module_scope_id FROM cycles WHERE id = ?1",
+            params![entry.cycle_id],
+            |row| row.get(0),
+        )
+        .optional()
+        .map_err(map_err)?
+        .ok_or_else(|| DomainError::CycleNotFound(entry.cycle_id.to_string()))?;
+
+    if let Some(scope_module_id) = module_scope_id {
+        // Feature must be owned by or tagged to the scope module.
+        let in_scope: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM (
+                    SELECT id FROM features WHERE id = ?1 AND module_id = ?2
+                    UNION
+                    SELECT feature_id FROM module_feature_tags WHERE feature_id = ?1 AND module_id = ?2
+                )",
+                params![entry.feature_id, scope_module_id],
+                |row| row.get(0),
+            )
+            .map_err(map_err)?;
+
+        if in_scope == 0 {
+            // Load slugs for a good error message.
+            let feature_slug: String = conn
+                .query_row(
+                    "SELECT slug FROM features WHERE id = ?1",
+                    params![entry.feature_id],
+                    |row| row.get(0),
+                )
+                .map_err(map_err)?;
+            let module_slug: String = conn
+                .query_row(
+                    "SELECT slug FROM modules WHERE id = ?1",
+                    params![scope_module_id],
+                    |row| row.get(0),
+                )
+                .map_err(map_err)?;
+            return Err(DomainError::FeatureNotInModuleScope {
+                feature_slug,
+                module_slug,
+            });
+        }
+    }
+
+    let now = chrono::Utc::now().to_rfc3339();
+    conn.execute(
+        "INSERT OR IGNORE INTO cycle_features (cycle_id, feature_id, added_at)
+         VALUES (?1, ?2, ?3)",
+        params![entry.cycle_id, entry.feature_id, now],
+    )
+    .map_err(map_err)?;
+    Ok(())
+}
+
+pub fn remove_feature_from_cycle(
+    conn: &Connection,
+    cycle_id: i64,
+    feature_id: i64,
+) -> Result<(), DomainError> {
+    conn.execute(
+        "DELETE FROM cycle_features WHERE cycle_id = ?1 AND feature_id = ?2",
+        params![cycle_id, feature_id],
+    )
+    .map_err(map_err)?;
+    Ok(())
+}

--- a/crates/agileplus-sqlite/src/repository/cycles/progress.rs
+++ b/crates/agileplus-sqlite/src/repository/cycles/progress.rs
@@ -1,0 +1,48 @@
+use rusqlite::{Connection, params};
+
+use agileplus_domain::{domain::cycle::WpProgressSummary, error::DomainError};
+
+use crate::repository::features::map_err;
+
+/// Aggregate WP state counts across all features assigned to a cycle.
+pub(super) fn compute_wp_progress(
+    conn: &Connection,
+    cycle_id: i64,
+) -> Result<WpProgressSummary, DomainError> {
+    // Count WPs per state for features in this cycle.
+    let mut stmt = conn
+        .prepare(
+            "SELECT wp.state, COUNT(*) as cnt
+             FROM work_packages wp
+             INNER JOIN cycle_features cf ON wp.feature_id = cf.feature_id
+             WHERE cf.cycle_id = ?1
+             GROUP BY wp.state",
+        )
+        .map_err(map_err)?;
+
+    let mut summary = WpProgressSummary::default();
+
+    let rows = stmt
+        .query_map(params![cycle_id], |row| {
+            let state_str: String = row.get(0)?;
+            let count: i64 = row.get(1)?;
+            Ok((state_str, count))
+        })
+        .map_err(map_err)?;
+
+    for row in rows {
+        let (state_str, count) = row.map_err(map_err)?;
+        let count = count as u32;
+        summary.total += count;
+        match state_str.as_str() {
+            "planned" => summary.planned += count,
+            "doing" => summary.in_progress += count,
+            "review" => summary.in_progress += count,
+            "done" => summary.done += count,
+            "blocked" => summary.blocked += count,
+            _ => {}
+        }
+    }
+
+    Ok(summary)
+}

--- a/crates/agileplus-sqlite/src/repository/events.rs
+++ b/crates/agileplus-sqlite/src/repository/events.rs
@@ -1,0 +1,161 @@
+//! Event repository — CRUD for the `events` table.
+
+use rusqlite::{Connection, Row, params};
+
+use agileplus_domain::domain::event::Event;
+use agileplus_domain::error::DomainError;
+
+fn map_err(e: rusqlite::Error) -> DomainError {
+    DomainError::Storage(e.to_string())
+}
+
+fn row_to_event(row: &Row<'_>) -> rusqlite::Result<Event> {
+    let id: i64 = row.get(0)?;
+    let entity_type: String = row.get(1)?;
+    let entity_id: i64 = row.get(2)?;
+    let event_type: String = row.get(3)?;
+    let payload_str: String = row.get(4)?;
+    let actor: String = row.get(5)?;
+    let timestamp_str: String = row.get(6)?;
+    let prev_hash_bytes: Vec<u8> = row.get(7)?;
+    let hash_bytes: Vec<u8> = row.get(8)?;
+    let sequence: i64 = row.get(9)?;
+
+    let timestamp = timestamp_str
+        .parse::<chrono::DateTime<chrono::Utc>>()
+        .map_err(|e| {
+            rusqlite::Error::FromSqlConversionFailure(
+                6,
+                rusqlite::types::Type::Text,
+                Box::new(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    e.to_string(),
+                )),
+            )
+        })?;
+
+    let payload: serde_json::Value = serde_json::from_str(&payload_str).unwrap_or_default();
+
+    let mut prev_hash = [0u8; 32];
+    if prev_hash_bytes.len() == 32 {
+        prev_hash.copy_from_slice(&prev_hash_bytes);
+    }
+    let mut hash = [0u8; 32];
+    if hash_bytes.len() == 32 {
+        hash.copy_from_slice(&hash_bytes);
+    }
+
+    Ok(Event {
+        id,
+        entity_type,
+        entity_id,
+        event_type,
+        payload,
+        actor,
+        timestamp,
+        prev_hash,
+        hash,
+        sequence,
+    })
+}
+
+const SELECT_COLS: &str =
+    "id, entity_type, entity_id, event_type, payload, actor, timestamp, prev_hash, hash, sequence";
+
+pub fn append_event(conn: &Connection, event: &Event) -> Result<i64, DomainError> {
+    let payload_json = serde_json::to_string(&event.payload)
+        .map_err(|e| DomainError::Storage(format!("serialize payload: {e}")))?;
+
+    conn.execute(
+        &format!(
+            "INSERT INTO events ({SELECT_COLS}) VALUES (NULL, ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)"
+        ),
+        params![
+            event.entity_type,
+            event.entity_id,
+            event.event_type,
+            payload_json,
+            event.actor,
+            event.timestamp.to_rfc3339(),
+            &event.prev_hash[..],
+            &event.hash[..],
+            event.sequence,
+        ],
+    )
+    .map_err(map_err)?;
+
+    Ok(conn.last_insert_rowid())
+}
+
+pub fn get_events(
+    conn: &Connection,
+    entity_type: &str,
+    entity_id: i64,
+) -> Result<Vec<Event>, DomainError> {
+    let mut stmt = conn
+        .prepare(&format!(
+            "SELECT {SELECT_COLS} FROM events WHERE entity_type = ?1 AND entity_id = ?2 ORDER BY sequence ASC"
+        ))
+        .map_err(map_err)?;
+
+    let rows = stmt
+        .query_map(params![entity_type, entity_id], row_to_event)
+        .map_err(map_err)?;
+
+    rows.collect::<Result<Vec<_>, _>>().map_err(map_err)
+}
+
+pub fn get_events_since(
+    conn: &Connection,
+    entity_type: &str,
+    entity_id: i64,
+    sequence: i64,
+) -> Result<Vec<Event>, DomainError> {
+    let mut stmt = conn
+        .prepare(&format!(
+            "SELECT {SELECT_COLS} FROM events WHERE entity_type = ?1 AND entity_id = ?2 AND sequence > ?3 ORDER BY sequence ASC"
+        ))
+        .map_err(map_err)?;
+
+    let rows = stmt
+        .query_map(params![entity_type, entity_id, sequence], row_to_event)
+        .map_err(map_err)?;
+
+    rows.collect::<Result<Vec<_>, _>>().map_err(map_err)
+}
+
+pub fn get_events_by_range(
+    conn: &Connection,
+    entity_type: &str,
+    entity_id: i64,
+    from: &str,
+    to: &str,
+) -> Result<Vec<Event>, DomainError> {
+    let mut stmt = conn
+        .prepare(&format!(
+            "SELECT {SELECT_COLS} FROM events WHERE entity_type = ?1 AND entity_id = ?2 AND timestamp >= ?3 AND timestamp <= ?4 ORDER BY sequence ASC"
+        ))
+        .map_err(map_err)?;
+
+    let rows = stmt
+        .query_map(params![entity_type, entity_id, from, to], row_to_event)
+        .map_err(map_err)?;
+
+    rows.collect::<Result<Vec<_>, _>>().map_err(map_err)
+}
+
+pub fn get_latest_sequence(
+    conn: &Connection,
+    entity_type: &str,
+    entity_id: i64,
+) -> Result<i64, DomainError> {
+    let result: Option<i64> = conn
+        .query_row(
+            "SELECT MAX(sequence) FROM events WHERE entity_type = ?1 AND entity_id = ?2",
+            params![entity_type, entity_id],
+            |row| row.get(0),
+        )
+        .map_err(map_err)?;
+
+    Ok(result.unwrap_or(0))
+}

--- a/crates/agileplus-sqlite/src/repository/evidence.rs
+++ b/crates/agileplus-sqlite/src/repository/evidence.rs
@@ -1,0 +1,131 @@
+//! Evidence repository — CRUD for the `evidence` table.
+
+use rusqlite::{Connection, Row, params};
+
+use agileplus_domain::{
+    domain::governance::{Evidence, EvidenceType},
+    error::DomainError,
+};
+
+fn map_err(e: rusqlite::Error) -> DomainError {
+    DomainError::Storage(e.to_string())
+}
+
+fn evidence_type_str(t: EvidenceType) -> &'static str {
+    t.as_str()
+}
+
+fn evidence_type_from_str(s: &str) -> Result<EvidenceType, DomainError> {
+    match s {
+        "test_result" => Ok(EvidenceType::TestResult),
+        "ci_output" => Ok(EvidenceType::CiOutput),
+        "review_approval" => Ok(EvidenceType::ReviewApproval),
+        "security_scan" => Ok(EvidenceType::SecurityScan),
+        "lint_result" => Ok(EvidenceType::LintResult),
+        "manual_attestation" => Ok(EvidenceType::ManualAttestation),
+        _ => Err(DomainError::Storage(format!("invalid evidence type: {s}"))),
+    }
+}
+
+#[allow(clippy::type_complexity)]
+fn row_to_evidence(
+    row: &Row<'_>,
+) -> rusqlite::Result<(i64, i64, String, String, String, Option<String>, String)> {
+    Ok((
+        row.get(0)?,
+        row.get(1)?,
+        row.get(2)?,
+        row.get(3)?,
+        row.get(4)?,
+        row.get(5)?,
+        row.get(6)?,
+    ))
+}
+
+fn parse_evidence(
+    row_data: (i64, i64, String, String, String, Option<String>, String),
+) -> Result<Evidence, DomainError> {
+    let (id, wp_id, fr_id, evidence_type_s, artifact_path, metadata_s, created_at_s) = row_data;
+
+    let evidence_type = evidence_type_from_str(&evidence_type_s)?;
+    let metadata = metadata_s
+        .map(|s| serde_json::from_str(&s))
+        .transpose()
+        .map_err(|e: serde_json::Error| DomainError::Storage(e.to_string()))?;
+    let created_at = created_at_s
+        .parse::<chrono::DateTime<chrono::Utc>>()
+        .map_err(|e| DomainError::Storage(e.to_string()))?;
+
+    Ok(Evidence {
+        id,
+        wp_id,
+        fr_id,
+        evidence_type,
+        artifact_path,
+        metadata,
+        created_at,
+    })
+}
+
+pub fn create_evidence(conn: &Connection, evidence: &Evidence) -> Result<i64, DomainError> {
+    let metadata_s = evidence
+        .metadata
+        .as_ref()
+        .map(serde_json::to_string)
+        .transpose()
+        .map_err(|e| DomainError::Storage(e.to_string()))?;
+
+    conn.execute(
+        "INSERT INTO evidence (wp_id, fr_id, evidence_type, artifact_path, metadata, created_at)
+         VALUES (?1,?2,?3,?4,?5,?6)",
+        params![
+            evidence.wp_id,
+            evidence.fr_id,
+            evidence_type_str(evidence.evidence_type),
+            evidence.artifact_path,
+            metadata_s,
+            evidence.created_at.to_rfc3339(),
+        ],
+    )
+    .map_err(map_err)?;
+
+    Ok(conn.last_insert_rowid())
+}
+
+pub fn get_evidence_by_wp(conn: &Connection, wp_id: i64) -> Result<Vec<Evidence>, DomainError> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT id,wp_id,fr_id,evidence_type,artifact_path,metadata,created_at
+             FROM evidence WHERE wp_id = ?1",
+        )
+        .map_err(map_err)?;
+
+    let rows = stmt
+        .query_map(params![wp_id], row_to_evidence)
+        .map_err(map_err)?;
+
+    rows.collect::<rusqlite::Result<Vec<_>>>()
+        .map_err(map_err)?
+        .into_iter()
+        .map(parse_evidence)
+        .collect()
+}
+
+pub fn get_evidence_by_fr(conn: &Connection, fr_id: &str) -> Result<Vec<Evidence>, DomainError> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT id,wp_id,fr_id,evidence_type,artifact_path,metadata,created_at
+             FROM evidence WHERE fr_id = ?1",
+        )
+        .map_err(map_err)?;
+
+    let rows = stmt
+        .query_map(params![fr_id], row_to_evidence)
+        .map_err(map_err)?;
+
+    rows.collect::<rusqlite::Result<Vec<_>>>()
+        .map_err(map_err)?
+        .into_iter()
+        .map(parse_evidence)
+        .collect()
+}

--- a/crates/agileplus-sqlite/src/repository/features.rs
+++ b/crates/agileplus-sqlite/src/repository/features.rs
@@ -1,0 +1,211 @@
+//! Feature repository — CRUD operations for the `features` table.
+
+use rusqlite::{Connection, Row, params};
+
+use agileplus_domain::{
+    domain::{feature::Feature, state_machine::FeatureState},
+    error::DomainError,
+};
+
+pub(crate) fn map_err(e: rusqlite::Error) -> DomainError {
+    DomainError::Storage(e.to_string())
+}
+
+fn state_str(s: FeatureState) -> &'static str {
+    match s {
+        FeatureState::Created => "created",
+        FeatureState::Specified => "specified",
+        FeatureState::Researched => "researched",
+        FeatureState::Planned => "planned",
+        FeatureState::Implementing => "implementing",
+        FeatureState::Validated => "validated",
+        FeatureState::Shipped => "shipped",
+        FeatureState::Retrospected => "retrospected",
+    }
+}
+
+fn row_to_feature(row: &Row<'_>) -> rusqlite::Result<Feature> {
+    let id: i64 = row.get(0)?;
+    let slug: String = row.get(1)?;
+    let friendly_name: String = row.get(2)?;
+    let state_str: String = row.get(3)?;
+    let spec_hash_bytes: Vec<u8> = row.get(4)?;
+    let target_branch: String = row.get(5)?;
+    let created_at_str: String = row.get(6)?;
+    let updated_at_str: String = row.get(7)?;
+    // module_id column added by migration 015 -- may be NULL.
+    let module_id: Option<i64> = row.get(8).unwrap_or(None);
+
+    let state = state_str.parse::<FeatureState>().map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(
+            3,
+            rusqlite::types::Type::Text,
+            Box::new(std::io::Error::new(std::io::ErrorKind::InvalidData, e)),
+        )
+    })?;
+
+    let mut spec_hash = [0u8; 32];
+    if spec_hash_bytes.len() == 32 {
+        spec_hash.copy_from_slice(&spec_hash_bytes);
+    }
+
+    let created_at = created_at_str
+        .parse::<chrono::DateTime<chrono::Utc>>()
+        .map_err(|e| {
+            rusqlite::Error::FromSqlConversionFailure(
+                6,
+                rusqlite::types::Type::Text,
+                Box::new(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    e.to_string(),
+                )),
+            )
+        })?;
+
+    let updated_at = updated_at_str
+        .parse::<chrono::DateTime<chrono::Utc>>()
+        .map_err(|e| {
+            rusqlite::Error::FromSqlConversionFailure(
+                7,
+                rusqlite::types::Type::Text,
+                Box::new(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    e.to_string(),
+                )),
+            )
+        })?;
+
+    Ok(Feature {
+        id,
+        slug,
+        friendly_name,
+        state,
+        spec_hash,
+        target_branch,
+        plane_issue_id: None,
+        plane_state_id: None,
+        labels: Vec::new(),
+        module_id,
+        project_id: None,
+        created_at,
+        updated_at,
+        created_at_commit: None,
+        last_modified_commit: None,
+    })
+}
+
+pub fn create_feature(conn: &Connection, feature: &Feature) -> Result<i64, DomainError> {
+    conn.execute(
+        "INSERT INTO features (slug, friendly_name, state, spec_hash, target_branch, created_at, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+        params![
+            feature.slug,
+            feature.friendly_name,
+            state_str(feature.state),
+            feature.spec_hash.as_slice(),
+            feature.target_branch,
+            feature.created_at.to_rfc3339(),
+            feature.updated_at.to_rfc3339(),
+        ],
+    )
+    .map_err(map_err)?;
+    Ok(conn.last_insert_rowid())
+}
+
+pub fn get_feature_by_slug(conn: &Connection, slug: &str) -> Result<Option<Feature>, DomainError> {
+    conn.query_row(
+        "SELECT id, slug, friendly_name, state, spec_hash, target_branch, created_at, updated_at
+         FROM features WHERE slug = ?1",
+        params![slug],
+        row_to_feature,
+    )
+    .optional()
+    .map_err(map_err)
+}
+
+pub fn get_feature_by_id(conn: &Connection, id: i64) -> Result<Option<Feature>, DomainError> {
+    conn.query_row(
+        "SELECT id, slug, friendly_name, state, spec_hash, target_branch, created_at, updated_at
+         FROM features WHERE id = ?1",
+        params![id],
+        row_to_feature,
+    )
+    .optional()
+    .map_err(map_err)
+}
+
+pub fn update_feature_state(
+    conn: &Connection,
+    id: i64,
+    state: FeatureState,
+) -> Result<(), DomainError> {
+    let now = chrono::Utc::now().to_rfc3339();
+    conn.execute(
+        "UPDATE features SET state = ?1, updated_at = ?2 WHERE id = ?3",
+        params![state_str(state), now, id],
+    )
+    .map_err(map_err)?;
+    Ok(())
+}
+
+pub fn update_feature(conn: &Connection, feature: &Feature) -> Result<(), DomainError> {
+    let now = chrono::Utc::now().to_rfc3339();
+    conn.execute(
+        "UPDATE features SET slug = ?1, friendly_name = ?2, state = ?3, updated_at = ?4 WHERE id = ?5",
+        params![
+            feature.slug,
+            feature.friendly_name,
+            state_str(feature.state),
+            now,
+            feature.id
+        ],
+    )
+    .map_err(map_err)?;
+    Ok(())
+}
+
+pub fn list_features_by_state(
+    conn: &Connection,
+    state: FeatureState,
+) -> Result<Vec<Feature>, DomainError> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, slug, friendly_name, state, spec_hash, target_branch, created_at, updated_at
+             FROM features WHERE state = ?1 ORDER BY created_at",
+        )
+        .map_err(map_err)?;
+
+    let rows = stmt
+        .query_map(params![state_str(state)], row_to_feature)
+        .map_err(map_err)?;
+
+    rows.collect::<rusqlite::Result<Vec<_>>>().map_err(map_err)
+}
+
+pub fn list_all_features(conn: &Connection) -> Result<Vec<Feature>, DomainError> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, slug, friendly_name, state, spec_hash, target_branch, created_at, updated_at
+             FROM features ORDER BY created_at DESC",
+        )
+        .map_err(map_err)?;
+
+    let rows = stmt.query_map([], row_to_feature).map_err(map_err)?;
+
+    rows.collect::<rusqlite::Result<Vec<_>>>().map_err(map_err)
+}
+
+/// Extension trait to add `.optional()` on rusqlite query results.
+trait OptionalExt<T> {
+    fn optional(self) -> rusqlite::Result<Option<T>>;
+}
+
+impl<T> OptionalExt<T> for rusqlite::Result<T> {
+    fn optional(self) -> rusqlite::Result<Option<T>> {
+        match self {
+            Ok(v) => Ok(Some(v)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+}

--- a/crates/agileplus-sqlite/src/repository/governance.rs
+++ b/crates/agileplus-sqlite/src/repository/governance.rs
@@ -1,0 +1,201 @@
+//! Governance repository — CRUD for `governance_contracts` and `policy_rules`.
+
+use rusqlite::{Connection, Row, params};
+
+use agileplus_domain::{
+    domain::governance::{
+        GovernanceContract, GovernanceRule, PolicyDefinition, PolicyDomain, PolicyRule,
+    },
+    error::DomainError,
+};
+
+fn map_err(e: rusqlite::Error) -> DomainError {
+    DomainError::Storage(e.to_string())
+}
+
+fn policy_domain_str(d: PolicyDomain) -> &'static str {
+    d.as_str()
+}
+
+fn policy_domain_from_str(s: &str) -> Result<PolicyDomain, DomainError> {
+    match s {
+        "security" => Ok(PolicyDomain::Security),
+        "quality" => Ok(PolicyDomain::Quality),
+        "compliance" => Ok(PolicyDomain::Compliance),
+        "performance" => Ok(PolicyDomain::Performance),
+        "custom" => Ok(PolicyDomain::Custom),
+        _ => Err(DomainError::Storage(format!("invalid policy domain: {s}"))),
+    }
+}
+
+// -- Governance Contracts --
+
+pub fn create_governance_contract(
+    conn: &Connection,
+    contract: &GovernanceContract,
+) -> Result<i64, DomainError> {
+    let rules_json =
+        serde_json::to_string(&contract.rules).map_err(|e| DomainError::Storage(e.to_string()))?;
+
+    conn.execute(
+        "INSERT INTO governance_contracts (feature_id, version, rules, bound_at)
+         VALUES (?1,?2,?3,?4)",
+        params![
+            contract.feature_id,
+            contract.version,
+            rules_json,
+            contract.bound_at.to_rfc3339(),
+        ],
+    )
+    .map_err(map_err)?;
+
+    Ok(conn.last_insert_rowid())
+}
+
+fn row_to_contract_parts(row: &Row<'_>) -> rusqlite::Result<(i64, i64, i32, String, String)> {
+    Ok((
+        row.get(0)?,
+        row.get(1)?,
+        row.get(2)?,
+        row.get(3)?,
+        row.get(4)?,
+    ))
+}
+
+fn parse_contract(
+    parts: (i64, i64, i32, String, String),
+) -> Result<GovernanceContract, DomainError> {
+    let (id, feature_id, version, rules_json, bound_at_s) = parts;
+
+    let rules: Vec<GovernanceRule> =
+        serde_json::from_str(&rules_json).map_err(|e| DomainError::Storage(e.to_string()))?;
+    let bound_at = bound_at_s
+        .parse::<chrono::DateTime<chrono::Utc>>()
+        .map_err(|e| DomainError::Storage(e.to_string()))?;
+
+    Ok(GovernanceContract {
+        id,
+        feature_id,
+        version,
+        rules,
+        bound_at,
+    })
+}
+
+pub fn get_governance_contract(
+    conn: &Connection,
+    feature_id: i64,
+    version: i32,
+) -> Result<Option<GovernanceContract>, DomainError> {
+    conn.query_row(
+        "SELECT id,feature_id,version,rules,bound_at
+         FROM governance_contracts WHERE feature_id=?1 AND version=?2",
+        params![feature_id, version],
+        row_to_contract_parts,
+    )
+    .optional()
+    .map_err(map_err)?
+    .map(parse_contract)
+    .transpose()
+}
+
+pub fn get_latest_governance_contract(
+    conn: &Connection,
+    feature_id: i64,
+) -> Result<Option<GovernanceContract>, DomainError> {
+    conn.query_row(
+        "SELECT id,feature_id,version,rules,bound_at
+         FROM governance_contracts WHERE feature_id=?1 ORDER BY version DESC LIMIT 1",
+        params![feature_id],
+        row_to_contract_parts,
+    )
+    .optional()
+    .map_err(map_err)?
+    .map(parse_contract)
+    .transpose()
+}
+
+// -- Policy Rules --
+
+pub fn create_policy_rule(conn: &Connection, rule: &PolicyRule) -> Result<i64, DomainError> {
+    let rule_json =
+        serde_json::to_string(&rule.rule).map_err(|e| DomainError::Storage(e.to_string()))?;
+
+    conn.execute(
+        "INSERT INTO policy_rules (domain, rule, active, created_at, updated_at)
+         VALUES (?1,?2,?3,?4,?5)",
+        params![
+            policy_domain_str(rule.domain),
+            rule_json,
+            rule.active as i32,
+            rule.created_at.to_rfc3339(),
+            rule.updated_at.to_rfc3339(),
+        ],
+    )
+    .map_err(map_err)?;
+
+    Ok(conn.last_insert_rowid())
+}
+
+pub fn list_active_policies(conn: &Connection) -> Result<Vec<PolicyRule>, DomainError> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT id,domain,rule,active,created_at,updated_at
+             FROM policy_rules WHERE active = 1",
+        )
+        .map_err(map_err)?;
+
+    let rows = stmt
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, i32>(3)?,
+                row.get::<_, String>(4)?,
+                row.get::<_, String>(5)?,
+            ))
+        })
+        .map_err(map_err)?;
+
+    rows.collect::<rusqlite::Result<Vec<_>>>()
+        .map_err(map_err)?
+        .into_iter()
+        .map(
+            |(id, domain_s, rule_json, active, created_at_s, updated_at_s)| {
+                let domain = policy_domain_from_str(&domain_s)?;
+                let rule: PolicyDefinition = serde_json::from_str(&rule_json)
+                    .map_err(|e| DomainError::Storage(e.to_string()))?;
+                let created_at = created_at_s
+                    .parse::<chrono::DateTime<chrono::Utc>>()
+                    .map_err(|e| DomainError::Storage(e.to_string()))?;
+                let updated_at = updated_at_s
+                    .parse::<chrono::DateTime<chrono::Utc>>()
+                    .map_err(|e| DomainError::Storage(e.to_string()))?;
+                Ok(PolicyRule {
+                    id,
+                    domain,
+                    rule,
+                    active: active != 0,
+                    created_at,
+                    updated_at,
+                })
+            },
+        )
+        .collect()
+}
+
+/// Extension trait to add `.optional()` on rusqlite query results.
+trait OptionalExt<T> {
+    fn optional(self) -> rusqlite::Result<Option<T>>;
+}
+
+impl<T> OptionalExt<T> for rusqlite::Result<T> {
+    fn optional(self) -> rusqlite::Result<Option<T>> {
+        match self {
+            Ok(v) => Ok(Some(v)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+}

--- a/crates/agileplus-sqlite/src/repository/metrics.rs
+++ b/crates/agileplus-sqlite/src/repository/metrics.rs
@@ -1,0 +1,97 @@
+//! Metrics repository — CRUD for the `metrics` table.
+
+use rusqlite::{Connection, params};
+
+use agileplus_domain::{domain::metric::Metric, error::DomainError};
+
+fn map_err(e: rusqlite::Error) -> DomainError {
+    DomainError::Storage(e.to_string())
+}
+
+pub fn record_metric(conn: &Connection, metric: &Metric) -> Result<i64, DomainError> {
+    let metadata_s = metric
+        .metadata
+        .as_ref()
+        .map(serde_json::to_string)
+        .transpose()
+        .map_err(|e| DomainError::Storage(e.to_string()))?;
+
+    conn.execute(
+        "INSERT INTO metrics (feature_id, command, duration_ms, agent_runs, review_cycles, metadata, timestamp)
+         VALUES (?1,?2,?3,?4,?5,?6,?7)",
+        params![
+            metric.feature_id,
+            metric.command,
+            metric.duration_ms,
+            metric.agent_runs,
+            metric.review_cycles,
+            metadata_s,
+            metric.timestamp.to_rfc3339(),
+        ],
+    )
+    .map_err(map_err)?;
+
+    Ok(conn.last_insert_rowid())
+}
+
+pub fn get_metrics_by_feature(
+    conn: &Connection,
+    feature_id: i64,
+) -> Result<Vec<Metric>, DomainError> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT id,feature_id,command,duration_ms,agent_runs,review_cycles,metadata,timestamp
+             FROM metrics WHERE feature_id = ?1 ORDER BY timestamp",
+        )
+        .map_err(map_err)?;
+
+    let rows = stmt
+        .query_map(params![feature_id], |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, Option<i64>>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, i64>(3)?,
+                row.get::<_, i32>(4)?,
+                row.get::<_, i32>(5)?,
+                row.get::<_, Option<String>>(6)?,
+                row.get::<_, String>(7)?,
+            ))
+        })
+        .map_err(map_err)?;
+
+    rows.collect::<rusqlite::Result<Vec<_>>>()
+        .map_err(map_err)?
+        .into_iter()
+        .map(
+            |(
+                id,
+                feature_id,
+                command,
+                duration_ms,
+                agent_runs,
+                review_cycles,
+                metadata_s,
+                timestamp_s,
+            )| {
+                let metadata = metadata_s
+                    .map(|s| serde_json::from_str(&s))
+                    .transpose()
+                    .map_err(|e: serde_json::Error| DomainError::Storage(e.to_string()))?;
+                let timestamp = timestamp_s
+                    .parse::<chrono::DateTime<chrono::Utc>>()
+                    .map_err(|e| DomainError::Storage(e.to_string()))?;
+                Ok(Metric {
+                    id,
+                    feature_id,
+                    command,
+                    duration_ms,
+                    agent_runs,
+                    review_cycles,
+                    metadata,
+                    timestamp,
+                })
+            },
+        )
+        .collect()
+}

--- a/crates/agileplus-sqlite/src/repository/mod.rs
+++ b/crates/agileplus-sqlite/src/repository/mod.rs
@@ -1,0 +1,14 @@
+//! Repository implementations for the SQLite adapter.
+
+pub mod audit;
+pub mod backlog;
+pub mod cycles;
+pub mod events;
+pub mod evidence;
+pub mod features;
+pub mod governance;
+pub mod metrics;
+pub mod modules;
+pub mod projects;
+pub mod sync_mappings;
+pub mod work_packages;

--- a/crates/agileplus-sqlite/src/repository/modules/crud.rs
+++ b/crates/agileplus-sqlite/src/repository/modules/crud.rs
@@ -1,0 +1,220 @@
+use rusqlite::{Connection, params};
+
+use agileplus_domain::{
+    domain::module::{Module, ModuleWithFeatures},
+    error::DomainError,
+};
+
+use crate::repository::features::map_err;
+
+use super::mappers::{OptionalExt, row_to_feature, row_to_module};
+
+/// Create a module. Returns the new row ID.
+///
+/// Detects circular references via a recursive CTE before inserting.
+pub fn create_module(conn: &Connection, module: &Module) -> Result<i64, DomainError> {
+    if let Some(parent_id) = module.parent_module_id {
+        let parent_exists: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM modules WHERE id = ?1",
+                params![parent_id],
+                |row| row.get(0),
+            )
+            .map_err(map_err)?;
+        if parent_exists == 0 {
+            return Err(DomainError::ModuleNotFound(parent_id.to_string()));
+        }
+    }
+
+    let now = chrono::Utc::now().to_rfc3339();
+    conn.execute(
+        "INSERT INTO modules (slug, friendly_name, description, parent_module_id, created_at, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        params![
+            module.slug,
+            module.friendly_name,
+            module.description,
+            module.parent_module_id,
+            now,
+            now,
+        ],
+    )
+    .map_err(map_err)?;
+    Ok(conn.last_insert_rowid())
+}
+
+pub fn get_module(conn: &Connection, id: i64) -> Result<Option<Module>, DomainError> {
+    conn.query_row(
+        "SELECT id, slug, friendly_name, description, parent_module_id, created_at, updated_at
+         FROM modules WHERE id = ?1",
+        params![id],
+        row_to_module,
+    )
+    .optional()
+    .map_err(map_err)
+}
+
+pub fn get_module_by_slug(conn: &Connection, slug: &str) -> Result<Option<Module>, DomainError> {
+    conn.query_row(
+        "SELECT id, slug, friendly_name, description, parent_module_id, created_at, updated_at
+         FROM modules WHERE slug = ?1",
+        params![slug],
+        row_to_module,
+    )
+    .optional()
+    .map_err(map_err)
+}
+
+pub fn update_module(
+    conn: &Connection,
+    id: i64,
+    friendly_name: &str,
+    description: Option<&str>,
+) -> Result<(), DomainError> {
+    let slug = agileplus_domain::domain::module::Module::slug_from_name(friendly_name);
+    let now = chrono::Utc::now().to_rfc3339();
+    let rows = conn
+        .execute(
+            "UPDATE modules SET slug = ?1, friendly_name = ?2, description = ?3, updated_at = ?4
+             WHERE id = ?5",
+            params![slug, friendly_name, description, now, id],
+        )
+        .map_err(map_err)?;
+    if rows == 0 {
+        return Err(DomainError::ModuleNotFound(id.to_string()));
+    }
+    Ok(())
+}
+
+/// Delete a module. Fails with `ModuleHasDependents` if child modules or owned features exist.
+pub fn delete_module(conn: &Connection, id: i64) -> Result<(), DomainError> {
+    let child_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM modules WHERE parent_module_id = ?1",
+            params![id],
+            |row| row.get(0),
+        )
+        .map_err(map_err)?;
+    if child_count > 0 {
+        return Err(DomainError::ModuleHasDependents(format!(
+            "module {id} has {child_count} child module(s)"
+        )));
+    }
+
+    let feature_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM features WHERE module_id = ?1",
+            params![id],
+            |row| row.get(0),
+        )
+        .map_err(map_err)?;
+    if feature_count > 0 {
+        return Err(DomainError::ModuleHasDependents(format!(
+            "module {id} owns {feature_count} feature(s)"
+        )));
+    }
+
+    let rows = conn
+        .execute("DELETE FROM modules WHERE id = ?1", params![id])
+        .map_err(map_err)?;
+    if rows == 0 {
+        return Err(DomainError::ModuleNotFound(id.to_string()));
+    }
+    Ok(())
+}
+
+pub fn list_root_modules(conn: &Connection) -> Result<Vec<Module>, DomainError> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, slug, friendly_name, description, parent_module_id, created_at, updated_at
+             FROM modules WHERE parent_module_id IS NULL ORDER BY friendly_name",
+        )
+        .map_err(map_err)?;
+    let rows = stmt.query_map([], row_to_module).map_err(map_err)?;
+    rows.collect::<rusqlite::Result<Vec<_>>>().map_err(map_err)
+}
+
+pub fn list_child_modules(conn: &Connection, parent_id: i64) -> Result<Vec<Module>, DomainError> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, slug, friendly_name, description, parent_module_id, created_at, updated_at
+             FROM modules WHERE parent_module_id = ?1 ORDER BY friendly_name",
+        )
+        .map_err(map_err)?;
+    let rows = stmt
+        .query_map(params![parent_id], row_to_module)
+        .map_err(map_err)?;
+    rows.collect::<rusqlite::Result<Vec<_>>>().map_err(map_err)
+}
+
+/// Detect whether setting `proposed_parent_id` as the parent of `module_id` would
+/// create a cycle in the module hierarchy using a recursive CTE.
+pub fn would_create_circular_ref(
+    conn: &Connection,
+    module_id: i64,
+    proposed_parent_id: i64,
+) -> Result<bool, DomainError> {
+    let count: i64 = conn
+        .query_row(
+            "WITH RECURSIVE ancestors(id) AS (
+                SELECT ?1
+                UNION ALL
+                SELECT m.parent_module_id
+                FROM modules m
+                INNER JOIN ancestors a ON m.id = a.id
+                WHERE m.parent_module_id IS NOT NULL
+            )
+            SELECT COUNT(*) FROM ancestors WHERE id = ?2",
+            params![proposed_parent_id, module_id],
+            |row| row.get(0),
+        )
+        .map_err(map_err)?;
+    Ok(count > 0)
+}
+
+pub fn get_module_with_features(
+    conn: &Connection,
+    id: i64,
+) -> Result<Option<ModuleWithFeatures>, DomainError> {
+    let module = match get_module(conn, id)? {
+        Some(m) => m,
+        None => return Ok(None),
+    };
+
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, slug, friendly_name, state, spec_hash, target_branch, created_at, updated_at
+             FROM features WHERE module_id = ?1 ORDER BY created_at",
+        )
+        .map_err(map_err)?;
+    let owned_features = stmt
+        .query_map(params![id], row_to_feature)
+        .map_err(map_err)?
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .map_err(map_err)?;
+
+    let mut stmt = conn
+        .prepare(
+            "SELECT f.id, f.slug, f.friendly_name, f.state, f.spec_hash, f.target_branch,
+                    f.created_at, f.updated_at
+             FROM features f
+             INNER JOIN module_feature_tags t ON f.id = t.feature_id
+             WHERE t.module_id = ?1
+             ORDER BY f.created_at",
+        )
+        .map_err(map_err)?;
+    let tagged_features = stmt
+        .query_map(params![id], row_to_feature)
+        .map_err(map_err)?
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .map_err(map_err)?;
+
+    let child_modules = list_child_modules(conn, id)?;
+
+    Ok(Some(ModuleWithFeatures {
+        module,
+        owned_features,
+        tagged_features,
+        child_modules,
+    }))
+}

--- a/crates/agileplus-sqlite/src/repository/modules/mappers.rs
+++ b/crates/agileplus-sqlite/src/repository/modules/mappers.rs
@@ -1,0 +1,131 @@
+use rusqlite::Row;
+
+use agileplus_domain::domain::{feature::Feature, module::Module, state_machine::FeatureState};
+
+pub(super) fn row_to_module(row: &Row<'_>) -> rusqlite::Result<Module> {
+    let id: i64 = row.get(0)?;
+    let slug: String = row.get(1)?;
+    let friendly_name: String = row.get(2)?;
+    let description: Option<String> = row.get(3)?;
+    let parent_module_id: Option<i64> = row.get(4)?;
+    let created_at_str: String = row.get(5)?;
+    let updated_at_str: String = row.get(6)?;
+
+    let created_at = created_at_str
+        .parse::<chrono::DateTime<chrono::Utc>>()
+        .map_err(|e| {
+            rusqlite::Error::FromSqlConversionFailure(
+                5,
+                rusqlite::types::Type::Text,
+                Box::new(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    e.to_string(),
+                )),
+            )
+        })?;
+
+    let updated_at = updated_at_str
+        .parse::<chrono::DateTime<chrono::Utc>>()
+        .map_err(|e| {
+            rusqlite::Error::FromSqlConversionFailure(
+                6,
+                rusqlite::types::Type::Text,
+                Box::new(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    e.to_string(),
+                )),
+            )
+        })?;
+
+    Ok(Module {
+        id,
+        slug,
+        friendly_name,
+        description,
+        parent_module_id,
+        created_at,
+        updated_at,
+    })
+}
+
+pub(super) fn row_to_feature(row: &Row<'_>) -> rusqlite::Result<Feature> {
+    let id: i64 = row.get(0)?;
+    let slug: String = row.get(1)?;
+    let friendly_name: String = row.get(2)?;
+    let state_str: String = row.get(3)?;
+    let spec_hash_bytes: Vec<u8> = row.get(4)?;
+    let target_branch: String = row.get(5)?;
+    let created_at_str: String = row.get(6)?;
+    let updated_at_str: String = row.get(7)?;
+
+    let state = state_str.parse::<FeatureState>().map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(
+            3,
+            rusqlite::types::Type::Text,
+            Box::new(std::io::Error::new(std::io::ErrorKind::InvalidData, e)),
+        )
+    })?;
+
+    let mut spec_hash = [0u8; 32];
+    if spec_hash_bytes.len() == 32 {
+        spec_hash.copy_from_slice(&spec_hash_bytes);
+    }
+
+    let created_at = created_at_str
+        .parse::<chrono::DateTime<chrono::Utc>>()
+        .map_err(|e| {
+            rusqlite::Error::FromSqlConversionFailure(
+                6,
+                rusqlite::types::Type::Text,
+                Box::new(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    e.to_string(),
+                )),
+            )
+        })?;
+
+    let updated_at = updated_at_str
+        .parse::<chrono::DateTime<chrono::Utc>>()
+        .map_err(|e| {
+            rusqlite::Error::FromSqlConversionFailure(
+                7,
+                rusqlite::types::Type::Text,
+                Box::new(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    e.to_string(),
+                )),
+            )
+        })?;
+
+    Ok(Feature {
+        id,
+        slug,
+        friendly_name,
+        state,
+        spec_hash,
+        target_branch,
+        plane_issue_id: None,
+        plane_state_id: None,
+        labels: Vec::new(),
+        module_id: None,
+        project_id: None,
+        created_at_commit: None,
+        last_modified_commit: None,
+        created_at,
+        updated_at,
+    })
+}
+
+pub(super) trait OptionalExt<T> {
+    fn optional(self) -> rusqlite::Result<Option<T>>;
+}
+
+impl<T> OptionalExt<T> for rusqlite::Result<T> {
+    fn optional(self) -> rusqlite::Result<Option<T>> {
+        match self {
+            Ok(v) => Ok(Some(v)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+}

--- a/crates/agileplus-sqlite/src/repository/modules/mod.rs
+++ b/crates/agileplus-sqlite/src/repository/modules/mod.rs
@@ -1,0 +1,13 @@
+//! Module repository -- CRUD operations for the `modules` table and `module_feature_tags`.
+//!
+//! Traces to: FR-M01, FR-M02, FR-M04, FR-M07
+
+mod crud;
+mod mappers;
+mod tags;
+
+pub use crud::{
+    create_module, delete_module, get_module, get_module_by_slug, get_module_with_features,
+    list_child_modules, list_root_modules, update_module, would_create_circular_ref,
+};
+pub use tags::{tag_feature_to_module, untag_feature_from_module};

--- a/crates/agileplus-sqlite/src/repository/modules/tags.rs
+++ b/crates/agileplus-sqlite/src/repository/modules/tags.rs
@@ -1,0 +1,31 @@
+use rusqlite::{Connection, params};
+
+use agileplus_domain::domain::module::ModuleFeatureTag;
+use agileplus_domain::error::DomainError;
+
+use crate::repository::features::map_err;
+
+/// Tag a feature to a module. Idempotent (INSERT OR IGNORE).
+pub fn tag_feature_to_module(conn: &Connection, tag: &ModuleFeatureTag) -> Result<(), DomainError> {
+    let now = chrono::Utc::now().to_rfc3339();
+    conn.execute(
+        "INSERT OR IGNORE INTO module_feature_tags (module_id, feature_id, created_at)
+         VALUES (?1, ?2, ?3)",
+        params![tag.module_id, tag.feature_id, now],
+    )
+    .map_err(map_err)?;
+    Ok(())
+}
+
+pub fn untag_feature_from_module(
+    conn: &Connection,
+    module_id: i64,
+    feature_id: i64,
+) -> Result<(), DomainError> {
+    conn.execute(
+        "DELETE FROM module_feature_tags WHERE module_id = ?1 AND feature_id = ?2",
+        params![module_id, feature_id],
+    )
+    .map_err(map_err)?;
+    Ok(())
+}

--- a/crates/agileplus-sqlite/src/repository/projects.rs
+++ b/crates/agileplus-sqlite/src/repository/projects.rs
@@ -1,0 +1,60 @@
+//! Project repository functions.
+//!
+//! Traceability: FR-STORE-PROJECT
+
+use chrono::DateTime;
+use rusqlite::{Connection, params};
+
+use agileplus_domain::domain::project::Project;
+use agileplus_domain::error::DomainError;
+
+fn map_err(e: rusqlite::Error) -> DomainError {
+    DomainError::Storage(e.to_string())
+}
+
+fn parse_dt(s: &str) -> DateTime<chrono::Utc> {
+    DateTime::parse_from_rfc3339(s)
+        .map(|dt| dt.with_timezone(&chrono::Utc))
+        .unwrap_or_else(|_| chrono::Utc::now())
+}
+
+fn row_to_project(row: &rusqlite::Row<'_>) -> rusqlite::Result<Project> {
+    let created_at: String = row.get(4)?;
+    let updated_at: String = row.get(5)?;
+    Ok(Project {
+        id: row.get(0)?,
+        slug: row.get(1)?,
+        name: row.get(2)?,
+        description: row.get(3)?,
+        created_at: parse_dt(&created_at),
+        updated_at: parse_dt(&updated_at),
+    })
+}
+
+/// Create a project and return its new row ID.
+pub fn create_project(conn: &Connection, project: &Project) -> Result<i64, DomainError> {
+    let now = chrono::Utc::now().to_rfc3339();
+    conn.execute(
+        "INSERT INTO projects (slug, name, description, created_at, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5)",
+        params![project.slug, project.name, project.description, now, now],
+    )
+    .map_err(map_err)?;
+    Ok(conn.last_insert_rowid())
+}
+
+/// Look up a project by its slug. Returns None if not found.
+pub fn get_project_by_slug(conn: &Connection, slug: &str) -> Result<Option<Project>, DomainError> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, slug, name, description, created_at, updated_at \
+             FROM projects WHERE slug = ?1",
+        )
+        .map_err(map_err)?;
+
+    match stmt.query_row(params![slug], row_to_project) {
+        Ok(project) => Ok(Some(project)),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(e) => Err(map_err(e)),
+    }
+}

--- a/crates/agileplus-sqlite/src/repository/sync_mappings.rs
+++ b/crates/agileplus-sqlite/src/repository/sync_mappings.rs
@@ -1,0 +1,137 @@
+//! Sync mapping repository functions.
+//!
+//! Traceability: WP06-T033
+
+use chrono::Utc;
+use rusqlite::{Connection, params};
+
+use agileplus_domain::domain::sync_mapping::{SyncDirection, SyncMapping};
+use agileplus_domain::error::DomainError;
+
+fn map_err(e: rusqlite::Error) -> DomainError {
+    DomainError::Storage(e.to_string())
+}
+
+/// Look up a sync mapping by entity_type and entity_id.
+pub fn get_sync_mapping(
+    conn: &Connection,
+    entity_type: &str,
+    entity_id: i64,
+) -> Result<Option<SyncMapping>, DomainError> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, entity_type, entity_id, plane_issue_id, content_hash, \
+             last_synced_at, sync_direction, conflict_count \
+             FROM sync_mappings WHERE entity_type = ?1 AND entity_id = ?2",
+        )
+        .map_err(map_err)?;
+
+    let result = stmt.query_row(params![entity_type, entity_id], |row| {
+        Ok(SyncMapping {
+            id: row.get(0)?,
+            entity_type: row.get(1)?,
+            entity_id: row.get(2)?,
+            plane_issue_id: row.get(3)?,
+            content_hash: row.get(4)?,
+            last_synced_at: row.get::<_, String>(5).map(|s| {
+                chrono::DateTime::parse_from_rfc3339(&s)
+                    .map(|dt| dt.with_timezone(&Utc))
+                    .unwrap_or_else(|_| Utc::now())
+            })?,
+            sync_direction: row.get::<_, String>(6).map(|s| match s.as_str() {
+                "push" => SyncDirection::Push,
+                "pull" => SyncDirection::Pull,
+                _ => SyncDirection::Bidirectional,
+            })?,
+            conflict_count: row.get(7)?,
+        })
+    });
+
+    match result {
+        Ok(m) => Ok(Some(m)),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(e) => Err(map_err(e)),
+    }
+}
+
+/// Insert or update a sync mapping (upsert on entity_type + entity_id).
+pub fn upsert_sync_mapping(conn: &Connection, mapping: &SyncMapping) -> Result<(), DomainError> {
+    conn.execute(
+        "INSERT INTO sync_mappings (entity_type, entity_id, plane_issue_id, content_hash, \
+         last_synced_at, sync_direction, conflict_count) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7) \
+         ON CONFLICT (entity_type, entity_id) DO UPDATE SET \
+             plane_issue_id = excluded.plane_issue_id, \
+             content_hash = excluded.content_hash, \
+             last_synced_at = excluded.last_synced_at, \
+             sync_direction = excluded.sync_direction, \
+             conflict_count = excluded.conflict_count",
+        params![
+            mapping.entity_type,
+            mapping.entity_id,
+            mapping.plane_issue_id,
+            mapping.content_hash,
+            mapping.last_synced_at.to_rfc3339(),
+            mapping.sync_direction.to_string(),
+            mapping.conflict_count,
+        ],
+    )
+    .map_err(map_err)?;
+    Ok(())
+}
+
+/// Look up a sync mapping by entity_type and plane_issue_id.
+pub fn get_sync_mapping_by_plane_id(
+    conn: &Connection,
+    entity_type: &str,
+    plane_issue_id: &str,
+) -> Result<Option<SyncMapping>, DomainError> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, entity_type, entity_id, plane_issue_id, content_hash, \
+             last_synced_at, sync_direction, conflict_count \
+             FROM sync_mappings WHERE entity_type = ?1 AND plane_issue_id = ?2",
+        )
+        .map_err(map_err)?;
+
+    let result = stmt.query_row(params![entity_type, plane_issue_id], |row| {
+        Ok(SyncMapping {
+            id: row.get(0)?,
+            entity_type: row.get(1)?,
+            entity_id: row.get(2)?,
+            plane_issue_id: row.get(3)?,
+            content_hash: row.get(4)?,
+            last_synced_at: row.get::<_, String>(5).map(|s| {
+                chrono::DateTime::parse_from_rfc3339(&s)
+                    .map(|dt| dt.with_timezone(&Utc))
+                    .unwrap_or_else(|_| Utc::now())
+            })?,
+            sync_direction: row.get::<_, String>(6).map(|s| match s.as_str() {
+                "push" => SyncDirection::Push,
+                "pull" => SyncDirection::Pull,
+                _ => SyncDirection::Bidirectional,
+            })?,
+            conflict_count: row.get(7)?,
+        })
+    });
+
+    match result {
+        Ok(m) => Ok(Some(m)),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(e) => Err(map_err(e)),
+    }
+}
+
+/// Delete a sync mapping by entity_type and entity_id.
+pub fn delete_sync_mapping(
+    conn: &Connection,
+    entity_type: &str,
+    entity_id: i64,
+) -> Result<(), DomainError> {
+    conn.execute(
+        "DELETE FROM sync_mappings WHERE entity_type = ?1 AND entity_id = ?2",
+        params![entity_type, entity_id],
+    )
+    .map_err(map_err)?;
+    Ok(())
+}

--- a/crates/agileplus-sqlite/src/repository/work_packages.rs
+++ b/crates/agileplus-sqlite/src/repository/work_packages.rs
@@ -1,0 +1,320 @@
+//! Work package repository — CRUD operations for `work_packages` and `wp_dependencies`.
+
+use rusqlite::{Connection, Row, params};
+
+use agileplus_domain::{
+    domain::work_package::{DependencyType, PrState, WorkPackage, WpDependency, WpState},
+    error::DomainError,
+};
+
+fn map_err(e: rusqlite::Error) -> DomainError {
+    DomainError::Storage(e.to_string())
+}
+
+fn wp_state_str(s: WpState) -> &'static str {
+    match s {
+        WpState::Planned => "planned",
+        WpState::Doing => "doing",
+        WpState::Review => "review",
+        WpState::Done => "done",
+        WpState::Blocked => "blocked",
+    }
+}
+
+fn wp_state_from_str(s: &str) -> Result<WpState, DomainError> {
+    match s {
+        "planned" => Ok(WpState::Planned),
+        "doing" => Ok(WpState::Doing),
+        "review" => Ok(WpState::Review),
+        "done" => Ok(WpState::Done),
+        "blocked" => Ok(WpState::Blocked),
+        _ => Err(DomainError::Storage(format!("invalid wp state: {s}"))),
+    }
+}
+
+fn pr_state_str(s: PrState) -> &'static str {
+    match s {
+        PrState::Open => "open",
+        PrState::Review => "review",
+        PrState::ChangesRequested => "changes_requested",
+        PrState::Approved => "approved",
+        PrState::Merged => "merged",
+    }
+}
+
+fn dep_type_str(d: DependencyType) -> &'static str {
+    match d {
+        DependencyType::Explicit => "explicit",
+        DependencyType::FileOverlap => "file_overlap",
+        DependencyType::Data => "data",
+    }
+}
+
+fn dep_type_from_str(s: &str) -> Result<DependencyType, DomainError> {
+    match s {
+        "explicit" => Ok(DependencyType::Explicit),
+        "file_overlap" => Ok(DependencyType::FileOverlap),
+        "data" => Ok(DependencyType::Data),
+        _ => Err(DomainError::Storage(format!("invalid dep type: {s}"))),
+    }
+}
+
+fn row_to_wp(row: &Row<'_>) -> rusqlite::Result<WorkPackage> {
+    let id: i64 = row.get(0)?;
+    let feature_id: i64 = row.get(1)?;
+    let title: String = row.get(2)?;
+    let state_s: String = row.get(3)?;
+    let sequence: i32 = row.get(4)?;
+    let file_scope_json: String = row.get(5)?;
+    let acceptance_criteria: String = row.get(6)?;
+    let agent_id: Option<String> = row.get(7)?;
+    let pr_url: Option<String> = row.get(8)?;
+    let pr_state_s: Option<String> = row.get(9)?;
+    let worktree_path: Option<String> = row.get(10)?;
+    let created_at_s: String = row.get(11)?;
+    let updated_at_s: String = row.get(12)?;
+
+    let state = wp_state_from_str(&state_s).map_err(|_| {
+        rusqlite::Error::FromSqlConversionFailure(
+            3,
+            rusqlite::types::Type::Text,
+            Box::new(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "bad wp state",
+            )),
+        )
+    })?;
+
+    // We use serde_json to parse, but can't use ? directly in rusqlite's Result<T>
+    let file_scope: Vec<String> = serde_json::from_str(&file_scope_json).unwrap_or_default();
+
+    let pr_state = pr_state_s.as_deref().map(|s| match s {
+        "open" => PrState::Open,
+        "review" => PrState::Review,
+        "changes_requested" => PrState::ChangesRequested,
+        "approved" => PrState::Approved,
+        "merged" => PrState::Merged,
+        _ => PrState::Open, // fallback
+    });
+
+    let created_at = created_at_s
+        .parse::<chrono::DateTime<chrono::Utc>>()
+        .map_err(|e| {
+            rusqlite::Error::FromSqlConversionFailure(
+                11,
+                rusqlite::types::Type::Text,
+                Box::new(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    e.to_string(),
+                )),
+            )
+        })?;
+
+    let updated_at = updated_at_s
+        .parse::<chrono::DateTime<chrono::Utc>>()
+        .map_err(|e| {
+            rusqlite::Error::FromSqlConversionFailure(
+                12,
+                rusqlite::types::Type::Text,
+                Box::new(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    e.to_string(),
+                )),
+            )
+        })?;
+
+    Ok(WorkPackage {
+        id,
+        feature_id,
+        title,
+        state,
+        sequence,
+        file_scope,
+        acceptance_criteria,
+        agent_id,
+        pr_url,
+        pr_state,
+        worktree_path,
+        plane_sub_issue_id: None,
+        created_at,
+        updated_at,
+        base_commit: None,
+        head_commit: None,
+    })
+}
+
+pub fn create_work_package(conn: &Connection, wp: &WorkPackage) -> Result<i64, DomainError> {
+    let file_scope_json =
+        serde_json::to_string(&wp.file_scope).map_err(|e| DomainError::Storage(e.to_string()))?;
+    let pr_state_s = wp.pr_state.map(pr_state_str);
+
+    conn.execute(
+        "INSERT INTO work_packages
+         (feature_id, title, state, sequence, file_scope, acceptance_criteria,
+          agent_id, pr_url, pr_state, worktree_path, created_at, updated_at)
+         VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12)",
+        params![
+            wp.feature_id,
+            wp.title,
+            wp_state_str(wp.state),
+            wp.sequence,
+            file_scope_json,
+            wp.acceptance_criteria,
+            wp.agent_id,
+            wp.pr_url,
+            pr_state_s,
+            wp.worktree_path,
+            wp.created_at.to_rfc3339(),
+            wp.updated_at.to_rfc3339(),
+        ],
+    )
+    .map_err(map_err)?;
+    Ok(conn.last_insert_rowid())
+}
+
+pub fn get_work_package(conn: &Connection, id: i64) -> Result<Option<WorkPackage>, DomainError> {
+    conn.query_row(
+        "SELECT id,feature_id,title,state,sequence,file_scope,acceptance_criteria,
+                agent_id,pr_url,pr_state,worktree_path,created_at,updated_at
+         FROM work_packages WHERE id = ?1",
+        params![id],
+        row_to_wp,
+    )
+    .optional()
+    .map_err(map_err)
+}
+
+pub fn update_wp_state(conn: &Connection, id: i64, state: WpState) -> Result<(), DomainError> {
+    let now = chrono::Utc::now().to_rfc3339();
+    conn.execute(
+        "UPDATE work_packages SET state = ?1, updated_at = ?2 WHERE id = ?3",
+        params![wp_state_str(state), now, id],
+    )
+    .map_err(map_err)?;
+    Ok(())
+}
+
+pub fn update_work_package(conn: &Connection, wp: &WorkPackage) -> Result<(), DomainError> {
+    let now = chrono::Utc::now().to_rfc3339();
+    let file_scope_json =
+        serde_json::to_string(&wp.file_scope).map_err(|e| DomainError::Storage(e.to_string()))?;
+    let pr_state_s = wp.pr_state.map(pr_state_str);
+
+    conn.execute(
+        "UPDATE work_packages SET title = ?1, state = ?2, sequence = ?3, file_scope = ?4, \
+         acceptance_criteria = ?5, agent_id = ?6, pr_url = ?7, pr_state = ?8, worktree_path = ?9, \
+         updated_at = ?10 WHERE id = ?11",
+        params![
+            wp.title,
+            wp_state_str(wp.state),
+            wp.sequence,
+            file_scope_json,
+            wp.acceptance_criteria,
+            wp.agent_id,
+            wp.pr_url,
+            pr_state_s,
+            wp.worktree_path,
+            now,
+            wp.id
+        ],
+    )
+    .map_err(map_err)?;
+    Ok(())
+}
+
+pub fn list_wps_by_feature(
+    conn: &Connection,
+    feature_id: i64,
+) -> Result<Vec<WorkPackage>, DomainError> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT id,feature_id,title,state,sequence,file_scope,acceptance_criteria,
+                    agent_id,pr_url,pr_state,worktree_path,created_at,updated_at
+             FROM work_packages WHERE feature_id = ?1 ORDER BY sequence",
+        )
+        .map_err(map_err)?;
+
+    let rows = stmt
+        .query_map(params![feature_id], row_to_wp)
+        .map_err(map_err)?;
+    rows.collect::<rusqlite::Result<Vec<_>>>().map_err(map_err)
+}
+
+pub fn add_wp_dependency(conn: &Connection, dep: &WpDependency) -> Result<(), DomainError> {
+    conn.execute(
+        "INSERT OR IGNORE INTO wp_dependencies (wp_id, depends_on, dep_type)
+         VALUES (?1, ?2, ?3)",
+        params![dep.wp_id, dep.depends_on, dep_type_str(dep.dep_type)],
+    )
+    .map_err(map_err)?;
+    Ok(())
+}
+
+pub fn get_wp_dependencies(
+    conn: &Connection,
+    wp_id: i64,
+) -> Result<Vec<WpDependency>, DomainError> {
+    let mut stmt = conn
+        .prepare("SELECT wp_id, depends_on, dep_type FROM wp_dependencies WHERE wp_id = ?1")
+        .map_err(map_err)?;
+
+    let rows = stmt
+        .query_map(params![wp_id], |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, i64>(1)?,
+                row.get::<_, String>(2)?,
+            ))
+        })
+        .map_err(map_err)?;
+
+    let mut deps = Vec::new();
+    for row in rows {
+        let (wp_id, depends_on, dep_type_s) = row.map_err(map_err)?;
+        let dep_type = dep_type_from_str(&dep_type_s)?;
+        deps.push(WpDependency {
+            wp_id,
+            depends_on,
+            dep_type,
+        });
+    }
+    Ok(deps)
+}
+
+pub fn get_ready_wps(conn: &Connection, feature_id: i64) -> Result<Vec<WorkPackage>, DomainError> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT wp.id,wp.feature_id,wp.title,wp.state,wp.sequence,wp.file_scope,
+                    wp.acceptance_criteria,wp.agent_id,wp.pr_url,wp.pr_state,
+                    wp.worktree_path,wp.created_at,wp.updated_at
+             FROM work_packages wp
+             WHERE wp.feature_id = ?1 AND wp.state = 'planned'
+               AND NOT EXISTS (
+                   SELECT 1 FROM wp_dependencies d
+                   JOIN work_packages dep ON dep.id = d.depends_on
+                   WHERE d.wp_id = wp.id AND dep.state != 'done'
+               )
+             ORDER BY wp.sequence",
+        )
+        .map_err(map_err)?;
+
+    let rows = stmt
+        .query_map(params![feature_id], row_to_wp)
+        .map_err(map_err)?;
+    rows.collect::<rusqlite::Result<Vec<_>>>().map_err(map_err)
+}
+
+/// Extension trait to add `.optional()` on rusqlite query results.
+trait OptionalExt<T> {
+    fn optional(self) -> rusqlite::Result<Option<T>>;
+}
+
+impl<T> OptionalExt<T> for rusqlite::Result<T> {
+    fn optional(self) -> rusqlite::Result<Option<T>> {
+        match self {
+            Ok(v) => Ok(Some(v)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+}

--- a/crates/agileplus-sqlite/src/tests.rs
+++ b/crates/agileplus-sqlite/src/tests.rs
@@ -1,0 +1,4 @@
+#[path = "lib/tests/mod.rs"]
+mod tests_impl;
+
+use crate::SqliteStorageAdapter;


### PR DESCRIPTION
## Summary

- Fills the empty `agileplus-domain` crate stub with all aggregate types, error variants, and hexagonal port traits required by downstream crates (`events`, `sqlite`, `fixtures`, `dashboard`)
- Derived exact struct shapes and field names from adapter usage in `agileplus-sqlite` — no guessing, no breaking changes to existing code
- All 4 domain-related crates now build cleanly: `agileplus-domain`, `agileplus-events`, `agileplus-sqlite`, `agileplus-fixtures`

## Key additions

| File | Content |
|------|---------|
| `domain/{event,snapshot,feature,work_package,module,cycle,project,metric,governance,audit,backlog,sync_mapping,state_machine}` | Minimal structs with serde derives, matching adapter field access exactly |
| `error.rs` | `DomainError` with all variants used by sqlite (`CycleNotFound`, `FeatureNotInModuleScope{feature_slug,module_slug}`, `Storage`, `NotFound`, `NotImplemented`, etc.) |
| `ports/{StoragePort, ContentStoragePort, VcsPort}` | Async trait definitions matching `SqliteStorageAdapter` impl signatures |
| `ports/vcs` | `BranchInfo`, `WorktreeInfo`, `MergeResult`, `ConflictInfo`, `FeatureArtifacts` value objects |
| `Cargo.toml` | Added serde/serde_json/thiserror/chrono/sha2 workspace deps |

## Pre-existing failures not introduced here

`agileplus-dashboard` still fails due to missing `.html` template files in the `templates/` directory — unrelated to this change, existed before.

## Test plan

- [x] `cargo build -p agileplus-domain` — clean (warnings only, no errors)
- [x] `cargo build -p agileplus-domain -p agileplus-events -p agileplus-sqlite -p agileplus-fixtures` — all pass
- [ ] `agileplus-dashboard` template files — out of scope for this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Foundational domain and persistence contracts affect every downstream crate; audit hash-chain and cycle/module scope rules are easy to get wrong, though the change is mostly additive with heavy test coverage.
> 
> **Overview**
> Replaces the **`agileplus-domain`** stub with a full domain layer: serde-backed aggregates (features, work packages, cycles, modules, backlog, governance, hash-chained audit/events), **`DomainError`**, and hexagonal **`StoragePort`**, **`ContentStoragePort`**, and **`VcsPort`** traits aligned with existing adapter call sites. **`Feature::transition`** and **`hash_entry`** for audit chaining are included; **`Cargo.toml`** picks up serde/chrono/sha2 workspace deps.
> 
> The same change set adds **`agileplus-sqlite`** as the persistence adapter: embedded SQL migrations, WAL + FK setup, **`SqliteStorageAdapter`** implementing the storage/content/event ports, repository modules, and broad async integration tests (including module/cycle scope rules and audit **`prev_hash`** enforcement). **`Cargo.lock`** grows for the new workspace crates and their Axum/Askama/rusqlite-style dependencies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca88bda2e7b77b3178084a72df301cbb4935e1a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->