### PR TITLE
feat(domain): add User/Epic/Story aggregates; harden Project constructor

### DIFF
--- a/crates/agileplus-domain/src/domain/epic.rs
+++ b/crates/agileplus-domain/src/domain/epic.rs
@@ -1,0 +1,157 @@
+//! Epic aggregate — a large body of work scoped to a project.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::str::FromStr;
+
+use crate::error::DomainError;
+
+/// Lifecycle status of an epic.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum EpicStatus {
+    Backlog,
+    Active,
+    Review,
+    Done,
+    Cancelled,
+}
+
+impl fmt::Display for EpicStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            EpicStatus::Backlog => "backlog",
+            EpicStatus::Active => "active",
+            EpicStatus::Review => "review",
+            EpicStatus::Done => "done",
+            EpicStatus::Cancelled => "cancelled",
+        };
+        write!(f, "{s}")
+    }
+}
+
+impl FromStr for EpicStatus {
+    type Err = DomainError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "backlog" => Ok(EpicStatus::Backlog),
+            "active" => Ok(EpicStatus::Active),
+            "review" => Ok(EpicStatus::Review),
+            "done" => Ok(EpicStatus::Done),
+            "cancelled" => Ok(EpicStatus::Cancelled),
+            _ => Err(DomainError::Validation(format!("unknown EpicStatus: {s}"))),
+        }
+    }
+}
+
+impl EpicStatus {
+    /// Returns `true` if a transition from `self` to `target` is allowed.
+    pub fn can_transition_to(self, target: EpicStatus) -> bool {
+        use EpicStatus::*;
+        matches!(
+            (self, target),
+            (Backlog, Active)
+                | (Active, Review)
+                | (Active, Cancelled)
+                | (Review, Done)
+                | (Review, Active)
+        )
+    }
+}
+
+/// An epic — a large, named unit of work belonging to a project.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Epic {
+    pub id: i64,
+    /// Owning project.
+    pub project_id: i64,
+    /// Human-readable title — must be non-empty.
+    pub title: String,
+    pub description: Option<String>,
+    pub status: EpicStatus,
+    /// Optional owner (user id).
+    pub owner_id: Option<i64>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl Epic {
+    /// Construct a new `Epic`. `title` must be non-empty.
+    pub fn new(project_id: i64, title: &str) -> Result<Self, DomainError> {
+        let title = title.trim();
+        if title.is_empty() {
+            return Err(DomainError::Validation(
+                "epic title must not be empty".to_string(),
+            ));
+        }
+        let now = Utc::now();
+        Ok(Self {
+            id: 0,
+            project_id,
+            title: title.to_string(),
+            description: None,
+            status: EpicStatus::Backlog,
+            owner_id: None,
+            created_at: now,
+            updated_at: now,
+        })
+    }
+
+    /// Attempt a status transition. Returns `Err(DomainError::InvalidTransition)`
+    /// if the transition is not permitted.
+    pub fn transition_status(&mut self, target: EpicStatus) -> Result<(), DomainError> {
+        if !self.status.can_transition_to(target) {
+            return Err(DomainError::InvalidTransition {
+                from: self.status.to_string(),
+                to: target.to_string(),
+                reason: "not an allowed epic status transition".to_string(),
+            });
+        }
+        self.status = target;
+        self.updated_at = Utc::now();
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_epic_construction() {
+        let e = Epic::new(1, "Authentication Overhaul").unwrap();
+        assert_eq!(e.title, "Authentication Overhaul");
+        assert_eq!(e.project_id, 1);
+        assert_eq!(e.status, EpicStatus::Backlog);
+    }
+
+    #[test]
+    fn rejects_empty_title() {
+        let err = Epic::new(1, "  ").unwrap_err();
+        assert!(matches!(err, DomainError::Validation(_)));
+    }
+
+    #[test]
+    fn valid_status_transition() {
+        let mut e = Epic::new(1, "Big Feature").unwrap();
+        e.transition_status(EpicStatus::Active).unwrap();
+        assert_eq!(e.status, EpicStatus::Active);
+        e.transition_status(EpicStatus::Review).unwrap();
+        assert_eq!(e.status, EpicStatus::Review);
+    }
+
+    #[test]
+    fn invalid_status_transition_rejected() {
+        let mut e = Epic::new(1, "Skipped Epic").unwrap();
+        // Backlog -> Done is not allowed
+        let err = e.transition_status(EpicStatus::Done).unwrap_err();
+        assert!(matches!(err, DomainError::InvalidTransition { .. }));
+    }
+
+    #[test]
+    fn title_trimmed_on_construction() {
+        let e = Epic::new(2, "  Trimmed  ").unwrap();
+        assert_eq!(e.title, "Trimmed");
+    }
+}

--- a/crates/agileplus-domain/src/domain/mod.rs
+++ b/crates/agileplus-domain/src/domain/mod.rs
@@ -3,6 +3,7 @@
 pub mod audit;
 pub mod backlog;
 pub mod cycle;
+pub mod epic;
 pub mod event;
 pub mod feature;
 pub mod governance;
@@ -11,5 +12,7 @@ pub mod module;
 pub mod project;
 pub mod snapshot;
 pub mod state_machine;
+pub mod story;
 pub mod sync_mapping;
+pub mod user;
 pub mod work_package;

--- a/crates/agileplus-domain/src/domain/project.rs
+++ b/crates/agileplus-domain/src/domain/project.rs
@@ -3,13 +3,94 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+use crate::error::DomainError;
+
 /// A project that owns modules, cycles, and features.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Project {
     pub id: i64,
+    /// URL-safe slug — must be non-empty and contain only `[a-z0-9-]`.
     pub slug: String,
+    /// Human-readable name — must be non-empty.
     pub name: String,
     pub description: Option<String>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+}
+
+impl Project {
+    /// Construct a new `Project`. `name` must be non-empty; `slug` must be
+    /// non-empty and consist only of lowercase ASCII alphanumerics and hyphens.
+    pub fn new(name: &str, slug: &str) -> Result<Self, DomainError> {
+        let name = name.trim();
+        if name.is_empty() {
+            return Err(DomainError::Validation(
+                "project name must not be empty".to_string(),
+            ));
+        }
+        let slug = slug.trim();
+        if slug.is_empty() {
+            return Err(DomainError::Validation(
+                "project slug must not be empty".to_string(),
+            ));
+        }
+        if !slug
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+        {
+            return Err(DomainError::Validation(
+                "project slug must contain only lowercase letters, digits, and hyphens".to_string(),
+            ));
+        }
+        let now = Utc::now();
+        Ok(Self {
+            id: 0,
+            slug: slug.to_string(),
+            name: name.to_string(),
+            description: None,
+            created_at: now,
+            updated_at: now,
+        })
+    }
+
+    /// Derive a slug from a human-readable name (same algorithm as `Module`).
+    pub fn slug_from_name(name: &str) -> String {
+        name.to_lowercase()
+            .chars()
+            .map(|c| if c.is_alphanumeric() { c } else { '-' })
+            .collect::<String>()
+            .split('-')
+            .filter(|s| !s.is_empty())
+            .collect::<Vec<_>>()
+            .join("-")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_project_construction() {
+        let p = Project::new("My Project", "my-project").unwrap();
+        assert_eq!(p.name, "My Project");
+        assert_eq!(p.slug, "my-project");
+    }
+
+    #[test]
+    fn rejects_empty_name() {
+        let err = Project::new("  ", "my-project").unwrap_err();
+        assert!(matches!(err, DomainError::Validation(_)));
+    }
+
+    #[test]
+    fn rejects_invalid_slug() {
+        let err = Project::new("My Project", "My Project").unwrap_err();
+        assert!(matches!(err, DomainError::Validation(_)));
+    }
+
+    #[test]
+    fn slug_from_name_helper() {
+        assert_eq!(Project::slug_from_name("Hello World!"), "hello-world");
+    }
 }

--- a/crates/agileplus-domain/src/domain/story.rs
+++ b/crates/agileplus-domain/src/domain/story.rs
@@ -1,0 +1,193 @@
+//! Story aggregate — a user-facing deliverable belonging to an Epic.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::str::FromStr;
+
+use crate::error::DomainError;
+
+/// Lifecycle status of a story.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StoryStatus {
+    Todo,
+    InProgress,
+    Review,
+    Done,
+    Blocked,
+    Cancelled,
+}
+
+impl fmt::Display for StoryStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            StoryStatus::Todo => "todo",
+            StoryStatus::InProgress => "in_progress",
+            StoryStatus::Review => "review",
+            StoryStatus::Done => "done",
+            StoryStatus::Blocked => "blocked",
+            StoryStatus::Cancelled => "cancelled",
+        };
+        write!(f, "{s}")
+    }
+}
+
+impl FromStr for StoryStatus {
+    type Err = DomainError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "todo" => Ok(StoryStatus::Todo),
+            "in_progress" => Ok(StoryStatus::InProgress),
+            "review" => Ok(StoryStatus::Review),
+            "done" => Ok(StoryStatus::Done),
+            "blocked" => Ok(StoryStatus::Blocked),
+            "cancelled" => Ok(StoryStatus::Cancelled),
+            _ => Err(DomainError::Validation(format!("unknown StoryStatus: {s}"))),
+        }
+    }
+}
+
+impl StoryStatus {
+    /// Returns `true` if a transition from `self` to `target` is allowed.
+    pub fn can_transition_to(self, target: StoryStatus) -> bool {
+        use StoryStatus::*;
+        matches!(
+            (self, target),
+            (Todo, InProgress)
+                | (Todo, Cancelled)
+                | (InProgress, Review)
+                | (InProgress, Blocked)
+                | (InProgress, Cancelled)
+                | (Blocked, InProgress)
+                | (Review, Done)
+                | (Review, InProgress)
+        )
+    }
+}
+
+/// A story — a user-facing unit of work owned by an Epic.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Story {
+    pub id: i64,
+    /// Owning epic.
+    pub epic_id: i64,
+    /// Owning project (denormalised for queries).
+    pub project_id: i64,
+    /// Title — must be non-empty.
+    pub title: String,
+    /// "As a <role>, I want <goal> so that <benefit>." Free-form narrative.
+    pub description: Option<String>,
+    pub status: StoryStatus,
+    /// Story-point estimate — must be positive when set.
+    pub points: Option<u32>,
+    /// Assignee (user id).
+    pub assignee_id: Option<i64>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl Story {
+    /// Construct a new `Story`. `title` must be non-empty; `points` must be > 0 when given.
+    pub fn new(
+        epic_id: i64,
+        project_id: i64,
+        title: &str,
+        points: Option<u32>,
+    ) -> Result<Self, DomainError> {
+        let title = title.trim();
+        if title.is_empty() {
+            return Err(DomainError::Validation(
+                "story title must not be empty".to_string(),
+            ));
+        }
+        if points == Some(0) {
+            return Err(DomainError::Validation(
+                "story points must be greater than zero".to_string(),
+            ));
+        }
+        let now = Utc::now();
+        Ok(Self {
+            id: 0,
+            epic_id,
+            project_id,
+            title: title.to_string(),
+            description: None,
+            status: StoryStatus::Todo,
+            points,
+            assignee_id: None,
+            created_at: now,
+            updated_at: now,
+        })
+    }
+
+    /// Attempt a status transition. Returns `Err(DomainError::InvalidTransition)`
+    /// if the transition is not permitted.
+    pub fn transition_status(&mut self, target: StoryStatus) -> Result<(), DomainError> {
+        if !self.status.can_transition_to(target) {
+            return Err(DomainError::InvalidTransition {
+                from: self.status.to_string(),
+                to: target.to_string(),
+                reason: "not an allowed story status transition".to_string(),
+            });
+        }
+        self.status = target;
+        self.updated_at = Utc::now();
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_story_construction() {
+        let s = Story::new(1, 10, "User can log in", Some(3)).unwrap();
+        assert_eq!(s.title, "User can log in");
+        assert_eq!(s.epic_id, 1);
+        assert_eq!(s.project_id, 10);
+        assert_eq!(s.points, Some(3));
+        assert_eq!(s.status, StoryStatus::Todo);
+    }
+
+    #[test]
+    fn rejects_empty_title() {
+        let err = Story::new(1, 10, "", None).unwrap_err();
+        assert!(matches!(err, DomainError::Validation(_)));
+    }
+
+    #[test]
+    fn rejects_zero_points() {
+        let err = Story::new(1, 10, "Has zero points", Some(0)).unwrap_err();
+        assert!(matches!(err, DomainError::Validation(_)));
+    }
+
+    #[test]
+    fn valid_status_transition() {
+        let mut s = Story::new(1, 10, "Login flow", None).unwrap();
+        s.transition_status(StoryStatus::InProgress).unwrap();
+        assert_eq!(s.status, StoryStatus::InProgress);
+        s.transition_status(StoryStatus::Review).unwrap();
+        assert_eq!(s.status, StoryStatus::Review);
+        s.transition_status(StoryStatus::Done).unwrap();
+        assert_eq!(s.status, StoryStatus::Done);
+    }
+
+    #[test]
+    fn invalid_status_transition_rejected() {
+        let mut s = Story::new(1, 10, "Skip ahead", None).unwrap();
+        // Todo -> Done is not allowed
+        let err = s.transition_status(StoryStatus::Done).unwrap_err();
+        assert!(matches!(err, DomainError::InvalidTransition { .. }));
+    }
+
+    #[test]
+    fn blocked_unblocked_cycle() {
+        let mut s = Story::new(2, 20, "Blocked story", Some(5)).unwrap();
+        s.transition_status(StoryStatus::InProgress).unwrap();
+        s.transition_status(StoryStatus::Blocked).unwrap();
+        s.transition_status(StoryStatus::InProgress).unwrap();
+        assert_eq!(s.status, StoryStatus::InProgress);
+    }
+}

--- a/crates/agileplus-domain/src/domain/user.rs
+++ b/crates/agileplus-domain/src/domain/user.rs
@@ -1,0 +1,178 @@
+//! User aggregate — a person who interacts with the system.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::str::FromStr;
+
+use crate::error::DomainError;
+
+/// Role of a user within the platform.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum UserRole {
+    Admin,
+    Member,
+    Viewer,
+}
+
+impl fmt::Display for UserRole {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            UserRole::Admin => "admin",
+            UserRole::Member => "member",
+            UserRole::Viewer => "viewer",
+        };
+        write!(f, "{s}")
+    }
+}
+
+impl FromStr for UserRole {
+    type Err = DomainError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "admin" => Ok(UserRole::Admin),
+            "member" => Ok(UserRole::Member),
+            "viewer" => Ok(UserRole::Viewer),
+            _ => Err(DomainError::Validation(format!("unknown UserRole: {s}"))),
+        }
+    }
+}
+
+/// Account status of a user.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum UserStatus {
+    Active,
+    Inactive,
+    Suspended,
+}
+
+impl fmt::Display for UserStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            UserStatus::Active => "active",
+            UserStatus::Inactive => "inactive",
+            UserStatus::Suspended => "suspended",
+        };
+        write!(f, "{s}")
+    }
+}
+
+impl UserStatus {
+    /// Returns `true` if a transition from `self` to `target` is allowed.
+    pub fn can_transition_to(self, target: UserStatus) -> bool {
+        use UserStatus::*;
+        matches!(
+            (self, target),
+            (Active, Inactive)
+                | (Active, Suspended)
+                | (Inactive, Active)
+                | (Suspended, Active)
+        )
+    }
+}
+
+/// A user who interacts with the platform.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct User {
+    pub id: i64,
+    /// Display name — must be non-empty.
+    pub display_name: String,
+    /// Email address — must contain '@'.
+    pub email: String,
+    pub role: UserRole,
+    pub status: UserStatus,
+    pub avatar_url: Option<String>,
+    pub github_login: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl User {
+    /// Construct a new `User`, enforcing non-empty display name and basic email
+    /// validity (must contain `@`).
+    pub fn new(display_name: &str, email: &str, role: UserRole) -> Result<Self, DomainError> {
+        let display_name = display_name.trim();
+        if display_name.is_empty() {
+            return Err(DomainError::Validation(
+                "display_name must not be empty".to_string(),
+            ));
+        }
+        let email = email.trim();
+        if !email.contains('@') {
+            return Err(DomainError::Validation(
+                "email must contain '@'".to_string(),
+            ));
+        }
+        let now = Utc::now();
+        Ok(Self {
+            id: 0,
+            display_name: display_name.to_string(),
+            email: email.to_string(),
+            role,
+            status: UserStatus::Active,
+            avatar_url: None,
+            github_login: None,
+            created_at: now,
+            updated_at: now,
+        })
+    }
+
+    /// Attempt a status transition. Returns `Err(DomainError::InvalidTransition)`
+    /// if the transition is not permitted.
+    pub fn transition_status(&mut self, target: UserStatus) -> Result<(), DomainError> {
+        if !self.status.can_transition_to(target) {
+            return Err(DomainError::InvalidTransition {
+                from: self.status.to_string(),
+                to: target.to_string(),
+                reason: "not an allowed user status transition".to_string(),
+            });
+        }
+        self.status = target;
+        self.updated_at = Utc::now();
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_user_construction() {
+        let u = User::new("Alice", "alice@example.com", UserRole::Member).unwrap();
+        assert_eq!(u.display_name, "Alice");
+        assert_eq!(u.email, "alice@example.com");
+        assert_eq!(u.status, UserStatus::Active);
+        assert_eq!(u.role, UserRole::Member);
+    }
+
+    #[test]
+    fn rejects_empty_display_name() {
+        let err = User::new("  ", "a@b.com", UserRole::Viewer).unwrap_err();
+        assert!(matches!(err, DomainError::Validation(_)));
+    }
+
+    #[test]
+    fn rejects_invalid_email() {
+        let err = User::new("Bob", "notanemail", UserRole::Member).unwrap_err();
+        assert!(matches!(err, DomainError::Validation(_)));
+    }
+
+    #[test]
+    fn valid_status_transition() {
+        let mut u = User::new("Carol", "carol@x.com", UserRole::Admin).unwrap();
+        u.transition_status(UserStatus::Inactive).unwrap();
+        assert_eq!(u.status, UserStatus::Inactive);
+    }
+
+    #[test]
+    fn invalid_status_transition_rejected() {
+        let mut u = User::new("Dave", "dave@x.com", UserRole::Member).unwrap();
+        // Active -> Suspended is allowed; Suspended -> Inactive is NOT
+        u.transition_status(UserStatus::Suspended).unwrap();
+        let err = u.transition_status(UserStatus::Inactive).unwrap_err();
+        assert!(matches!(err, DomainError::InvalidTransition { .. }));
+    }
+}


### PR DESCRIPTION
## **User description**
## Summary
- Implements `User` aggregate with `UserRole`, `UserStatus` state machine, non-empty display-name and `@`-email guards
- Implements `Epic` aggregate scoped to a `Project` with `EpicStatus` lifecycle (Backlog→Active→Review→Done/Cancelled)
- Implements `Story` aggregate scoped to an `Epic` with `StoryStatus` lifecycle (Todo→InProgress→Review→Done, Blocked/unblock cycle, zero-points guard)
- Extends `Project` with `Project::new()` enforcing non-empty name and `[a-z0-9-]` slug; adds `slug_from_name` helper

## Invariants enforced
- Empty titles/names rejected via `DomainError::Validation`
- Invalid status transitions rejected via `DomainError::InvalidTransition`
- `Story.points = Some(0)` rejected
- `User.email` must contain `@`
- `Project.slug` must be `[a-z0-9-]` only

## Test plan
- [x] `cargo test -p agileplus-domain` — 20 tests, 0 failures
- [x] `cargo check --workspace` — green (warnings pre-existing)
- [x] Valid construction, invariant rejection, status-transition tests for each new type

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure domain-layer additions and tests with no API, persistence, or auth wiring yet; behavior is isolated to invariants and state machines.
> 
> **Overview**
> Introduces **User**, **Epic**, and **Story** domain aggregates in `agileplus-domain`, wired through `domain/mod.rs`, each with serde-friendly status/role enums, `Display`/`FromStr`, and guarded `new` plus `transition_status` that rejects illegal moves via `DomainError::InvalidTransition`.
> 
> **Epic** is project-scoped (Backlog→Active→Review→Done/Cancelled with review rollback). **Story** is epic-scoped with denormalized `project_id`, optional positive story points, and a workflow including Blocked/unblock. **User** adds roles (admin/member/viewer), account status transitions, and lightweight email/display-name validation.
> 
> **Project** gains `Project::new` with non-empty name and `[a-z0-9-]` slug rules plus `slug_from_name`, replacing a previously unvalidated struct-only model. Unit tests cover construction, invariant failures, and status transitions for each type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74908ab3bedfc6399586ce2b097a6accbc454165. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Add guarded Project, User, Epic, and Story domain records**

### What Changed
- Projects now have a safe creation flow that rejects empty names and invalid slugs, and can generate a URL-friendly slug from a name
- Users can now be created with a role and active status, with empty display names and invalid email addresses rejected; user status changes now allow only valid moves
- Epics and stories now have their own lifecycle states, with invalid status changes rejected
- Stories now enforce positive point values when provided, and support a blocked/unblocked workflow
- Added coverage for valid creation, rejected invalid input, and allowed/disallowed status changes

### Impact
`✅ Fewer invalid project records`
`✅ Clearer user account setup`
`✅ Safer epic and story status changes`  
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
