### PR TITLE
feat(agileplus-github): GitHub → domain mapping

### DIFF
--- a/crates/agileplus-github/Cargo.toml
+++ b/crates/agileplus-github/Cargo.toml
@@ -12,3 +12,5 @@ serde.workspace = true
 serde_json.workspace = true
 tracing.workspace = true
 async-trait.workspace = true
+chrono.workspace = true
+agileplus-domain = { path = "../agileplus-domain" }

--- a/crates/agileplus-github/src/lib.rs
+++ b/crates/agileplus-github/src/lib.rs
@@ -1,1 +1,3 @@
-//! agileplus-github stub
+//! agileplus-github — GitHub REST API client + domain mapping.
+
+pub mod map;

--- a/crates/agileplus-github/src/map.rs
+++ b/crates/agileplus-github/src/map.rs
@@ -1,0 +1,262 @@
+//! Mapping from GitHub REST API types → agileplus-domain entities.
+//!
+//! Traceability: WP19-T115
+
+use agileplus_domain::domain::story::{Story, StoryStatus};
+use agileplus_domain::domain::user::{User, UserRole};
+use agileplus_domain::error::DomainError;
+
+/// A minimal GitHub issue representation suitable for mapping.
+/// Mirrors the fields returned by the GitHub REST API and our own
+/// `GitHubIssueResponse`, but kept as a plain struct so tests can
+/// construct it without hitting the network.
+#[derive(Debug, Clone)]
+pub struct GhIssue {
+    pub number: i64,
+    pub title: String,
+    pub body: Option<String>,
+    /// "open" or "closed"
+    pub state: String,
+    pub user_login: Option<String>,
+    pub user_email: Option<String>,
+    pub user_avatar_url: Option<String>,
+}
+
+/// A minimal GitHub pull-request representation suitable for mapping.
+#[derive(Debug, Clone)]
+pub struct GhPullRequest {
+    pub number: i64,
+    pub title: String,
+    pub body: Option<String>,
+    /// "open" or "closed" or "merged"
+    pub state: String,
+    pub merged: bool,
+    pub user_login: Option<String>,
+    pub user_email: Option<String>,
+    pub user_avatar_url: Option<String>,
+}
+
+/// Map a GitHub issue state string to a domain `StoryStatus`.
+///
+/// * `"open"`   → `Todo`
+/// * `"closed"` → `Done`
+/// * anything else → `Err(DomainError::Validation(…))`
+pub fn gh_state_to_story_status(state: &str) -> Result<StoryStatus, DomainError> {
+    match state.to_ascii_lowercase().as_str() {
+        "open" => Ok(StoryStatus::Todo),
+        "closed" => Ok(StoryStatus::Done),
+        other => Err(DomainError::Validation(format!(
+            "unknown GitHub issue state: '{other}'"
+        ))),
+    }
+}
+
+/// Map a GitHub PR state to a domain `StoryStatus`.
+///
+/// * `"open"`   → `InProgress`
+/// * `"merged"` / `"closed" + merged=true`  → `Done`
+/// * `"closed"` (not merged) → `Cancelled`
+pub fn gh_pr_state_to_story_status(state: &str, merged: bool) -> Result<StoryStatus, DomainError> {
+    match state.to_ascii_lowercase().as_str() {
+        "open" => Ok(StoryStatus::InProgress),
+        "closed" | "merged" => {
+            if merged {
+                Ok(StoryStatus::Done)
+            } else {
+                Ok(StoryStatus::Cancelled)
+            }
+        }
+        other => Err(DomainError::Validation(format!(
+            "unknown GitHub PR state: '{other}'"
+        ))),
+    }
+}
+
+/// Convert a GitHub login into a best-effort `User`.
+///
+/// GitHub doesn't always expose a real email; when absent we synthesise
+/// `<login>@github.invalid` so the domain invariant (must contain `@`)
+/// is always satisfied.
+///
+/// The returned `User` has `id = 0` (not yet persisted) and
+/// `github_login` set to the login string.
+pub fn gh_user_to_domain(
+    login: &str,
+    email: Option<&str>,
+    avatar_url: Option<&str>,
+) -> Result<User, DomainError> {
+    let effective_email = match email {
+        Some(e) if e.contains('@') => e.to_string(),
+        _ => format!("{}@github.invalid", login),
+    };
+
+    let mut user = User::new(login, &effective_email, UserRole::Member)?;
+    user.github_login = Some(login.to_string());
+    user.avatar_url = avatar_url.map(str::to_string);
+    Ok(user)
+}
+
+/// Map a `GhIssue` → domain `Story`.
+///
+/// * `epic_id` and `project_id` are caller-supplied context (GitHub has no concept of epics).
+/// * Title must be non-empty; an empty title returns `Err(DomainError::Validation)`.
+/// * Unknown `state` values return `Err(DomainError::Validation)`.
+pub fn issue_to_story(
+    issue: &GhIssue,
+    epic_id: i64,
+    project_id: i64,
+) -> Result<Story, DomainError> {
+    let status = gh_state_to_story_status(&issue.state)?;
+    let mut story = Story::new(epic_id, project_id, &issue.title, None)?;
+    story.description = issue.body.clone().filter(|b| !b.trim().is_empty());
+    story.status = status;
+    story.id = issue.number;
+    Ok(story)
+}
+
+/// Map a `GhPullRequest` → domain `Story`.
+///
+/// PRs are treated as stories: open → InProgress, merged → Done, closed-without-merge → Cancelled.
+pub fn pr_to_story(
+    pr: &GhPullRequest,
+    epic_id: i64,
+    project_id: i64,
+) -> Result<Story, DomainError> {
+    let status = gh_pr_state_to_story_status(&pr.state, pr.merged)?;
+    let mut story = Story::new(epic_id, project_id, &pr.title, None)?;
+    story.description = pr.body.clone().filter(|b| !b.trim().is_empty());
+    story.status = status;
+    story.id = pr.number;
+    Ok(story)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use agileplus_domain::domain::story::StoryStatus;
+    use agileplus_domain::error::DomainError;
+
+    fn open_issue(title: &str) -> GhIssue {
+        GhIssue {
+            number: 42,
+            title: title.to_string(),
+            body: Some("Reproduces on startup.".to_string()),
+            state: "open".to_string(),
+            user_login: Some("octocat".to_string()),
+            user_email: None,
+            user_avatar_url: None,
+        }
+    }
+
+    // ── issue_to_story ────────────────────────────────────────────────────────
+
+    #[test]
+    fn open_issue_maps_to_todo_story() {
+        let issue = open_issue("Fix login crash");
+        let story = issue_to_story(&issue, 1, 10).unwrap();
+        assert_eq!(story.title, "Fix login crash");
+        assert_eq!(story.status, StoryStatus::Todo);
+        assert_eq!(story.id, 42);
+        assert_eq!(story.epic_id, 1);
+        assert_eq!(story.project_id, 10);
+        assert_eq!(story.description.as_deref(), Some("Reproduces on startup."));
+    }
+
+    #[test]
+    fn closed_issue_maps_to_done_story() {
+        let mut issue = open_issue("Deploy hotfix");
+        issue.state = "closed".to_string();
+        let story = issue_to_story(&issue, 2, 20).unwrap();
+        assert_eq!(story.status, StoryStatus::Done);
+    }
+
+    #[test]
+    fn empty_title_returns_validation_error() {
+        let issue = open_issue("   ");
+        let err = issue_to_story(&issue, 1, 1).unwrap_err();
+        assert!(
+            matches!(err, DomainError::Validation(_)),
+            "expected Validation, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn unknown_state_returns_validation_error() {
+        let mut issue = open_issue("Some issue");
+        issue.state = "draft".to_string();
+        let err = issue_to_story(&issue, 1, 1).unwrap_err();
+        assert!(
+            matches!(err, DomainError::Validation(_)),
+            "expected Validation, got {err:?}"
+        );
+    }
+
+    // ── pr_to_story ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn open_pr_maps_to_in_progress() {
+        let pr = GhPullRequest {
+            number: 99,
+            title: "feat: add dark mode".to_string(),
+            body: Some("Implements dark mode toggle.".to_string()),
+            state: "open".to_string(),
+            merged: false,
+            user_login: Some("dev".to_string()),
+            user_email: None,
+            user_avatar_url: None,
+        };
+        let story = pr_to_story(&pr, 3, 30).unwrap();
+        assert_eq!(story.status, StoryStatus::InProgress);
+        assert_eq!(story.id, 99);
+    }
+
+    #[test]
+    fn merged_pr_maps_to_done() {
+        let pr = GhPullRequest {
+            number: 100,
+            title: "fix: null deref".to_string(),
+            body: None,
+            state: "closed".to_string(),
+            merged: true,
+            user_login: None,
+            user_email: None,
+            user_avatar_url: None,
+        };
+        let story = pr_to_story(&pr, 3, 30).unwrap();
+        assert_eq!(story.status, StoryStatus::Done);
+        assert!(story.description.is_none());
+    }
+
+    #[test]
+    fn closed_unmerged_pr_maps_to_cancelled() {
+        let pr = GhPullRequest {
+            number: 101,
+            title: "wip: experiment".to_string(),
+            body: None,
+            state: "closed".to_string(),
+            merged: false,
+            user_login: None,
+            user_email: None,
+            user_avatar_url: None,
+        };
+        let story = pr_to_story(&pr, 3, 30).unwrap();
+        assert_eq!(story.status, StoryStatus::Cancelled);
+    }
+
+    // ── gh_user_to_domain ─────────────────────────────────────────────────────
+
+    #[test]
+    fn user_without_email_gets_synthetic_email() {
+        let user = gh_user_to_domain("torvalds", None, None).unwrap();
+        assert_eq!(user.email, "torvalds@github.invalid");
+        assert_eq!(user.github_login.as_deref(), Some("torvalds"));
+    }
+
+    #[test]
+    fn user_with_real_email_uses_it() {
+        let user =
+            gh_user_to_domain("alice", Some("alice@example.com"), Some("https://avatar")).unwrap();
+        assert_eq!(user.email, "alice@example.com");
+        assert_eq!(user.avatar_url.as_deref(), Some("https://avatar"));
+    }
+}


### PR DESCRIPTION
## **User description**
## Summary
- Adds `crates/agileplus-github/src/map.rs` with `issue_to_story`, `pr_to_story`, `gh_user_to_domain`, and state helpers (`gh_state_to_story_status`, `gh_pr_state_to_story_status`)
- `GhIssue`/`GhPullRequest` plain structs serve as the input side (network-free, easy to construct in tests)
- State mapping: `open`→`Todo`, `closed`→`Done` for issues; `open`→`InProgress`, merged→`Done`, closed-unmerged→`Cancelled` for PRs
- Missing email synthesised as `<login>@github.invalid` to satisfy domain invariant
- Adds `agileplus-domain` path-dep + `chrono` workspace dep to the crate

## Test plan
- [x] 9 unit tests in `map::tests` — open/closed issue, merged/closed-unmerged PR, empty-title validation error, unknown-state validation error, user with/without email
- [x] `cargo test -p agileplus-github` → 9 passed, 0 failed
- [x] `cargo check --workspace` → Finished (no new errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New, isolated mapping code with no network or auth; main caveat is using GitHub issue/PR numbers as story IDs and synthetic emails when syncing downstream.
> 
> **Overview**
> Replaces the **agileplus-github** stub with a **`map`** module that converts GitHub-shaped data into **agileplus-domain** `Story` and `User` values, wired via new **`agileplus-domain`** and **`chrono`** crate dependencies.
> 
> Issues and PRs map through test-friendly **`GhIssue`** / **`GhPullRequest`** structs: **`issue_to_story`** and **`pr_to_story`** apply caller-supplied `epic_id`/`project_id`, copy title/body, set **`story.id`** from the GitHub number, and map states (issues: open→`Todo`, closed→`Done`; PRs: open→`InProgress`, merged→`Done`, closed unmerged→`Cancelled`). Unknown states and empty titles surface **`DomainError::Validation`**. **`gh_user_to_domain`** fills missing emails with **`<login>@github.invalid`**, sets **`github_login`**, and defaults role to **`Member`**.
> 
> Nine unit tests cover the state mappings, validation paths, and email synthesis.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f270a14a9f7506dd4519f11e8fd13c721cd46ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Map GitHub issues, pull requests, and users into domain records**

### What Changed
- GitHub issues and pull requests can now be converted into domain stories with the right status: open issues become todo, closed issues become done, open PRs become in progress, merged PRs become done, and closed unmerged PRs become cancelled
- Issue and PR titles are validated, and unknown states now return a clear validation error instead of producing invalid records
- GitHub users without a real email are given a synthetic `@github.invalid` address so they can still be stored as valid domain users
- Issue and PR text is carried over when present, and blank descriptions are ignored

### Impact
`✅ Consistent GitHub sync into stories`
`✅ Fewer import failures from missing user emails`
`✅ Clearer validation errors for bad GitHub data`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
