### PR TITLE
feat(p2p): vector-clock replication protocol

### DIFF
--- a/crates/agileplus-p2p/src/export.rs
+++ b/crates/agileplus-p2p/src/export.rs
@@ -18,8 +18,8 @@ use std::time::Instant;
 use agileplus_domain::domain::event::Event;
 use agileplus_domain::domain::snapshot::Snapshot;
 use agileplus_domain::domain::sync_mapping::SyncMapping;
-use agileplus_events::store::EventStore;
 use agileplus_events::snapshot::SnapshotStore;
+use agileplus_events::store::EventStore;
 use serde_json::Value;
 use tracing::debug;
 
@@ -140,9 +140,7 @@ where
             .map_err(|e| ExportError::EventStore(e.to_string()))?;
 
         if !events.is_empty() {
-            let events_dir = output_dir
-                .join("events")
-                .join(&entity.entity_type);
+            let events_dir = output_dir.join("events").join(&entity.entity_type);
             std::fs::create_dir_all(&events_dir)?;
             let file_path = events_dir.join(format!("{}.jsonl", entity.entity_id));
             let mut file = std::fs::File::create(&file_path)?;
@@ -168,9 +166,7 @@ where
             .map_err(|e| ExportError::SnapshotStore(e.to_string()))?;
 
         if let Some(snap) = snapshot {
-            let snap_dir = output_dir
-                .join("snapshots")
-                .join(&entity.entity_type);
+            let snap_dir = output_dir.join("snapshots").join(&entity.entity_type);
             std::fs::create_dir_all(&snap_dir)?;
             let file_path = snap_dir.join(format!("{}.json", entity.entity_id));
             let snap_json = serde_json::to_value(&snap)?;
@@ -189,12 +185,12 @@ where
         "sync_vector": sync_vector_json,
     });
     let sync_state_path = output_dir.join("sync_state.json");
-    std::fs::write(
-        &sync_state_path,
-        to_sorted_pretty(sync_state)?.as_bytes(),
-    )?;
+    std::fs::write(&sync_state_path, to_sorted_pretty(sync_state)?.as_bytes())?;
     stats.sync_mappings_exported = sync_mappings.len();
-    debug!("Wrote sync_state.json with {} mappings", sync_mappings.len());
+    debug!(
+        "Wrote sync_state.json with {} mappings",
+        sync_mappings.len()
+    );
 
     stats.duration_ms = started.elapsed().as_millis() as u64;
     Ok(stats)
@@ -341,7 +337,13 @@ mod tests {
         let ds = InMemoryDeviceStore::default();
 
         // Seed one event
-        let mut ev = Event::new("Feature", 1, "created", serde_json::json!({"title": "T1"}), "test");
+        let mut ev = Event::new(
+            "Feature",
+            1,
+            "created",
+            serde_json::json!({"title": "T1"}),
+            "test",
+        );
         ev.sequence = 1;
         es.append(&ev).await.unwrap();
 
@@ -349,8 +351,20 @@ mod tests {
         let snap = Snapshot::new("Feature", 1, serde_json::json!({"title": "T1"}), 1);
         ss.save(&snap).await.unwrap();
 
-        let mappings = vec![SyncMapping::new("Feature", 1, "plane-001", "hash-aaa")];
-        let entities = vec![EntityRef { entity_type: "Feature".into(), entity_id: 1 }];
+        let mappings = vec![SyncMapping {
+            id: 0,
+            entity_type: "Feature".to_string(),
+            entity_id: 1,
+            plane_issue_id: "plane-001".to_string(),
+            content_hash: "hash-aaa".to_string(),
+            last_synced_at: chrono::Utc::now(),
+            sync_direction: agileplus_domain::domain::sync_mapping::SyncDirection::Bidirectional,
+            conflict_count: 0,
+        }];
+        let entities = vec![EntityRef {
+            entity_type: "Feature".into(),
+            entity_id: 1,
+        }];
 
         let stats = export_state(
             &es,

--- a/crates/agileplus-p2p/src/export/tests.rs
+++ b/crates/agileplus-p2p/src/export/tests.rs
@@ -141,7 +141,16 @@ async fn export_creates_expected_files() {
     let snap = Snapshot::new("Feature", 1, serde_json::json!({"title": "T1"}), 1);
     ss.save(&snap).await.unwrap();
 
-    let mappings = vec![SyncMapping::new("Feature", 1, "plane-001", "hash-aaa")];
+    let mappings = vec![SyncMapping {
+        id: 0,
+        entity_type: "Feature".to_string(),
+        entity_id: 1,
+        plane_issue_id: "plane-001".to_string(),
+        content_hash: "hash-aaa".to_string(),
+        last_synced_at: chrono::Utc::now(),
+        sync_direction: agileplus_domain::domain::sync_mapping::SyncDirection::Bidirectional,
+        conflict_count: 0,
+    }];
     let entities = vec![EntityRef {
         entity_type: "Feature".into(),
         entity_id: 1,

--- a/crates/agileplus-p2p/src/import.rs
+++ b/crates/agileplus-p2p/src/import.rs
@@ -157,12 +157,11 @@ fn read_sync_mappings(sync_state_path: &Path) -> Result<Vec<SyncMapping>, Import
         .cloned()
         .unwrap_or(serde_json::Value::Array(Vec::new()));
 
-    let mappings: Vec<SyncMapping> = serde_json::from_value(mappings_value).map_err(|e| {
-        ImportError::Deserialization {
+    let mappings: Vec<SyncMapping> =
+        serde_json::from_value(mappings_value).map_err(|e| ImportError::Deserialization {
             file: sync_state_path.display().to_string(),
             source: e,
-        }
-    })?;
+        })?;
 
     Ok(mappings)
 }
@@ -209,17 +208,13 @@ where
         if event.sequence <= latest_seq {
             // Potentially a duplicate; verify by loading the exact event.
             let existing = event_store
-                .get_events_since(
-                    &event.entity_type,
-                    event.entity_id,
-                    event.sequence - 1,
-                )
+                .get_events_since(&event.entity_type, event.entity_id, event.sequence - 1)
                 .await
                 .map_err(|e| ImportError::EventStore(e.to_string()))?;
 
-            let already_present = existing.iter().any(|e| {
-                e.sequence == event.sequence && e.hash == event.hash
-            });
+            let already_present = existing
+                .iter()
+                .any(|e| e.sequence == event.sequence && e.hash == event.hash);
 
             if already_present {
                 debug!(
@@ -405,7 +400,13 @@ mod tests {
     // ── Helpers ───────────────────────────────────────────────────────────────
 
     fn make_event(entity_type: &str, entity_id: i64, sequence: i64) -> Event {
-        let mut e = Event::new(entity_type, entity_id, "created", serde_json::json!({}), "test");
+        let mut e = Event::new(
+            entity_type,
+            entity_id,
+            "created",
+            serde_json::json!({}),
+            "test",
+        );
         e.sequence = sequence;
         e
     }
@@ -498,7 +499,10 @@ mod tests {
         std::fs::write(snaps_dir.join("1.json"), json).unwrap();
 
         let stats = import_state(dir, &es, &ss).await.unwrap();
-        assert_eq!(stats.snapshots_updated, 0, "older snapshot must not overwrite newer");
+        assert_eq!(
+            stats.snapshots_updated, 0,
+            "older snapshot must not overwrite newer"
+        );
     }
 
     #[tokio::test]
@@ -507,8 +511,28 @@ mod tests {
         let dir = tmp.path();
 
         let mappings = vec![
-            agileplus_domain::domain::sync_mapping::SyncMapping::new("Feature", 1, "p1", "h1"),
-            agileplus_domain::domain::sync_mapping::SyncMapping::new("Feature", 2, "p2", "h2"),
+            agileplus_domain::domain::sync_mapping::SyncMapping {
+                id: 0,
+                entity_type: "Feature".to_string(),
+                entity_id: 1,
+                plane_issue_id: "p1".to_string(),
+                content_hash: "h1".to_string(),
+                last_synced_at: chrono::Utc::now(),
+                sync_direction:
+                    agileplus_domain::domain::sync_mapping::SyncDirection::Bidirectional,
+                conflict_count: 0,
+            },
+            agileplus_domain::domain::sync_mapping::SyncMapping {
+                id: 0,
+                entity_type: "Feature".to_string(),
+                entity_id: 2,
+                plane_issue_id: "p2".to_string(),
+                content_hash: "h2".to_string(),
+                last_synced_at: chrono::Utc::now(),
+                sync_direction:
+                    agileplus_domain::domain::sync_mapping::SyncDirection::Bidirectional,
+                conflict_count: 0,
+            },
         ];
         let sync_state = serde_json::json!({ "sync_mappings": mappings, "sync_vector": {} });
         std::fs::write(

--- a/crates/agileplus-p2p/src/import/tests.rs
+++ b/crates/agileplus-p2p/src/import/tests.rs
@@ -209,8 +209,26 @@ async fn import_sync_mappings_counted() {
     let dir = tmp.path();
 
     let mappings = vec![
-        agileplus_domain::domain::sync_mapping::SyncMapping::new("Feature", 1, "p1", "h1"),
-        agileplus_domain::domain::sync_mapping::SyncMapping::new("Feature", 2, "p2", "h2"),
+        agileplus_domain::domain::sync_mapping::SyncMapping {
+            id: 0,
+            entity_type: "Feature".to_string(),
+            entity_id: 1,
+            plane_issue_id: "p1".to_string(),
+            content_hash: "h1".to_string(),
+            last_synced_at: chrono::Utc::now(),
+            sync_direction: agileplus_domain::domain::sync_mapping::SyncDirection::Bidirectional,
+            conflict_count: 0,
+        },
+        agileplus_domain::domain::sync_mapping::SyncMapping {
+            id: 0,
+            entity_type: "Feature".to_string(),
+            entity_id: 2,
+            plane_issue_id: "p2".to_string(),
+            content_hash: "h2".to_string(),
+            last_synced_at: chrono::Utc::now(),
+            sync_direction: agileplus_domain::domain::sync_mapping::SyncDirection::Bidirectional,
+            conflict_count: 0,
+        },
     ];
     let sync_state = serde_json::json!({ "sync_mappings": mappings, "sync_vector": {} });
     std::fs::write(

--- a/crates/agileplus-p2p/src/replication.rs
+++ b/crates/agileplus-p2p/src/replication.rs
@@ -1,23 +1,300 @@
 //! Event replication over NATS between AgilePlus peers.
 //!
-//! Connects to a peer's NATS instance (at `nats://{peer_tailscale_ip}:4222`),
-//! publishes local events to the peer's device subject, and subscribes to
-//! receive events the peer wants to push to us.
-//!
-//! Uses JetStream for reliable delivery with message persistence.
+//! This module now also hosts the in-memory delta replication protocol used by
+//! the peer-to-peer work-tracking state machine. The transport helpers remain
+//! for existing device sync callers, while the new state types are independent
+//! of network wiring.
 //!
 //! Traceability: WP16 / T098
 
+use std::collections::BTreeMap;
+
+use agileplus_domain::domain::{epic::Epic, project::Project, story::Story, user::User};
 use async_nats::jetstream;
+use chrono::{DateTime, Utc};
 use futures_util::StreamExt as _;
 use serde::{Deserialize, Serialize};
 use tokio::time::{Duration, sleep};
 use tracing::{debug, error, info, warn};
 
-use agileplus_domain::domain::event::Event;
-
 use crate::discovery::PeerInfo;
 use crate::error::SyncError;
+use crate::vector_clock::{ClockRelation, SyncVector};
+
+// ── In-memory replication model ──────────────────────────────────────────────
+
+/// Domain aggregate kinds carried by the replication protocol.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub enum DomainKind {
+    User,
+    Project,
+    Epic,
+    Story,
+}
+
+/// Stable identifier for one replicated aggregate.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct ItemKey {
+    pub kind: DomainKind,
+    pub id: i64,
+}
+
+/// In-memory representation of a replicated aggregate.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", content = "item")]
+pub enum DomainItem {
+    User(User),
+    Project(Project),
+    Epic(Epic),
+    Story(Story),
+}
+
+impl DomainItem {
+    pub fn key(&self) -> ItemKey {
+        match self {
+            DomainItem::User(item) => ItemKey {
+                kind: DomainKind::User,
+                id: item.id,
+            },
+            DomainItem::Project(item) => ItemKey {
+                kind: DomainKind::Project,
+                id: item.id,
+            },
+            DomainItem::Epic(item) => ItemKey {
+                kind: DomainKind::Epic,
+                id: item.id,
+            },
+            DomainItem::Story(item) => ItemKey {
+                kind: DomainKind::Story,
+                id: item.id,
+            },
+        }
+    }
+
+    pub fn updated_at(&self) -> DateTime<Utc> {
+        match self {
+            DomainItem::User(item) => item.updated_at,
+            DomainItem::Project(item) => item.updated_at,
+            DomainItem::Epic(item) => item.updated_at,
+            DomainItem::Story(item) => item.updated_at,
+        }
+    }
+}
+
+/// Snapshot of one aggregate version and its causal history.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VersionedItem {
+    pub item: DomainItem,
+    pub clock: SyncVector,
+}
+
+impl VersionedItem {
+    pub fn new(item: DomainItem, clock: SyncVector) -> Self {
+        Self { item, clock }
+    }
+}
+
+/// Item payload sent to another peer during a delta exchange.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Delta {
+    pub key: ItemKey,
+    pub item: DomainItem,
+    pub clock: SyncVector,
+}
+
+impl Delta {
+    pub fn new(item: DomainItem, clock: SyncVector) -> Self {
+        let key = item.key();
+        Self { key, item, clock }
+    }
+}
+
+/// Winner chosen for a concurrent conflict.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ConflictWinner {
+    Local,
+    Incoming,
+}
+
+/// Details of a concurrent conflict detected during merge.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Conflict {
+    pub key: ItemKey,
+    pub local: DomainItem,
+    pub incoming: DomainItem,
+    pub local_clock: SyncVector,
+    pub incoming_clock: SyncVector,
+    pub winner: ConflictWinner,
+    pub resolved: DomainItem,
+}
+
+/// Result of applying a batch of incoming deltas.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct MergeOutcome {
+    pub applied: usize,
+    pub skipped: usize,
+    pub conflicts: Vec<Conflict>,
+}
+
+/// Per-item clock index keyed by aggregate identity.
+pub type ItemClockMap = BTreeMap<ItemKey, SyncVector>;
+
+/// In-memory replication state for a peer.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct ReplicationState {
+    pub items: BTreeMap<ItemKey, VersionedItem>,
+}
+
+impl ReplicationState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert or update an item locally and advance the actor component of its clock.
+    pub fn upsert_local(&mut self, replica_id: &str, item: DomainItem) -> ItemKey {
+        let key = item.key();
+        let mut clock = self
+            .items
+            .get(&key)
+            .map(|existing| existing.clock.clone())
+            .unwrap_or_else(|| SyncVector::new(replica_id));
+        bump_replica(&mut clock, replica_id);
+        self.items
+            .insert(key.clone(), VersionedItem::new(item, clock));
+        key
+    }
+
+    /// Return the current causal clock for every known item.
+    pub fn clocks(&self) -> ItemClockMap {
+        self.items
+            .iter()
+            .map(|(key, versioned)| (key.clone(), versioned.clock.clone()))
+            .collect()
+    }
+
+    /// Compute the deltas the remote peer has not yet seen.
+    ///
+    /// Items are sent when our clock dominates the remote clock, or when the
+    /// clocks are concurrent and we need to expose our branch to the peer.
+    pub fn diff_against(&self, remote_clock: &ItemClockMap) -> Vec<Delta> {
+        let mut deltas = self
+            .items
+            .iter()
+            .filter_map(|(key, local)| {
+                let should_send = match remote_clock.get(key) {
+                    None => true,
+                    Some(remote) => matches!(
+                        local.clock.compare(remote),
+                        ClockRelation::Greater | ClockRelation::Concurrent
+                    ),
+                };
+
+                should_send.then(|| Delta {
+                    key: key.clone(),
+                    item: local.item.clone(),
+                    clock: local.clock.clone(),
+                })
+            })
+            .collect::<Vec<_>>();
+        deltas.sort_by(|a, b| a.key.cmp(&b.key));
+        deltas
+    }
+
+    /// Apply incoming deltas using vector-clock comparison.
+    pub fn apply_deltas<I>(&mut self, deltas: I) -> MergeOutcome
+    where
+        I: IntoIterator<Item = Delta>,
+    {
+        let mut outcome = MergeOutcome::default();
+
+        for delta in deltas {
+            match self.items.get_mut(&delta.key) {
+                None => {
+                    self.items.insert(
+                        delta.key.clone(),
+                        VersionedItem::new(delta.item.clone(), delta.clock.clone()),
+                    );
+                    outcome.applied += 1;
+                }
+                Some(local) => {
+                    let relation = local.clock.compare(&delta.clock);
+                    match relation {
+                        ClockRelation::Equal => {
+                            outcome.skipped += 1;
+                        }
+                        ClockRelation::Greater => {
+                            // Local already dominates the incoming version.
+                            outcome.skipped += 1;
+                        }
+                        ClockRelation::Less => {
+                            local.item = delta.item.clone();
+                            local.clock = delta.clock.clone();
+                            outcome.applied += 1;
+                        }
+                        ClockRelation::Concurrent => {
+                            let local_snapshot = local.item.clone();
+                            let local_clock = local.clock.clone();
+                            let incoming_clock = delta.clock.clone();
+
+                            let winner = choose_lww_winner(&local_snapshot, &delta.item);
+                            let resolved = match winner {
+                                ConflictWinner::Local => local_snapshot.clone(),
+                                ConflictWinner::Incoming => delta.item.clone(),
+                            };
+
+                            local.clock = merged_clock(&local_clock, &incoming_clock);
+                            if matches!(winner, ConflictWinner::Incoming) {
+                                local.item = delta.item.clone();
+                            }
+
+                            outcome.conflicts.push(Conflict {
+                                key: delta.key.clone(),
+                                local: local_snapshot,
+                                incoming: delta.item.clone(),
+                                local_clock,
+                                incoming_clock,
+                                winner,
+                                resolved: resolved.clone(),
+                            });
+                            outcome.applied += 1;
+                        }
+                    }
+                }
+            }
+        }
+
+        outcome
+    }
+}
+
+fn merged_clock(left: &SyncVector, right: &SyncVector) -> SyncVector {
+    let mut merged = left.clone();
+    merged.merge(right);
+    merged
+}
+
+fn bump_replica(clock: &mut SyncVector, replica_id: &str) {
+    let entry = clock.get(replica_id, CLOCK_ENTRY_ID);
+    clock.advance(replica_id, CLOCK_ENTRY_ID, entry + 1);
+}
+
+fn choose_lww_winner(local: &DomainItem, incoming: &DomainItem) -> ConflictWinner {
+    match local.updated_at().cmp(&incoming.updated_at()) {
+        std::cmp::Ordering::Less => ConflictWinner::Incoming,
+        std::cmp::Ordering::Greater => ConflictWinner::Local,
+        std::cmp::Ordering::Equal => {
+            let local_json = serde_json::to_string(local).unwrap_or_default();
+            let incoming_json = serde_json::to_string(incoming).unwrap_or_default();
+            if incoming_json >= local_json {
+                ConflictWinner::Incoming
+            } else {
+                ConflictWinner::Local
+            }
+        }
+    }
+}
+
+const CLOCK_ENTRY_ID: &str = "__clock__";
 
 // ── NATS subject helpers ──────────────────────────────────────────────────────
 
@@ -32,7 +309,7 @@ pub fn device_subject(target_device_id: &str) -> String {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct EventBatch {
     pub sender_device_id: String,
-    pub events: Vec<Event>,
+    pub events: Vec<agileplus_domain::domain::event::Event>,
 }
 
 // ── Result type ───────────────────────────────────────────────────────────────
@@ -52,7 +329,7 @@ pub struct ReplicationResult {
 pub async fn replicate_events(
     local_device_id: &str,
     peer: &PeerInfo,
-    events: Vec<Event>,
+    events: Vec<agileplus_domain::domain::event::Event>,
 ) -> Result<ReplicationResult, SyncError> {
     let url = format!("nats://{}:4222", peer.tailscale_ip);
     let client = connect_with_retry(&url, &peer.device_id).await?;
@@ -197,6 +474,249 @@ async fn drain_pending(js: &jetstream::Context, stream_name: &str, subject: &str
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use agileplus_domain::domain::{
+        epic::{Epic, EpicStatus},
+        project::Project,
+        story::{Story, StoryStatus},
+        user::{User, UserRole, UserStatus},
+    };
+
+    fn clock(replica: &str, counter: u64) -> SyncVector {
+        let mut clock = SyncVector::new(replica);
+        clock.advance(replica, CLOCK_ENTRY_ID, counter);
+        clock
+    }
+
+    fn sample_user(id: i64, updated_at: DateTime<Utc>) -> User {
+        User {
+            id,
+            display_name: format!("User {id}"),
+            email: format!("user{id}@example.com"),
+            role: UserRole::Member,
+            status: UserStatus::Active,
+            avatar_url: None,
+            github_login: None,
+            created_at: updated_at,
+            updated_at,
+        }
+    }
+
+    fn sample_project(id: i64, updated_at: DateTime<Utc>) -> Project {
+        Project {
+            id,
+            slug: format!("project-{id}"),
+            name: format!("Project {id}"),
+            description: None,
+            created_at: updated_at,
+            updated_at,
+        }
+    }
+
+    fn sample_epic(id: i64, project_id: i64, updated_at: DateTime<Utc>) -> Epic {
+        Epic {
+            id,
+            project_id,
+            title: format!("Epic {id}"),
+            description: None,
+            status: EpicStatus::Active,
+            owner_id: None,
+            created_at: updated_at,
+            updated_at,
+        }
+    }
+
+    fn sample_story(id: i64, epic_id: i64, project_id: i64, updated_at: DateTime<Utc>) -> Story {
+        Story {
+            id,
+            epic_id,
+            project_id,
+            title: format!("Story {id}"),
+            description: None,
+            status: StoryStatus::Todo,
+            points: Some(3),
+            assignee_id: None,
+            created_at: updated_at,
+            updated_at,
+        }
+    }
+
+    #[test]
+    fn fresh_peer_pulls_all_items() {
+        let now = Utc::now();
+        let mut state = ReplicationState::new();
+        state.items.insert(
+            ItemKey {
+                kind: DomainKind::User,
+                id: 1,
+            },
+            VersionedItem::new(DomainItem::User(sample_user(1, now)), clock("peer-a", 1)),
+        );
+        state.items.insert(
+            ItemKey {
+                kind: DomainKind::Project,
+                id: 2,
+            },
+            VersionedItem::new(
+                DomainItem::Project(sample_project(2, now)),
+                clock("peer-a", 2),
+            ),
+        );
+
+        let deltas = state.diff_against(&ItemClockMap::new());
+        assert_eq!(deltas.len(), 2);
+        assert_eq!(deltas[0].key.kind, DomainKind::User);
+        assert_eq!(deltas[1].key.kind, DomainKind::Project);
+    }
+
+    #[test]
+    fn no_op_when_clocks_equal() {
+        let now = Utc::now();
+        let mut state = ReplicationState::new();
+        let key = ItemKey {
+            kind: DomainKind::Epic,
+            id: 7,
+        };
+        let item = DomainItem::Epic(sample_epic(7, 99, now));
+        let version = VersionedItem::new(item.clone(), clock("peer-a", 3));
+        state.items.insert(key.clone(), version.clone());
+
+        let outcome = state.apply_deltas(vec![Delta::new(item, clock("peer-a", 3))]);
+        assert_eq!(outcome.applied, 0);
+        assert_eq!(outcome.skipped, 1);
+        assert!(outcome.conflicts.is_empty());
+        assert_eq!(
+            state.items.get(&key).unwrap().clock.compare(&version.clock),
+            ClockRelation::Equal
+        );
+    }
+
+    #[test]
+    fn causal_update_applied() {
+        let base = Utc::now();
+        let mut state = ReplicationState::new();
+        let key = ItemKey {
+            kind: DomainKind::Story,
+            id: 9,
+        };
+        state.items.insert(
+            key.clone(),
+            VersionedItem::new(
+                DomainItem::Story(sample_story(9, 1, 2, base)),
+                clock("peer-a", 1),
+            ),
+        );
+
+        let newer = DomainItem::Story(sample_story(9, 1, 2, base + chrono::Duration::seconds(10)));
+        let outcome = state.apply_deltas(vec![Delta::new(newer.clone(), clock("peer-a", 2))]);
+        assert_eq!(outcome.applied, 1);
+        assert!(outcome.conflicts.is_empty());
+        match &state.items.get(&key).unwrap().item {
+            DomainItem::Story(story) => {
+                assert_eq!(story.updated_at, base + chrono::Duration::seconds(10))
+            }
+            _ => panic!("expected story"),
+        }
+    }
+
+    #[test]
+    fn concurrent_edits_flagged_as_conflict() {
+        let base = Utc::now();
+        let mut state = ReplicationState::new();
+        let key = ItemKey {
+            kind: DomainKind::User,
+            id: 11,
+        };
+        state.items.insert(
+            key.clone(),
+            VersionedItem::new(DomainItem::User(sample_user(11, base)), clock("peer-a", 1)),
+        );
+
+        let mut incoming_user = sample_user(11, base + chrono::Duration::seconds(5));
+        incoming_user.display_name = "Remote User".to_string();
+        let incoming = DomainItem::User(incoming_user);
+        let outcome = state.apply_deltas(vec![Delta::new(incoming.clone(), clock("peer-b", 1))]);
+        assert_eq!(outcome.conflicts.len(), 1);
+        assert_eq!(outcome.applied, 1);
+        assert_eq!(outcome.conflicts[0].key, key);
+        assert_eq!(outcome.conflicts[0].winner, ConflictWinner::Incoming);
+        match &state.items.get(&key).unwrap().item {
+            DomainItem::User(user) => assert_eq!(user.display_name, "Remote User"),
+            _ => panic!("expected user"),
+        }
+    }
+
+    #[test]
+    fn delta_diff_correctness() {
+        let base = Utc::now();
+        let mut state = ReplicationState::new();
+        let user_key = ItemKey {
+            kind: DomainKind::User,
+            id: 1,
+        };
+        let project_key = ItemKey {
+            kind: DomainKind::Project,
+            id: 2,
+        };
+        let epic_key = ItemKey {
+            kind: DomainKind::Epic,
+            id: 3,
+        };
+
+        state.items.insert(
+            user_key.clone(),
+            VersionedItem::new(DomainItem::User(sample_user(1, base)), clock("peer-a", 3)),
+        );
+        state.items.insert(
+            project_key.clone(),
+            VersionedItem::new(
+                DomainItem::Project(sample_project(2, base)),
+                clock("peer-a", 2),
+            ),
+        );
+        state.items.insert(
+            epic_key.clone(),
+            VersionedItem::new(
+                DomainItem::Epic(sample_epic(3, 2, base)),
+                clock("peer-a", 1),
+            ),
+        );
+
+        let mut remote_clock = ItemClockMap::new();
+        remote_clock.insert(user_key.clone(), clock("peer-a", 3));
+        remote_clock.insert(project_key.clone(), clock("peer-a", 1));
+        remote_clock.insert(epic_key.clone(), clock("peer-b", 1));
+
+        let deltas = state.diff_against(&remote_clock);
+        assert_eq!(deltas.len(), 2);
+        assert_eq!(deltas[0].key, project_key);
+        assert_eq!(deltas[1].key, epic_key);
+    }
+
+    #[test]
+    fn concurrent_local_wins_still_merges_clock() {
+        let base = Utc::now();
+        let mut state = ReplicationState::new();
+        let key = ItemKey {
+            kind: DomainKind::Project,
+            id: 44,
+        };
+        state.items.insert(
+            key.clone(),
+            VersionedItem::new(
+                DomainItem::Project(sample_project(44, base + chrono::Duration::seconds(2))),
+                clock("peer-a", 2),
+            ),
+        );
+
+        let incoming = DomainItem::Project(sample_project(44, base));
+        let outcome = state.apply_deltas(vec![Delta::new(incoming, clock("peer-b", 1))]);
+        assert_eq!(outcome.conflicts.len(), 1);
+        assert_eq!(outcome.conflicts[0].winner, ConflictWinner::Local);
+        let merged_clock = &state.items.get(&key).unwrap().clock;
+        assert_eq!(merged_clock.get("peer-a", CLOCK_ENTRY_ID), 2);
+        assert_eq!(merged_clock.get("peer-b", CLOCK_ENTRY_ID), 1);
+    }
 
     #[test]
     fn device_subject_format() {

--- a/crates/agileplus-p2p/src/vector_clock.rs
+++ b/crates/agileplus-p2p/src/vector_clock.rs
@@ -17,6 +17,15 @@ use tracing::{debug, info};
 use crate::discovery::PeerInfo;
 use crate::error::SyncError;
 
+/// Partial ordering between two vector-clock snapshots.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClockRelation {
+    Equal,
+    Greater,
+    Less,
+    Concurrent,
+}
+
 // ── Types ─────────────────────────────────────────────────────────────────────
 
 /// Per-entity watermark vector for one device.
@@ -63,6 +72,47 @@ impl SyncVector {
             .get(&(entity_type.to_string(), entity_id.to_string()))
             .copied()
             .unwrap_or(0)
+    }
+
+    /// Compare two clocks by taking the per-entry partial order.
+    pub fn compare(&self, other: &Self) -> ClockRelation {
+        let mut greater = false;
+        let mut less = false;
+
+        for key in self.entries.keys().chain(other.entries.keys()) {
+            let left = self.entries.get(key).copied().unwrap_or(0);
+            let right = other.entries.get(key).copied().unwrap_or(0);
+
+            if left > right {
+                greater = true;
+            } else if left < right {
+                less = true;
+            }
+
+            if greater && less {
+                return ClockRelation::Concurrent;
+            }
+        }
+
+        match (greater, less) {
+            (false, false) => ClockRelation::Equal,
+            (true, false) => ClockRelation::Greater,
+            (false, true) => ClockRelation::Less,
+            (true, true) => ClockRelation::Concurrent,
+        }
+    }
+
+    /// Returns `true` if `self` is greater than or equal to `other`.
+    pub fn dominates(&self, other: &Self) -> bool {
+        matches!(
+            self.compare(other),
+            ClockRelation::Equal | ClockRelation::Greater
+        )
+    }
+
+    /// Returns `true` if the two clocks are incomparable.
+    pub fn is_concurrent(&self, other: &Self) -> bool {
+        matches!(self.compare(other), ClockRelation::Concurrent)
     }
 }
 


### PR DESCRIPTION
## **User description**
Delta-exchange + vector-clock merge for peer replication.

What changed:
- Added an in-memory `ReplicationState` in `crates/agileplus-p2p`.
- Added `Delta`, `VersionedItem`, `ItemKey`, and conflict outcome types for domain items.
- Implemented `diff_against` and `apply_deltas` using vector-clock comparison.
- Added last-writer-wins resolution for concurrent edits and surfaced conflicts in `MergeOutcome.conflicts`.
- Reused the existing `SyncVector` clock model and added explicit comparison helpers.
- Fixed a few p2p crate test call sites that were using a non-existent `SyncMapping::new` constructor.

Why:
- This gives peers a local, in-memory replication protocol for work-tracking state without introducing new transport or storage dependencies.

Validation:
- `cargo test -p agileplus-p2p 2>&1 | tail -25`
- `cargo check --workspace 2>&1 | tail -10`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New merge/conflict logic affects replicated work-tracking state correctness; NATS replication paths are unchanged but the module’s responsibilities grew substantially.
> 
> **Overview**
> Introduces an **in-memory peer replication protocol** in `replication.rs` alongside the existing NATS event transport: `ReplicationState` holds versioned domain items (User, Project, Epic, Story) with per-item `SyncVector` clocks, **`diff_against`** selects deltas the remote has not seen, and **`apply_deltas`** merges using causal ordering with **last-writer-wins** (and JSON tie-break) on concurrent edits, recording outcomes in **`MergeOutcome.conflicts`**.
> 
> Extends **`SyncVector`** with **`ClockRelation`**, **`compare`**, **`dominates`**, and **`is_concurrent`** so replication can reason about equal, dominated, and concurrent clocks.
> 
> Export/import changes are mostly **formatting**; **p2p tests** now build **`SyncMapping`** via struct literals instead of a removed **`SyncMapping::new`** helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45aa50d920332e2a33e4076fafcf599646c51d9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Add vector-clock peer replication with conflict handling**

### What Changed
- Added an in-memory replication state for shared work items, so peers can exchange item updates without relying on transport or storage changes.
- Peers now send only the item changes a remote side has not seen, and incoming changes are merged by causal order with conflict tracking when edits happen at the same time.
- Concurrent edits are resolved with a clear winner, and the losing side is still recorded so conflicts can be reviewed later.
- Added vector-clock comparison helpers so the system can tell when items are unchanged, behind, ahead, or in conflict.
- Updated export/import test data to match the current sync mapping format and fixed related call sites.

### Impact
`✅ Peer-to-peer work state can stay in sync`
`✅ Fewer missed or repeated item updates`
`✅ Clearer conflict reporting during concurrent edits`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
