### PR TITLE
feat(events): typed DomainEvent enum, EventEnvelope + EventHandler port

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,19 +28,38 @@ dependencies = [
 name = "agileplus-api"
 version = "0.1.0"
 dependencies = [
+ "agileplus-dashboard",
+ "agileplus-domain",
+ "agileplus-git",
+ "agileplus-sqlite",
  "anyhow",
+ "askama",
  "axum 0.8.9",
+ "base64",
+ "chrono",
+ "rand",
  "serde",
  "serde_json",
+ "serde_yaml",
+ "sha2",
+ "thiserror 2.0.18",
  "tokio",
+ "tokio-stream",
+ "tower 0.5.3",
+ "tower-http",
  "tracing",
+ "tracing-subscriber",
+ "utoipa",
 ]
 
 [[package]]
 name = "agileplus-cli"
 version = "0.1.0"
 dependencies = [
+ "agileplus-domain",
  "anyhow",
+ "chrono",
+ "clap",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -77,6 +96,8 @@ dependencies = [
 name = "agileplus-domain"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "async-trait",
  "chrono",
  "serde",
  "serde_json",
@@ -96,6 +117,7 @@ dependencies = [
  "sha2",
  "thiserror 2.0.18",
  "tokio",
+ "uuid",
 ]
 
 [[package]]
@@ -112,7 +134,9 @@ name = "agileplus-git"
 version = "0.1.0"
 dependencies = [
  "agileplus-domain",
+ "anyhow",
  "async-nats",
+ "async-trait",
  "chrono",
  "git2",
  "gix",
@@ -129,8 +153,11 @@ dependencies = [
 name = "agileplus-github"
 version = "0.1.0"
 dependencies = [
+ "agileplus-domain",
  "anyhow",
  "async-trait",
+ "chrono",
+ "reqwest",
  "serde",
  "serde_json",
  "tokio",
@@ -145,6 +172,7 @@ dependencies = [
  "prost",
  "tokio",
  "tonic 0.13.1",
+ "tonic-build",
  "tracing",
 ]
 
@@ -173,10 +201,27 @@ dependencies = [
 name = "agileplus-p2p"
 version = "0.1.0"
 dependencies = [
+ "agileplus-domain",
+ "agileplus-events",
  "anyhow",
+ "async-nats",
  "async-trait",
+ "bytes",
+ "chrono",
+ "futures",
+ "futures-util",
+ "hostname",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "mdns-sd",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -290,7 +335,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -301,7 +346,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -345,7 +390,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -418,7 +463,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -429,7 +474,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -575,7 +620,7 @@ checksum = "7aa268c23bfbbd2c4363b9cd302a4f504fb2a9dfe7e3451d66f35dd392e20aca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -716,7 +761,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -765,6 +810,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -875,7 +930,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn",
+ "syn 2.0.117",
  "synthez",
 ]
 
@@ -916,7 +971,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -979,7 +1034,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 2.0.117",
  "unicode-xid",
 ]
 
@@ -1001,7 +1056,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1066,7 +1121,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1121,6 +1176,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1128,6 +1189,17 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
 ]
 
 [[package]]
@@ -1147,6 +1219,21 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1222,7 +1309,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1311,7 +1398,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn",
+ "syn 2.0.117",
  "textwrap",
  "thiserror 2.0.18",
  "typed-builder",
@@ -2344,6 +2431,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link",
+]
+
+[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2432,6 +2530,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2445,23 +2558,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64",
  "bytes",
  "futures-channel",
  "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -2597,6 +2731,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "if-addrs"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b2eeee38fef3aa9b4cc5f1beea8a2444fc00e7377cafae396de3f5c2065e24"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "ignore"
 version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2680,6 +2824,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2712,7 +2862,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2723,7 +2873,7 @@ checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2941,7 +3091,21 @@ checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "mdns-sd"
+version = "0.13.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328f4e1041f7cfeb3affccb814ddbe2f004856a2ce769c8bf22080d74c5204c6"
+dependencies = [
+ "fastrand",
+ "flume",
+ "if-addrs",
+ "log",
+ "mio",
+ "socket2 0.5.10",
 ]
 
 [[package]]
@@ -3001,6 +3165,29 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe 0.2.1",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -3096,7 +3283,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3136,6 +3323,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "openssl"
+version = "0.10.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3149,9 +3361,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.115"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",
@@ -3323,6 +3535,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "petgraph"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+dependencies = [
+ "fixedbitset",
+ "indexmap 2.14.0",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3339,7 +3561,7 @@ checksum = "a990e22f43e84855daf260dded30524ef4a9021cc7541c26540500a50b624389"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3416,7 +3638,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -3448,6 +3694,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-build"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+dependencies = [
+ "heck",
+ "itertools",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn 2.0.117",
+ "tempfile",
+]
+
+[[package]]
 name = "prost-derive"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3457,7 +3723,16 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -3566,7 +3841,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3597,6 +3872,46 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tower 0.5.3",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "ring"
@@ -3645,7 +3960,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3738,7 +4053,7 @@ checksum = "22f968c5ea23d555e670b449c1c5e7b2fc399fdaec1d304a17cd48e288abc107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3748,7 +4063,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -3797,7 +4112,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3841,7 +4156,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3863,6 +4178,19 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.14.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -3976,7 +4304,7 @@ checksum = "0eb01866308440fc64d6c44d9e86c5cc17adfe33c4d6eed55da9145044d0ffc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4002,7 +4330,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]
@@ -4041,6 +4378,16 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
@@ -4055,6 +4402,9 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -4064,7 +4414,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4073,7 +4423,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d8a928f38f1bc873f28e0d2ba8298ad65374a6ac2241dabd297271531a736cd"
 dependencies = [
- "syn",
+ "syn 2.0.117",
  "synthez-codegen",
  "synthez-core",
 ]
@@ -4084,7 +4434,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fb83b8df4238e11746984dfb3819b155cd270de0e25847f45abad56b3671047"
 dependencies = [
- "syn",
+ "syn 2.0.117",
  "synthez-core",
 ]
 
@@ -4097,7 +4447,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sealed",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4115,6 +4465,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4124,7 +4495,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4134,7 +4505,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4174,7 +4545,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4185,7 +4556,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4278,7 +4649,17 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -4300,6 +4681,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -4438,6 +4820,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic-build"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac6f67be712d12f0b41328db3137e0d0757645d8904b4cb7d51cd9c2279e847"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build",
+ "prost-types",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4497,9 +4893,11 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -4534,7 +4932,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4627,7 +5025,7 @@ checksum = "076a02dc54dd46795c2e9c8282ed40bcfb1e22747e955de9389a1de28190fb26"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4688,6 +5086,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4716,6 +5120,42 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "utoipa"
+version = "4.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5afb1a60e207dca502682537fefcfd9921e71d0b83e9576060f09abc6efab23"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20c24e8ab68ff9ee746aad22d39b5535601e6416d1b0feeabf78be986a5c4392"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "uuid"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+dependencies = [
+ "getrandom 0.4.2",
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "valuable"
@@ -4792,6 +5232,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4810,7 +5260,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -4855,6 +5305,16 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -4907,7 +5367,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4959,7 +5419,7 @@ checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4970,7 +5430,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4981,7 +5441,7 @@ checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4992,7 +5452,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5000,6 +5460,17 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result 0.4.1",
+ "windows-strings",
+]
 
 [[package]]
 name = "windows-result"
@@ -5033,6 +5504,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -5229,7 +5709,7 @@ dependencies = [
  "heck",
  "indexmap 2.14.0",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -5245,7 +5725,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -5312,7 +5792,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -5333,7 +5813,7 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5353,7 +5833,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -5393,7 +5873,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,3 +72,4 @@ opentelemetry-otlp = { version = "0.27", features = ["tonic", "gzip-tonic"] }
 # OpenTelemetry tracing bridge — uncomment when ready to use
 tracing-opentelemetry = "0.27"
 utoipa = "4"
+uuid = { version = "1", features = ["v4", "serde"] }

--- a/crates/agileplus-events/Cargo.toml
+++ b/crates/agileplus-events/Cargo.toml
@@ -14,6 +14,7 @@ sha2 = { workspace = true }
 thiserror = { workspace = true }
 async-trait = "0.1"
 tokio = { workspace = true }
+uuid = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/agileplus-events/src/domain_event.rs
+++ b/crates/agileplus-events/src/domain_event.rs
@@ -1,0 +1,680 @@
+//! Typed domain-event enum — every aggregate transition becomes a concrete variant.
+//!
+//! Design: the events crate defines *what happened* in the domain. It depends on
+//! `agileplus-domain` for status/state types but introduces no concrete bus or
+//! persistence.  Consumers (bus adapters, projections) implement the `EventHandler`
+//! port defined in this module.
+//!
+//! Traceability: FR-008 / WP02 (domain-event layer)
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use agileplus_domain::domain::epic::EpicStatus;
+use agileplus_domain::domain::state_machine::FeatureState;
+use agileplus_domain::domain::story::StoryStatus;
+use agileplus_domain::domain::user::{UserRole, UserStatus};
+use agileplus_domain::domain::work_package::WpState;
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Aggregate-id newtype (keeps IDs from different aggregates from mixing)
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Strongly-typed identifier for a domain aggregate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct AggregateId(pub i64);
+
+impl From<i64> for AggregateId {
+    fn from(v: i64) -> Self {
+        Self(v)
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Payload types (carry only the data needed by projections / subscribers)
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Project created.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProjectCreated {
+    pub project_id: AggregateId,
+    pub slug: String,
+    pub name: String,
+}
+
+/// Project renamed.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProjectRenamed {
+    pub project_id: AggregateId,
+    pub old_name: String,
+    pub new_name: String,
+}
+
+/// Project archived (soft-delete).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProjectArchived {
+    pub project_id: AggregateId,
+}
+
+/// Epic created under a project.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EpicCreated {
+    pub epic_id: AggregateId,
+    pub project_id: AggregateId,
+    pub title: String,
+}
+
+/// Epic status changed (e.g. Backlog → Active).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EpicStatusChanged {
+    pub epic_id: AggregateId,
+    pub project_id: AggregateId,
+    pub from: EpicStatus,
+    pub to: EpicStatus,
+}
+
+/// Story created under an epic.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StoryCreated {
+    pub story_id: AggregateId,
+    pub epic_id: AggregateId,
+    pub project_id: AggregateId,
+    pub title: String,
+    pub points: Option<u32>,
+}
+
+/// Story status changed.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StoryStatusChanged {
+    pub story_id: AggregateId,
+    pub epic_id: AggregateId,
+    pub from: StoryStatus,
+    pub to: StoryStatus,
+}
+
+/// Story assigned to a user (or unassigned).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StoryAssigned {
+    pub story_id: AggregateId,
+    pub assignee_id: Option<AggregateId>,
+}
+
+/// User added to the platform.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UserAdded {
+    pub user_id: AggregateId,
+    pub display_name: String,
+    pub email: String,
+    pub role: UserRole,
+}
+
+/// User role changed.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UserRoleChanged {
+    pub user_id: AggregateId,
+    pub old_role: UserRole,
+    pub new_role: UserRole,
+}
+
+/// User status changed (active / inactive / suspended).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UserStatusChanged {
+    pub user_id: AggregateId,
+    pub from: UserStatus,
+    pub to: UserStatus,
+}
+
+/// Feature created.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FeatureCreated {
+    pub feature_id: AggregateId,
+    pub slug: String,
+    pub friendly_name: String,
+    pub project_id: Option<AggregateId>,
+}
+
+/// Feature state advanced (e.g. Created → Specified).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FeatureStateAdvanced {
+    pub feature_id: AggregateId,
+    pub from: FeatureState,
+    pub to: FeatureState,
+}
+
+/// Feature shipped (terminal state reached).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FeatureShipped {
+    pub feature_id: AggregateId,
+    pub slug: String,
+}
+
+/// Work-package created under a feature.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkPackageCreated {
+    pub wp_id: AggregateId,
+    pub feature_id: AggregateId,
+    pub title: String,
+    pub sequence: i32,
+}
+
+/// Work-package state changed.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkPackageStateChanged {
+    pub wp_id: AggregateId,
+    pub feature_id: AggregateId,
+    pub from: WpState,
+    pub to: WpState,
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// The domain-event enum
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Every observable transition in the AgilePlus domain.
+///
+/// Add a variant here when a new aggregate is introduced or an existing one
+/// gains a new observable transition.  Variants are `#[non_exhaustive]` to
+/// allow downstream crates to match without breaking on future additions.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum DomainEvent {
+    // --- Project ---
+    ProjectCreated(ProjectCreated),
+    ProjectRenamed(ProjectRenamed),
+    ProjectArchived(ProjectArchived),
+
+    // --- Epic ---
+    EpicCreated(EpicCreated),
+    EpicStatusChanged(EpicStatusChanged),
+
+    // --- Story ---
+    StoryCreated(StoryCreated),
+    StoryStatusChanged(StoryStatusChanged),
+    StoryAssigned(StoryAssigned),
+
+    // --- User ---
+    UserAdded(UserAdded),
+    UserRoleChanged(UserRoleChanged),
+    UserStatusChanged(UserStatusChanged),
+
+    // --- Feature ---
+    FeatureCreated(FeatureCreated),
+    FeatureStateAdvanced(FeatureStateAdvanced),
+    FeatureShipped(FeatureShipped),
+
+    // --- WorkPackage ---
+    WorkPackageCreated(WorkPackageCreated),
+    WorkPackageStateChanged(WorkPackageStateChanged),
+}
+
+impl DomainEvent {
+    /// Human-readable event type string (useful for logging / routing).
+    pub fn event_type(&self) -> &'static str {
+        match self {
+            DomainEvent::ProjectCreated(_) => "project.created",
+            DomainEvent::ProjectRenamed(_) => "project.renamed",
+            DomainEvent::ProjectArchived(_) => "project.archived",
+            DomainEvent::EpicCreated(_) => "epic.created",
+            DomainEvent::EpicStatusChanged(_) => "epic.status_changed",
+            DomainEvent::StoryCreated(_) => "story.created",
+            DomainEvent::StoryStatusChanged(_) => "story.status_changed",
+            DomainEvent::StoryAssigned(_) => "story.assigned",
+            DomainEvent::UserAdded(_) => "user.added",
+            DomainEvent::UserRoleChanged(_) => "user.role_changed",
+            DomainEvent::UserStatusChanged(_) => "user.status_changed",
+            DomainEvent::FeatureCreated(_) => "feature.created",
+            DomainEvent::FeatureStateAdvanced(_) => "feature.state_advanced",
+            DomainEvent::FeatureShipped(_) => "feature.shipped",
+            DomainEvent::WorkPackageCreated(_) => "work_package.created",
+            DomainEvent::WorkPackageStateChanged(_) => "work_package.state_changed",
+        }
+    }
+
+    /// The aggregate type this event belongs to (e.g. `"Project"`).
+    pub fn aggregate_type(&self) -> &'static str {
+        match self {
+            DomainEvent::ProjectCreated(_)
+            | DomainEvent::ProjectRenamed(_)
+            | DomainEvent::ProjectArchived(_) => "Project",
+
+            DomainEvent::EpicCreated(_) | DomainEvent::EpicStatusChanged(_) => "Epic",
+
+            DomainEvent::StoryCreated(_)
+            | DomainEvent::StoryStatusChanged(_)
+            | DomainEvent::StoryAssigned(_) => "Story",
+
+            DomainEvent::UserAdded(_)
+            | DomainEvent::UserRoleChanged(_)
+            | DomainEvent::UserStatusChanged(_) => "User",
+
+            DomainEvent::FeatureCreated(_)
+            | DomainEvent::FeatureStateAdvanced(_)
+            | DomainEvent::FeatureShipped(_) => "Feature",
+
+            DomainEvent::WorkPackageCreated(_) | DomainEvent::WorkPackageStateChanged(_) => {
+                "WorkPackage"
+            }
+        }
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// EventEnvelope — wraps a DomainEvent with routing metadata
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// An immutable, serialisable wrapper around a [`DomainEvent`].
+///
+/// The envelope carries the metadata needed by infrastructure (bus routing,
+/// idempotency checks, audit log) without leaking those concerns into the
+/// domain payload.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EventEnvelope {
+    /// Globally unique identifier for this envelope instance.
+    pub id: Uuid,
+    /// Wall-clock time when the envelope was created.
+    pub occurred_at: DateTime<Utc>,
+    /// The primary aggregate's id (entity that produced the event).
+    pub aggregate_id: AggregateId,
+    /// The aggregate type name (`"Project"`, `"Epic"`, …).
+    pub aggregate_type: String,
+    /// Causal chain: the id of the command/event that triggered this event.
+    pub causation_id: Option<Uuid>,
+    /// Correlation id that spans a logical operation across multiple events.
+    pub correlation_id: Option<Uuid>,
+    /// The event payload.
+    pub payload: DomainEvent,
+}
+
+impl EventEnvelope {
+    /// Wrap a [`DomainEvent`] in an envelope with a new UUID and current timestamp.
+    pub fn new(aggregate_id: impl Into<AggregateId>, payload: DomainEvent) -> Self {
+        let aggregate_id = aggregate_id.into();
+        let aggregate_type = payload.aggregate_type().to_string();
+        Self {
+            id: Uuid::new_v4(),
+            occurred_at: Utc::now(),
+            aggregate_id,
+            aggregate_type,
+            causation_id: None,
+            correlation_id: None,
+            payload,
+        }
+    }
+
+    /// Builder: attach a causation id.
+    pub fn with_causation(mut self, id: Uuid) -> Self {
+        self.causation_id = Some(id);
+        self
+    }
+
+    /// Builder: attach a correlation id.
+    pub fn with_correlation(mut self, id: Uuid) -> Self {
+        self.correlation_id = Some(id);
+        self
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// EventHandler port — hexagonal outbound port; NO concrete bus here
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Subscriber / handler port for domain events (hexagonal outbound port).
+///
+/// Infrastructure adapters (NATS publisher, in-memory bus, test spy, …) implement
+/// this trait.  The domain and application layers only depend on this trait, never
+/// on concrete message-broker libraries.
+///
+/// Implementations MUST be idempotent: the same envelope may be delivered more
+/// than once.
+pub trait EventHandler: Send + Sync {
+    /// Handle a single domain-event envelope synchronously.
+    ///
+    /// Return `Err` only for unrecoverable failures; transient errors should be
+    /// retried by the caller.
+    fn handle(&self, envelope: &EventEnvelope) -> Result<(), EventHandlerError>;
+}
+
+/// Async version of [`EventHandler`] for I/O-bound subscribers.
+#[async_trait::async_trait]
+pub trait AsyncEventHandler: Send + Sync {
+    async fn handle(&self, envelope: &EventEnvelope) -> Result<(), EventHandlerError>;
+}
+
+/// Error returned by an [`EventHandler`].
+#[derive(Debug, thiserror::Error)]
+pub enum EventHandlerError {
+    #[error("handler rejected event: {0}")]
+    Rejected(String),
+    #[error("handler encountered a transient error: {0}")]
+    Transient(String),
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// EventBus port — dispatches to registered handlers (no concrete impl here)
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Port for publishing domain-event envelopes to zero or more handlers.
+///
+/// Concrete adapters (in-process fan-out, NATS, etc.) implement this trait.
+pub trait EventBus: Send + Sync {
+    /// Publish an envelope to all registered handlers.
+    fn publish(&self, envelope: EventEnvelope) -> Result<(), EventHandlerError>;
+}
+
+/// Async version of [`EventBus`].
+#[async_trait::async_trait]
+pub trait AsyncEventBus: Send + Sync {
+    async fn publish(&self, envelope: EventEnvelope) -> Result<(), EventHandlerError>;
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Tests
+// ──────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use agileplus_domain::domain::epic::EpicStatus;
+    use agileplus_domain::domain::story::StoryStatus;
+    use agileplus_domain::domain::user::{UserRole, UserStatus};
+    use std::sync::{Arc, Mutex};
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    fn project_created() -> DomainEvent {
+        DomainEvent::ProjectCreated(ProjectCreated {
+            project_id: 1.into(),
+            slug: "my-project".into(),
+            name: "My Project".into(),
+        })
+    }
+
+    fn epic_status_changed() -> DomainEvent {
+        DomainEvent::EpicStatusChanged(EpicStatusChanged {
+            epic_id: 2.into(),
+            project_id: 1.into(),
+            from: EpicStatus::Backlog,
+            to: EpicStatus::Active,
+        })
+    }
+
+    fn story_created() -> DomainEvent {
+        DomainEvent::StoryCreated(StoryCreated {
+            story_id: 10.into(),
+            epic_id: 2.into(),
+            project_id: 1.into(),
+            title: "User can log in".into(),
+            points: Some(3),
+        })
+    }
+
+    fn story_status_changed() -> DomainEvent {
+        DomainEvent::StoryStatusChanged(StoryStatusChanged {
+            story_id: 10.into(),
+            epic_id: 2.into(),
+            from: StoryStatus::Todo,
+            to: StoryStatus::InProgress,
+        })
+    }
+
+    fn user_added() -> DomainEvent {
+        DomainEvent::UserAdded(UserAdded {
+            user_id: 5.into(),
+            display_name: "Alice".into(),
+            email: "alice@example.com".into(),
+            role: UserRole::Member,
+        })
+    }
+
+    // ── event construction ────────────────────────────────────────────────────
+
+    #[test]
+    fn project_created_event_type_string() {
+        assert_eq!(project_created().event_type(), "project.created");
+    }
+
+    #[test]
+    fn epic_status_changed_aggregate_type() {
+        assert_eq!(epic_status_changed().aggregate_type(), "Epic");
+    }
+
+    #[test]
+    fn story_created_aggregate_type() {
+        assert_eq!(story_created().aggregate_type(), "Story");
+    }
+
+    #[test]
+    fn user_added_event_type_string() {
+        assert_eq!(user_added().event_type(), "user.added");
+    }
+
+    #[test]
+    fn all_event_type_strings_are_unique() {
+        let variants: Vec<&str> = vec![
+            "project.created",
+            "project.renamed",
+            "project.archived",
+            "epic.created",
+            "epic.status_changed",
+            "story.created",
+            "story.status_changed",
+            "story.assigned",
+            "user.added",
+            "user.role_changed",
+            "user.status_changed",
+            "feature.created",
+            "feature.state_advanced",
+            "feature.shipped",
+            "work_package.created",
+            "work_package.state_changed",
+        ];
+        let mut seen = std::collections::HashSet::new();
+        for v in variants {
+            assert!(seen.insert(v), "duplicate event type string: {v}");
+        }
+    }
+
+    // ── EventEnvelope round-trip ──────────────────────────────────────────────
+
+    #[test]
+    fn envelope_round_trip_serde() {
+        let env = EventEnvelope::new(1i64, project_created());
+        let json = serde_json::to_string(&env).expect("serialize");
+        let decoded: EventEnvelope = serde_json::from_str(&json).expect("deserialize");
+
+        assert_eq!(env.id, decoded.id);
+        assert_eq!(env.aggregate_id, decoded.aggregate_id);
+        assert_eq!(env.aggregate_type, decoded.aggregate_type);
+        match decoded.payload {
+            DomainEvent::ProjectCreated(p) => {
+                assert_eq!(p.slug, "my-project");
+                assert_eq!(p.name, "My Project");
+            }
+            other => panic!("unexpected variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn epic_status_changed_serde_round_trip() {
+        let env = EventEnvelope::new(2i64, epic_status_changed());
+        let json = serde_json::to_string(&env).unwrap();
+        let decoded: EventEnvelope = serde_json::from_str(&json).unwrap();
+        match decoded.payload {
+            DomainEvent::EpicStatusChanged(e) => {
+                assert_eq!(e.from, EpicStatus::Backlog);
+                assert_eq!(e.to, EpicStatus::Active);
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn story_status_changed_serde_round_trip() {
+        let env = EventEnvelope::new(10i64, story_status_changed());
+        let json = serde_json::to_string(&env).unwrap();
+        let decoded: EventEnvelope = serde_json::from_str(&json).unwrap();
+        match decoded.payload {
+            DomainEvent::StoryStatusChanged(s) => {
+                assert_eq!(s.from, StoryStatus::Todo);
+                assert_eq!(s.to, StoryStatus::InProgress);
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn envelope_causation_correlation_builders() {
+        let cause = Uuid::new_v4();
+        let corr = Uuid::new_v4();
+        let env = EventEnvelope::new(1i64, project_created())
+            .with_causation(cause)
+            .with_correlation(corr);
+        assert_eq!(env.causation_id, Some(cause));
+        assert_eq!(env.correlation_id, Some(corr));
+    }
+
+    #[test]
+    fn envelope_ids_are_unique() {
+        let a = EventEnvelope::new(1i64, project_created());
+        let b = EventEnvelope::new(1i64, project_created());
+        assert_ne!(a.id, b.id);
+    }
+
+    // ── EventHandler port ─────────────────────────────────────────────────────
+
+    /// Test spy that records every envelope it receives.
+    struct SpyHandler {
+        received: Arc<Mutex<Vec<EventEnvelope>>>,
+    }
+
+    impl SpyHandler {
+        fn new() -> (Self, Arc<Mutex<Vec<EventEnvelope>>>) {
+            let received = Arc::new(Mutex::new(Vec::new()));
+            (
+                Self {
+                    received: received.clone(),
+                },
+                received,
+            )
+        }
+    }
+
+    impl EventHandler for SpyHandler {
+        fn handle(&self, envelope: &EventEnvelope) -> Result<(), EventHandlerError> {
+            self.received.lock().unwrap().push(envelope.clone());
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn handler_receives_emitted_events() {
+        let (handler, received) = SpyHandler::new();
+
+        let envelopes = vec![
+            EventEnvelope::new(1i64, project_created()),
+            EventEnvelope::new(2i64, epic_status_changed()),
+            EventEnvelope::new(10i64, story_created()),
+        ];
+
+        for env in &envelopes {
+            handler.handle(env).expect("handle should succeed");
+        }
+
+        let got = received.lock().unwrap();
+        assert_eq!(got.len(), 3);
+        assert_eq!(got[0].aggregate_type, "Project");
+        assert_eq!(got[1].aggregate_type, "Epic");
+        assert_eq!(got[2].aggregate_type, "Story");
+    }
+
+    #[test]
+    fn handler_event_types_match_payloads() {
+        let (handler, received) = SpyHandler::new();
+
+        handler
+            .handle(&EventEnvelope::new(5i64, user_added()))
+            .unwrap();
+
+        let got = received.lock().unwrap();
+        assert_eq!(got[0].payload.event_type(), "user.added");
+    }
+
+    // ── in-process EventBus ───────────────────────────────────────────────────
+
+    /// Minimal synchronous fan-out bus (in-process; no external deps).
+    struct InProcessBus {
+        handlers: Vec<Box<dyn EventHandler>>,
+    }
+
+    impl InProcessBus {
+        fn new() -> Self {
+            Self {
+                handlers: Vec::new(),
+            }
+        }
+
+        fn register(&mut self, h: impl EventHandler + 'static) {
+            self.handlers.push(Box::new(h));
+        }
+    }
+
+    impl EventBus for InProcessBus {
+        fn publish(&self, envelope: EventEnvelope) -> Result<(), EventHandlerError> {
+            for h in &self.handlers {
+                h.handle(&envelope)?;
+            }
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn bus_fan_out_to_multiple_handlers() {
+        let (h1, r1) = SpyHandler::new();
+        let (h2, r2) = SpyHandler::new();
+
+        let mut bus = InProcessBus::new();
+        bus.register(h1);
+        bus.register(h2);
+
+        bus.publish(EventEnvelope::new(1i64, project_created()))
+            .unwrap();
+
+        assert_eq!(r1.lock().unwrap().len(), 1);
+        assert_eq!(r2.lock().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn work_package_events_round_trip() {
+        let wp_created = DomainEvent::WorkPackageCreated(WorkPackageCreated {
+            wp_id: 20.into(),
+            feature_id: 3.into(),
+            title: "Implement login endpoint".into(),
+            sequence: 1,
+        });
+        let env = EventEnvelope::new(20i64, wp_created);
+        let json = serde_json::to_string(&env).unwrap();
+        let decoded: EventEnvelope = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.aggregate_type, "WorkPackage");
+        assert_eq!(decoded.payload.event_type(), "work_package.created");
+    }
+
+    #[test]
+    fn user_status_changed_round_trip() {
+        let ev = DomainEvent::UserStatusChanged(UserStatusChanged {
+            user_id: 5.into(),
+            from: UserStatus::Active,
+            to: UserStatus::Suspended,
+        });
+        let env = EventEnvelope::new(5i64, ev);
+        let json = serde_json::to_string(&env).unwrap();
+        let decoded: EventEnvelope = serde_json::from_str(&json).unwrap();
+        match decoded.payload {
+            DomainEvent::UserStatusChanged(u) => {
+                assert_eq!(u.from, UserStatus::Active);
+                assert_eq!(u.to, UserStatus::Suspended);
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+}

--- a/crates/agileplus-events/src/lib.rs
+++ b/crates/agileplus-events/src/lib.rs
@@ -1,15 +1,27 @@
 //! Event sourcing engine for AgilePlus.
 //!
-//! Provides append-only event storage with SHA-256 hash chain verification,
-//! snapshot management, aggregate replay, and query filtering.
+//! Provides:
+//! - Append-only event storage with SHA-256 hash chain verification
+//! - Snapshot management and aggregate replay
+//! - Query filtering
+//! - Typed domain-event enum + EventEnvelope + EventHandler port (hexagonal)
+//!
 //! Traceability: FR-008 / WP02
 
+pub mod domain_event;
 pub mod hash;
 pub mod query;
 pub mod replay;
 pub mod snapshot;
 pub mod store;
 
+pub use domain_event::{
+    AggregateId, AsyncEventBus, AsyncEventHandler, DomainEvent, EpicCreated, EpicStatusChanged,
+    EventBus, EventEnvelope, EventHandler, EventHandlerError, FeatureCreated, FeatureShipped,
+    FeatureStateAdvanced, ProjectArchived, ProjectCreated, ProjectRenamed, StoryAssigned,
+    StoryCreated, StoryStatusChanged, UserAdded, UserRoleChanged, UserStatusChanged,
+    WorkPackageCreated, WorkPackageStateChanged,
+};
 pub use hash::{HashError, compute_hash, verify_chain};
 pub use query::{EventQuery, QueryError};
 pub use replay::{Aggregate, ReplayError, replay_events, replay_events_since};


### PR DESCRIPTION
## **User description**
## Summary

- Adds `domain_event.rs` to `agileplus-events` with 16-variant `DomainEvent` enum covering all aggregate transitions: Project, Epic, Story, User, Feature, WorkPackage
- `EventEnvelope` wraps any `DomainEvent` with `id: Uuid`, `occurred_at`, `aggregate_id/type`, `causation_id`, `correlation_id`
- Hexagonal outbound ports: `EventHandler` (sync), `AsyncEventHandler` (async), `EventBus`, `AsyncEventBus` — no concrete bus dependency
- `uuid 1.x` (v4 + serde) added to workspace dependencies
- 35 tests: event construction, serde round-trips, handler spy, in-process fan-out bus

## Test plan
- [x] `cargo test -p agileplus-events` — 35/35 green
- [x] `cargo check --workspace` — 0 errors

Generated with Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API and ports in the events crate with broad test coverage; no changes to persistence, auth, or live publish paths yet.
> 
> **Overview**
> Introduces a **typed domain-event layer** in `agileplus-events` so aggregate transitions are explicit, serializable payloads instead of ad hoc messages.
> 
> Adds `domain_event.rs` with **`AggregateId`**, per-transition payload structs, and a **`#[non_exhaustive]` `DomainEvent`** enum (16 variants across Project, Epic, Story, User, Feature, WorkPackage) plus **`event_type()` / `aggregate_type()`** for routing and logging. **`EventEnvelope`** wraps each event with UUID id, timestamp, aggregate metadata, and optional causation/correlation IDs.
> 
> Defines hexagonal **outbound ports** only—**`EventHandler` / `AsyncEventHandler`**, **`EventBus` / `AsyncEventBus`**, and **`EventHandlerError`**—with no NATS or other broker wired in this PR. The crate **`lib.rs`** re-exports the new types; workspace **`uuid`** (v4 + serde) is added and **`agileplus-events`** depends on it. Unit tests cover serde round-trips, handler spy behavior, and an in-process fan-out bus.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf123ba3e7b7326b0be3bba7c80193dff3e06e23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Add typed domain events with routing metadata and handler ports**

### What Changed
- Domain changes are now represented as named event types for projects, epics, stories, users, features, and work packages
- Each event is wrapped with an ID, timestamp, aggregate details, and optional causation/correlation IDs for tracking related activity
- Event consumers can now handle events through shared sync or async handler and bus interfaces, including in-process fan-out
- Event data now includes readable event names and aggregate names for logging and routing

### Impact
`✅ Clearer event tracking`
`✅ Easier event routing`
`✅ Safer event handling`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
