### PR TITLE
feat(application): hexagonal application/use-case layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,14 +53,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "agileplus-application"
+version = "0.1.0"
+dependencies = [
+ "agileplus-domain",
+ "async-trait",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
 name = "agileplus-cli"
 version = "0.1.0"
 dependencies = [
  "agileplus-domain",
+ "agileplus-github",
  "anyhow",
+ "async-trait",
  "chrono",
  "clap",
  "tokio",
+ "tokio-test",
  "tracing",
  "tracing-subscriber",
 ]
@@ -485,9 +498,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "axum"
@@ -672,9 +685,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytecount"
@@ -699,9 +712,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -976,9 +989,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -1050,9 +1063,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1089,9 +1102,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "encode_unicode"
@@ -1160,13 +1173,12 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filetime"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
  "cfg-if",
  "libc",
- "libredox",
 ]
 
 [[package]]
@@ -1478,9 +1490,9 @@ dependencies = [
 
 [[package]]
 name = "gix-actor"
-version = "0.41.0"
+version = "0.41.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "272916673b83714734b15d4ef3c8b5f1ccddb15fea8ff548430b97c1ab7b7ed8"
+checksum = "8bc998b8f746dda8565450d08a63b792ced9165d8c27a1ed3f02799ec6a7820f"
 dependencies = [
  "bstr",
  "gix-date",
@@ -1502,9 +1514,9 @@ dependencies = [
 
 [[package]]
 name = "gix-attributes"
-version = "0.33.0"
+version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe17c5a1c0b6f2ef1476aa1d3222ea50cdff67608016613a58bfc3e078046000"
+checksum = "8d43f12e246d3bf7ec624c8fc15ac4a4b62b7c4c6f586cb82be6c90bf84c9d02"
 dependencies = [
  "bstr",
  "gix-glob",
@@ -1519,9 +1531,9 @@ dependencies = [
 
 [[package]]
 name = "gix-bitmap"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ecbfc77ec6852294e341ecc305a490b59f2813e6ca42d79efda5099dcab1894"
+checksum = "52ebef0c26ad305747649e727bbcd56a7b7910754eb7cea88f6dff6f93c51283"
 dependencies = [
  "gix-error",
 ]
@@ -1548,18 +1560,18 @@ dependencies = [
 
 [[package]]
 name = "gix-chunk"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edf288be9b60fe7231de03771faa292be1493d84786f68727e33ad1f91764320"
+checksum = "9faee47943b638e58ddd5e275a4906ad3e4b6c8584f1d41bd18ab9032ec52afb"
 dependencies = [
  "gix-error",
 ]
 
 [[package]]
 name = "gix-command"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86335306511abe43d75c866d4b1f3d90932fe202edcd43e1314036333e7384d8"
+checksum = "00706d4fef135ef4b01680d5218c6ee40cda8baf697b864296cbc887d19118f6"
 dependencies = [
  "bstr",
  "gix-path",
@@ -1570,9 +1582,9 @@ dependencies = [
 
 [[package]]
 name = "gix-commitgraph"
-version = "0.37.0"
+version = "0.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe3b5aa0f24e19028c261d229aeeedafcaaa52ebd71021cc15184620fc9d32eb"
+checksum = "7f675d0df484a7f6a47e64bd6f311af489d947c0323b0564f36d14f3d7762abb"
 dependencies = [
  "bstr",
  "gix-chunk",
@@ -1602,9 +1614,9 @@ dependencies = [
 
 [[package]]
 name = "gix-config-value"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13b39ed39ee4c10a3b157f9fb94bac8098d9f8e56201f0cf7dee6c187416c4b2"
+checksum = "ed42168329552f6c2e5df09665c104199d45d84bedb53683738a49b57fe1baab"
 dependencies = [
  "bitflags",
  "bstr",
@@ -1615,15 +1627,14 @@ dependencies = [
 
 [[package]]
 name = "gix-date"
-version = "0.15.3"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b94cdae4eb4b0f4136e3d9b3aa2d2cd03cfb5bb9b636b31263aea2df86d41543"
+checksum = "a3ecab64a98bbac9f8e02990a9ea5e3c974a7d49b95f2bd70ad94ad22fa6b48c"
 dependencies = [
  "bstr",
  "gix-error",
  "itoa",
  "jiff",
- "smallvec",
 ]
 
 [[package]]
@@ -1684,18 +1695,18 @@ dependencies = [
 
 [[package]]
 name = "gix-error"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e207b971746ab724fccdfced2e4e19e854744611904a0195d3aa8fda8a110613"
+checksum = "e57831e199be480af90dcd7e459abed8a174c09ec9a6e2cc8f7ca6c54598b06b"
 dependencies = [
  "bstr",
 ]
 
 [[package]]
 name = "gix-features"
-version = "0.48.0"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af375693ad5333d0a2c66b4c5b2cbe9ccc38e34f8e8bf24e4ae42c12307fdc4f"
+checksum = "1849ae154d38bc403185be14fa871e38e3c93ee606875d94e207fdb9fba52dbc"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -1733,9 +1744,9 @@ dependencies = [
 
 [[package]]
 name = "gix-fs"
-version = "0.21.1"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e1967daac9848757c47c2aef0c57bcadc1a897347f559778249bf286a536c86"
+checksum = "6cdff46db8798e47e2f727d84b9379aac5add3dd3d9d0b07bb4d7d5d640771fe"
 dependencies = [
  "bstr",
  "fastrand",
@@ -1747,9 +1758,9 @@ dependencies = [
 
 [[package]]
 name = "gix-glob"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08bf29249a069bf2507f5964f80997f37b134d320ea348d66527726b9be2c38c"
+checksum = "d1fcb8ef5b16bcf874abe9b68d8abb3c0493c876d367ab824151f30a0f3f3756"
 dependencies = [
  "bitflags",
  "bstr",
@@ -1759,9 +1770,9 @@ dependencies = [
 
 [[package]]
 name = "gix-hash"
-version = "0.25.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf70d1e252337eed16360f8b8ebb71865ece58eab7954b39ce38b420de703d2"
+checksum = "cb0926d3819c837750b4e03c7754901e73f68b8c9b690753a6372a1bed4eedce"
 dependencies = [
  "faster-hex",
  "gix-features",
@@ -1771,20 +1782,20 @@ dependencies = [
 
 [[package]]
 name = "gix-hashtable"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d33b455e07b3c16d3b2eeebc7b38d2dafcbf8a653de1138ef55d4c2a1fd0b08b"
+checksum = "b0e30b93eea8718baf7d8153fcb938e2926175bbf18097c09f1c01b6f0be0563"
 dependencies = [
  "gix-hash",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "parking_lot",
 ]
 
 [[package]]
 name = "gix-ignore"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bb13fbbeeafee943e52b61fcc88dfddf6a452fcaf0c4d0cdc8f218fa25bbec5"
+checksum = "d491bab9bf2c9f341dc754f425c31d5d3f63aca615312167b82e1deeaca97d8d"
 dependencies = [
  "bstr",
  "gix-glob",
@@ -1795,12 +1806,12 @@ dependencies = [
 
 [[package]]
 name = "gix-imara-diff"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39eb0623e15e4cb83c02ce6a959e48fadd1ae3b715b36b5acc01816e01388c82"
+checksum = "19753d40da53d0ec41604750eeb969097a90fb2d7f7992730d904541c04e2c19"
 dependencies = [
  "bstr",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -1833,9 +1844,9 @@ dependencies = [
 
 [[package]]
 name = "gix-lock"
-version = "23.0.0"
+version = "23.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b3bc074e5723027b482dcd9ab99d95804a53742f6de812d0172fbba4a186c1"
+checksum = "65c9dedd9e90b0d47624d2ed241d394e09294118364e87b9b7e5f1fe755f3c2c"
 dependencies = [
  "gix-tempfile",
  "gix-utils",
@@ -1943,9 +1954,9 @@ dependencies = [
 
 [[package]]
 name = "gix-packetline"
-version = "0.21.3"
+version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "362246df440ee691699f0664cbf7006a6ece477db6734222be95e4198e5656e6"
+checksum = "bb18337ba2830bb43367d1af43819c8c78f31337f079fc76d0f1f1750a173126"
 dependencies = [
  "bstr",
  "faster-hex",
@@ -1955,9 +1966,9 @@ dependencies = [
 
 [[package]]
 name = "gix-path"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "671a6059e8a4c1b7f406e24716499cefa3926e060876fb1959ef225efeee346e"
+checksum = "afa6ac14cd14939ea94a496ce7460daa6511c09f5b84757e9cfc6f9c8d0f93a6"
 dependencies = [
  "bstr",
  "gix-trace",
@@ -1967,9 +1978,9 @@ dependencies = [
 
 [[package]]
 name = "gix-pathspec"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a84a4f083dd70fb49f4377e13afa6d90df2daaa1c705c49d6ff1331fc7e8855"
+checksum = "3050783b41ee11511e1e8fb35623df81806194f4030395f14f48ea37c2798c9f"
 dependencies = [
  "bitflags",
  "bstr",
@@ -2001,9 +2012,9 @@ dependencies = [
 
 [[package]]
 name = "gix-quote"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e97b73791a64bc0fa7dd2c5b3e551136115f97750b876ed1c952c7a7dbaf8be"
+checksum = "a6e541fc33cc2b783b7979040d445a0c86a2eca747c8faea4ca84230d06ae6ef"
 dependencies = [
  "bstr",
  "gix-error",
@@ -2083,9 +2094,9 @@ dependencies = [
 
 [[package]]
 name = "gix-sec"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5a3a2d3e504a238136751e646a6c028252286a0ea64ea9974bf0498633407c6"
+checksum = "ab8519976e4c7e486270740a5400369f37940779b80bd1377d94cfa1125d01b3"
 dependencies = [
  "bitflags",
  "gix-path",
@@ -2095,9 +2106,9 @@ dependencies = [
 
 [[package]]
 name = "gix-shallow"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29187305521bfacf4aefd284ab28dbfa9fb74abd39a5e63dd313b1baa5808c27"
+checksum = "a292fc2fe548c5dfa575479d16b445b0ddf1dd2f56f1fec6aed386f82553cd97"
 dependencies = [
  "bstr",
  "gix-hash",
@@ -2146,9 +2157,9 @@ dependencies = [
 
 [[package]]
 name = "gix-tempfile"
-version = "23.0.0"
+version = "23.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "691ea1e31435c7e7d4d04705ec9d1c0d9482c46b2acf512bc723939d8f0af7fb"
+checksum = "27850097e1ff9515f46a0dad0f5f9c9d020e972727772dabab9450690c4adb22"
 dependencies = [
  "dashmap",
  "gix-fs",
@@ -2159,15 +2170,15 @@ dependencies = [
 
 [[package]]
 name = "gix-trace"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f23569e55f2ffaf958617353b9734a7d52a7c19c439eeaa5e3efc217fd2270e"
+checksum = "44dc45eae785c0eb14173e0f152e6e224dcf4d45b6a6999a3aed22af541ad678"
 
 [[package]]
 name = "gix-transport"
-version = "0.57.0"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffd6a5c676b92d4ead5f5a2b2935024415dec69edc997b6090ca9cac010a3018"
+checksum = "7cd0e34995b1aab0fa8dff2af8db726a0bfad3e119c89302604463264046e7ff"
 dependencies = [
  "bstr",
  "gix-command",
@@ -2198,9 +2209,9 @@ dependencies = [
 
 [[package]]
 name = "gix-url"
-version = "0.36.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35842d099e813f6f6bba529e88d4670572149c3df79b7a412952259887721ece"
+checksum = "65bb01ec69d55e82ccb7a19e264501ead4e6aac38463a8cebfdd81e22bb67ab2"
 dependencies = [
  "bstr",
  "gix-path",
@@ -2210,9 +2221,9 @@ dependencies = [
 
 [[package]]
 name = "gix-utils"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e477b4f07a6e8da4ba791c53c858102959703c60d70f199932010d5b94adb2c"
+checksum = "66c50966184123caf580ffa64e28031a878597f1c7fceb8fe19566c38eb1b771"
 dependencies = [
  "bstr",
  "fastrand",
@@ -2221,9 +2232,9 @@ dependencies = [
 
 [[package]]
 name = "gix-validate"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e26ac2602b43eadfdca0560b81d3341944162a3c9f64ccdeef8fc501ad80dad5"
+checksum = "7bc6fc771c4063ba7cd2f47b91fb6076251c6a823b64b7fe7b8874b0fe4afae3"
 dependencies = [
  "bstr",
 ]
@@ -2377,9 +2388,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
@@ -2443,9 +2457,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes",
  "itoa",
@@ -2509,9 +2523,9 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "eb92f162bf56536459fc83c79b974bb12837acfed43d6bc370a7916d0ae15ecc"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2590,7 +2604,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2773,7 +2787,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -2852,9 +2866,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.24"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
+checksum = "392c70591e8749fe235ddaf513e6f58b26bce3dcc16524cecc8936f75afa161e"
 dependencies = [
  "jiff-static",
  "jiff-tzdb-platform",
@@ -2862,14 +2876,14 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-link",
 ]
 
 [[package]]
 name = "jiff-static"
-version = "0.2.24"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
+checksum = "47b605b0c050d845fc355bb11eb3f9a8deddc218ea60c76e61aa1f2adfb2c96a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2903,9 +2917,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2925,9 +2939,9 @@ dependencies = [
 
 [[package]]
 name = "kqueue-sys"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7b65860415f949f23fa882e669f2dbd4a0f0eeb1acdd56790b30494afd7da2f"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
  "bitflags",
  "libc",
@@ -2962,9 +2976,9 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.18.3+1.9.2"
+version = "0.18.4+1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9b3acc4b91781bb0b3386669d325163746af5f6e4f73e6d2d630e09a35f3487"
+checksum = "9b26f66f35e1871b22efcf7191564123d2a446ca0538cde63c23adfefa9b15b7"
 dependencies = [
  "cc",
  "libc",
@@ -2979,18 +2993,6 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-
-[[package]]
-name = "libredox"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
-dependencies = [
- "bitflags",
- "libc",
- "plain",
- "redox_syscall 0.7.5",
-]
 
 [[package]]
 name = "libsqlite3-sys"
@@ -3058,9 +3060,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "matchers"
@@ -3085,9 +3087,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "maybe-async"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
+checksum = "746873a384ad60adc5db74471dfaba74bd278afbdcfd81db93fafcdfc8b5ca0c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3110,9 +3112,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "memmap2"
@@ -3157,9 +3159,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "log",
@@ -3487,7 +3489,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
@@ -3546,18 +3548,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf0d9e68100b3a7989b4901972f265cd542e560a3a8a724e1e20322f4d06ce9"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a990e22f43e84855daf260dded30524ef4a9021cc7541c26540500a50b624389"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3585,12 +3587,6 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "portable-atomic"
@@ -3811,15 +3807,6 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
 dependencies = [
  "bitflags",
 ]
@@ -4117,9 +4104,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -4325,9 +4312,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -4626,9 +4613,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.2"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -4636,7 +4623,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -4682,6 +4669,17 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
+]
+
+[[package]]
+name = "tokio-test"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6d24790a10a7af737693a3e8f1d03faef7e6ca0cc99aae5066f533766de545"
+dependencies = [
+ "futures-core",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -5220,9 +5218,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5233,9 +5231,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.70"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5243,9 +5241,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5253,9 +5251,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5266,9 +5264,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -5309,9 +5307,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.97"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5798,18 +5796,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "bce33a6288fa3f072a8c2c7d0f2fdbb90e28298f0135c1f99b96c3db2efcc60b"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "8fd425244944f4ab65ccff928e7323354c5a018c75838362fdce749dfad2ee1e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5818,9 +5816,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "3"
 members = [
+    "crates/agileplus-application",
     "crates/agileplus-dashboard",
     "crates/agileplus-domain",
     "crates/agileplus-events",

--- a/crates/agileplus-application/Cargo.toml
+++ b/crates/agileplus-application/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "agileplus-application"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+description = "Application / use-case layer (hexagonal — no framework deps)"
+
+[dependencies]
+agileplus-domain = { path = "../agileplus-domain" }
+async-trait.workspace = true
+thiserror.workspace = true
+tokio = { workspace = true, features = ["full"] }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["full"] }

--- a/crates/agileplus-application/src/dto/mod.rs
+++ b/crates/agileplus-application/src/dto/mod.rs
@@ -1,0 +1,74 @@
+//! Data Transfer Objects for application-layer command/query boundaries.
+//!
+//! These are plain data structs with no domain logic. They cross the use-case
+//! boundary and may be constructed by API handlers, CLI commands, or tests.
+
+use agileplus_domain::domain::feature::Feature;
+use agileplus_domain::domain::story::{Story, StoryStatus};
+
+// ── Feature ──────────────────────────────────────────────────────────────────
+
+/// Command: create a new Feature.
+#[derive(Debug, Clone)]
+pub struct CreateFeatureCmd {
+    pub slug: String,
+    pub friendly_name: String,
+    /// Optional SHA-256 spec hash; defaults to all-zeros if absent.
+    pub spec_hash: Option<[u8; 32]>,
+    pub target_branch: Option<String>,
+}
+
+/// Output of `CreateFeature::execute`.
+#[derive(Debug, Clone)]
+pub struct FeatureCreatedOutput {
+    pub id: i64,
+    pub feature: Feature,
+}
+
+/// Command: advance a Feature through its lifecycle.
+#[derive(Debug, Clone)]
+pub struct AdvanceFeatureCmd {
+    pub feature_id: i64,
+    /// Target state, expressed as the lowercase string (e.g. "specified").
+    pub target_state: String,
+}
+
+// ── Story ─────────────────────────────────────────────────────────────────────
+
+/// Command: create a new Story under an Epic.
+#[derive(Debug, Clone)]
+pub struct CreateStoryCmd {
+    pub epic_id: i64,
+    pub project_id: i64,
+    pub title: String,
+    pub points: Option<u32>,
+}
+
+/// Output of `CreateStory::execute`.
+#[derive(Debug, Clone)]
+pub struct StoryCreatedOutput {
+    pub id: i64,
+    pub story: Story,
+}
+
+/// Command: transition a Story's status.
+#[derive(Debug, Clone)]
+pub struct TransitionStoryCmd {
+    pub story_id: i64,
+    pub target_status: StoryStatus,
+}
+
+// ── Epic ──────────────────────────────────────────────────────────────────────
+
+/// Command: create a new Epic.
+#[derive(Debug, Clone)]
+pub struct CreateEpicCmd {
+    pub project_id: i64,
+    pub title: String,
+}
+
+/// Output of `CreateEpic::execute`.
+#[derive(Debug, Clone)]
+pub struct EpicCreatedOutput {
+    pub id: i64,
+}

--- a/crates/agileplus-application/src/error.rs
+++ b/crates/agileplus-application/src/error.rs
@@ -1,0 +1,24 @@
+//! Application-layer error type.
+//!
+//! Never leaks storage implementation details (no sqlx types, no raw DB errors).
+
+use std::error::Error;
+
+use thiserror::Error;
+
+use agileplus_domain::error::DomainError;
+
+#[derive(Debug, Error)]
+pub enum AppError {
+    /// Domain invariant violation — validation, invalid transition, etc.
+    #[error(transparent)]
+    Domain(#[from] DomainError),
+
+    /// Entity looked up by id / slug does not exist.
+    #[error("not found: {0}")]
+    NotFound(String),
+
+    /// Persistence failure, wrapped without leaking implementation types.
+    #[error("storage error")]
+    Storage(#[source] Box<dyn Error + Send + Sync>),
+}

--- a/crates/agileplus-application/src/events.rs
+++ b/crates/agileplus-application/src/events.rs
@@ -1,0 +1,3 @@
+//! Re-export domain events for application-layer consumers.
+
+pub use agileplus_domain::ports::events::{DomainEvent, DomainEventPublisher};

--- a/crates/agileplus-application/src/lib.rs
+++ b/crates/agileplus-application/src/lib.rs
@@ -132,6 +132,27 @@ mod tests {
         async fn delete_sync_mapping(&self, _: &str, _: i64) -> Result<(), DomainError> { Ok(()) }
         async fn create_project(&self, _: &agileplus_domain::domain::project::Project) -> Result<i64, DomainError> { Ok(0) }
         async fn get_project_by_slug(&self, _: &str) -> Result<Option<agileplus_domain::domain::project::Project>, DomainError> { Ok(None) }
+        async fn get_project_by_id(&self, _: i64) -> Result<Option<agileplus_domain::domain::project::Project>, DomainError> { Ok(None) }
+        async fn list_all_projects(&self) -> Result<Vec<agileplus_domain::domain::project::Project>, DomainError> { Ok(vec![]) }
+        async fn delete_project(&self, _: i64) -> Result<(), DomainError> { Ok(()) }
+        async fn create_user(&self, _: &agileplus_domain::domain::user::User) -> Result<i64, DomainError> { Ok(0) }
+        async fn get_user_by_id(&self, _: i64) -> Result<Option<agileplus_domain::domain::user::User>, DomainError> { Ok(None) }
+        async fn get_user_by_email(&self, _: &str) -> Result<Option<agileplus_domain::domain::user::User>, DomainError> { Ok(None) }
+        async fn update_user_status(&self, _: i64, _: agileplus_domain::domain::user::UserStatus) -> Result<(), DomainError> { Ok(()) }
+        async fn update_user_role(&self, _: i64, _: agileplus_domain::domain::user::UserRole) -> Result<(), DomainError> { Ok(()) }
+        async fn list_all_users(&self) -> Result<Vec<agileplus_domain::domain::user::User>, DomainError> { Ok(vec![]) }
+        async fn delete_user(&self, _: i64) -> Result<(), DomainError> { Ok(()) }
+        async fn create_epic(&self, _: &agileplus_domain::domain::epic::Epic) -> Result<i64, DomainError> { Ok(0) }
+        async fn get_epic_by_id(&self, _: i64) -> Result<Option<agileplus_domain::domain::epic::Epic>, DomainError> { Ok(None) }
+        async fn update_epic_status(&self, _: i64, _: agileplus_domain::domain::epic::EpicStatus) -> Result<(), DomainError> { Ok(()) }
+        async fn list_epics_by_project(&self, _: i64) -> Result<Vec<agileplus_domain::domain::epic::Epic>, DomainError> { Ok(vec![]) }
+        async fn delete_epic(&self, _: i64) -> Result<(), DomainError> { Ok(()) }
+        async fn create_story(&self, _: &agileplus_domain::domain::story::Story) -> Result<i64, DomainError> { Ok(0) }
+        async fn get_story_by_id(&self, _: i64) -> Result<Option<agileplus_domain::domain::story::Story>, DomainError> { Ok(None) }
+        async fn update_story_status(&self, _: i64, _: agileplus_domain::domain::story::StoryStatus) -> Result<(), DomainError> { Ok(()) }
+        async fn list_stories_by_epic(&self, _: i64) -> Result<Vec<agileplus_domain::domain::story::Story>, DomainError> { Ok(vec![]) }
+        async fn list_stories_by_project(&self, _: i64) -> Result<Vec<agileplus_domain::domain::story::Story>, DomainError> { Ok(vec![]) }
+        async fn delete_story(&self, _: i64) -> Result<(), DomainError> { Ok(()) }
     }
 
     /// In-memory Story store.

--- a/crates/agileplus-application/src/lib.rs
+++ b/crates/agileplus-application/src/lib.rs
@@ -1,0 +1,481 @@
+//! `agileplus-application` — hexagonal application / use-case layer.
+//!
+//! Each use case is a struct holding `Arc<dyn Port + Send + Sync>` deps wired
+//! explicitly at call-site. No DI frameworks; no axum/sqlx types.
+//!
+//! # Structure
+//! - `use_cases/` — one module per use case
+//! - `dto/`       — command/output data transfer objects
+//! - `error.rs`   — `AppError` (thiserror; never leaks storage details)
+//! - `events.rs`  — re-exports `DomainEvent` / `DomainEventPublisher`
+
+pub mod dto;
+pub mod error;
+pub mod events;
+pub mod use_cases;
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use async_trait::async_trait;
+    use tokio::sync::RwLock;
+
+    use agileplus_domain::domain::epic::{Epic, EpicStatus};
+    use agileplus_domain::domain::feature::Feature;
+    use agileplus_domain::domain::state_machine::FeatureState;
+    use agileplus_domain::domain::story::{Story, StoryStatus};
+    use agileplus_domain::error::DomainError;
+    use agileplus_domain::ports::epic::EpicRepository;
+    use agileplus_domain::ports::events::{DomainEvent, DomainEventPublisher};
+    use agileplus_domain::ports::story::StoryRepository;
+    use agileplus_domain::ports::StoragePort;
+
+    use crate::dto::*;
+    use crate::error::AppError;
+    use crate::use_cases::{
+        advance_feature::AdvanceFeature,
+        create_epic::CreateEpic,
+        create_feature::CreateFeature,
+        create_story::CreateStory,
+        transition_story::TransitionStory,
+    };
+
+    // ── In-memory doubles ────────────────────────────────────────────────────
+
+    /// In-memory Feature store.
+    #[derive(Default)]
+    struct InMemoryFeatureRepo {
+        store: RwLock<HashMap<i64, Feature>>,
+        next_id: RwLock<i64>,
+    }
+
+    #[async_trait]
+    impl StoragePort for InMemoryFeatureRepo {
+        async fn create_feature(&self, feature: &Feature) -> Result<i64, DomainError> {
+            let mut next = self.next_id.write().await;
+            *next += 1;
+            let id = *next;
+            let mut f = feature.clone();
+            f.id = id;
+            self.store.write().await.insert(id, f);
+            Ok(id)
+        }
+
+        async fn get_feature_by_id(&self, id: i64) -> Result<Option<Feature>, DomainError> {
+            Ok(self.store.read().await.get(&id).cloned())
+        }
+
+        async fn update_feature_state(&self, id: i64, state: FeatureState) -> Result<(), DomainError> {
+            let mut store = self.store.write().await;
+            if let Some(f) = store.get_mut(&id) {
+                f.state = state;
+                Ok(())
+            } else {
+                Err(DomainError::FeatureNotFound(id.to_string()))
+            }
+        }
+
+        // Minimal stubs for the rest of the trait
+        async fn get_feature_by_slug(&self, slug: &str) -> Result<Option<Feature>, DomainError> {
+            Ok(self.store.read().await.values().find(|f| f.slug == slug).cloned())
+        }
+        async fn list_features_by_state(&self, state: FeatureState) -> Result<Vec<Feature>, DomainError> {
+            Ok(self.store.read().await.values().filter(|f| f.state == state).cloned().collect())
+        }
+        async fn list_all_features(&self) -> Result<Vec<Feature>, DomainError> {
+            Ok(self.store.read().await.values().cloned().collect())
+        }
+        async fn create_work_package(&self, _: &agileplus_domain::domain::work_package::WorkPackage) -> Result<i64, DomainError> { Ok(0) }
+        async fn get_work_package(&self, _: i64) -> Result<Option<agileplus_domain::domain::work_package::WorkPackage>, DomainError> { Ok(None) }
+        async fn update_wp_state(&self, _: i64, _: agileplus_domain::domain::work_package::WpState) -> Result<(), DomainError> { Ok(()) }
+        async fn list_wps_by_feature(&self, _: i64) -> Result<Vec<agileplus_domain::domain::work_package::WorkPackage>, DomainError> { Ok(vec![]) }
+        async fn add_wp_dependency(&self, _: &agileplus_domain::domain::work_package::WpDependency) -> Result<(), DomainError> { Ok(()) }
+        async fn get_wp_dependencies(&self, _: i64) -> Result<Vec<agileplus_domain::domain::work_package::WpDependency>, DomainError> { Ok(vec![]) }
+        async fn get_ready_wps(&self, _: i64) -> Result<Vec<agileplus_domain::domain::work_package::WorkPackage>, DomainError> { Ok(vec![]) }
+        async fn append_audit_entry(&self, _: &agileplus_domain::domain::audit::AuditEntry) -> Result<i64, DomainError> { Ok(0) }
+        async fn get_audit_trail(&self, _: i64) -> Result<Vec<agileplus_domain::domain::audit::AuditEntry>, DomainError> { Ok(vec![]) }
+        async fn get_latest_audit_entry(&self, _: i64) -> Result<Option<agileplus_domain::domain::audit::AuditEntry>, DomainError> { Ok(None) }
+        async fn create_evidence(&self, _: &agileplus_domain::domain::governance::Evidence) -> Result<i64, DomainError> { Ok(0) }
+        async fn get_evidence_by_wp(&self, _: i64) -> Result<Vec<agileplus_domain::domain::governance::Evidence>, DomainError> { Ok(vec![]) }
+        async fn get_evidence_by_fr(&self, _: &str) -> Result<Vec<agileplus_domain::domain::governance::Evidence>, DomainError> { Ok(vec![]) }
+        async fn create_policy_rule(&self, _: &agileplus_domain::domain::governance::PolicyRule) -> Result<i64, DomainError> { Ok(0) }
+        async fn list_active_policies(&self) -> Result<Vec<agileplus_domain::domain::governance::PolicyRule>, DomainError> { Ok(vec![]) }
+        async fn record_metric(&self, _: &agileplus_domain::domain::metric::Metric) -> Result<i64, DomainError> { Ok(0) }
+        async fn get_metrics_by_feature(&self, _: i64) -> Result<Vec<agileplus_domain::domain::metric::Metric>, DomainError> { Ok(vec![]) }
+        async fn create_governance_contract(&self, _: &agileplus_domain::domain::governance::GovernanceContract) -> Result<i64, DomainError> { Ok(0) }
+        async fn get_governance_contract(&self, _: i64, _: i32) -> Result<Option<agileplus_domain::domain::governance::GovernanceContract>, DomainError> { Ok(None) }
+        async fn get_latest_governance_contract(&self, _: i64) -> Result<Option<agileplus_domain::domain::governance::GovernanceContract>, DomainError> { Ok(None) }
+        async fn create_module(&self, _: &agileplus_domain::domain::module::Module) -> Result<i64, DomainError> { Ok(0) }
+        async fn get_module(&self, _: i64) -> Result<Option<agileplus_domain::domain::module::Module>, DomainError> { Ok(None) }
+        async fn get_module_by_slug(&self, _: &str) -> Result<Option<agileplus_domain::domain::module::Module>, DomainError> { Ok(None) }
+        async fn update_module(&self, _: i64, _: &str, _: Option<&str>) -> Result<(), DomainError> { Ok(()) }
+        async fn delete_module(&self, _: i64) -> Result<(), DomainError> { Ok(()) }
+        async fn list_root_modules(&self) -> Result<Vec<agileplus_domain::domain::module::Module>, DomainError> { Ok(vec![]) }
+        async fn list_child_modules(&self, _: i64) -> Result<Vec<agileplus_domain::domain::module::Module>, DomainError> { Ok(vec![]) }
+        async fn get_module_with_features(&self, _: i64) -> Result<Option<agileplus_domain::domain::module::ModuleWithFeatures>, DomainError> { Ok(None) }
+        async fn tag_feature_to_module(&self, _: &agileplus_domain::domain::module::ModuleFeatureTag) -> Result<(), DomainError> { Ok(()) }
+        async fn untag_feature_from_module(&self, _: i64, _: i64) -> Result<(), DomainError> { Ok(()) }
+        async fn create_cycle(&self, _: &agileplus_domain::domain::cycle::Cycle) -> Result<i64, DomainError> { Ok(0) }
+        async fn get_cycle(&self, _: i64) -> Result<Option<agileplus_domain::domain::cycle::Cycle>, DomainError> { Ok(None) }
+        async fn update_cycle_state(&self, _: i64, _: agileplus_domain::domain::cycle::CycleState) -> Result<(), DomainError> { Ok(()) }
+        async fn list_cycles_by_state(&self, _: agileplus_domain::domain::cycle::CycleState) -> Result<Vec<agileplus_domain::domain::cycle::Cycle>, DomainError> { Ok(vec![]) }
+        async fn list_cycles_by_module(&self, _: i64) -> Result<Vec<agileplus_domain::domain::cycle::Cycle>, DomainError> { Ok(vec![]) }
+        async fn list_all_cycles(&self) -> Result<Vec<agileplus_domain::domain::cycle::Cycle>, DomainError> { Ok(vec![]) }
+        async fn get_cycle_with_features(&self, _: i64) -> Result<Option<agileplus_domain::domain::cycle::CycleWithFeatures>, DomainError> { Ok(None) }
+        async fn add_feature_to_cycle(&self, _: &agileplus_domain::domain::cycle::CycleFeature) -> Result<(), DomainError> { Ok(()) }
+        async fn remove_feature_from_cycle(&self, _: i64, _: i64) -> Result<(), DomainError> { Ok(()) }
+        async fn get_sync_mapping(&self, _: &str, _: i64) -> Result<Option<agileplus_domain::domain::sync_mapping::SyncMapping>, DomainError> { Ok(None) }
+        async fn upsert_sync_mapping(&self, _: &agileplus_domain::domain::sync_mapping::SyncMapping) -> Result<(), DomainError> { Ok(()) }
+        async fn get_sync_mapping_by_plane_id(&self, _: &str, _: &str) -> Result<Option<agileplus_domain::domain::sync_mapping::SyncMapping>, DomainError> { Ok(None) }
+        async fn delete_sync_mapping(&self, _: &str, _: i64) -> Result<(), DomainError> { Ok(()) }
+        async fn create_project(&self, _: &agileplus_domain::domain::project::Project) -> Result<i64, DomainError> { Ok(0) }
+        async fn get_project_by_slug(&self, _: &str) -> Result<Option<agileplus_domain::domain::project::Project>, DomainError> { Ok(None) }
+    }
+
+    /// In-memory Story store.
+    #[derive(Default)]
+    struct InMemoryStoryRepo {
+        store: RwLock<HashMap<i64, Story>>,
+        next_id: RwLock<i64>,
+    }
+
+    #[async_trait]
+    impl StoryRepository for InMemoryStoryRepo {
+        async fn create(&self, story: &Story) -> Result<i64, DomainError> {
+            let mut next = self.next_id.write().await;
+            *next += 1;
+            let id = *next;
+            let mut s = story.clone();
+            s.id = id;
+            self.store.write().await.insert(id, s);
+            Ok(id)
+        }
+
+        async fn get_by_id(&self, id: i64) -> Result<Option<Story>, DomainError> {
+            Ok(self.store.read().await.get(&id).cloned())
+        }
+
+        async fn update_status(&self, id: i64, status: StoryStatus) -> Result<(), DomainError> {
+            let mut store = self.store.write().await;
+            if let Some(s) = store.get_mut(&id) {
+                s.status = status;
+                Ok(())
+            } else {
+                Err(DomainError::NotFound(id.to_string()))
+            }
+        }
+
+        async fn list_by_epic(&self, epic_id: i64) -> Result<Vec<Story>, DomainError> {
+            Ok(self.store.read().await.values().filter(|s| s.epic_id == epic_id).cloned().collect())
+        }
+    }
+
+    /// In-memory Epic store.
+    #[derive(Default)]
+    struct InMemoryEpicRepo {
+        store: RwLock<HashMap<i64, Epic>>,
+        next_id: RwLock<i64>,
+    }
+
+    #[async_trait]
+    impl EpicRepository for InMemoryEpicRepo {
+        async fn create(&self, epic: &Epic) -> Result<i64, DomainError> {
+            let mut next = self.next_id.write().await;
+            *next += 1;
+            let id = *next;
+            let mut e = epic.clone();
+            e.id = id;
+            self.store.write().await.insert(id, e);
+            Ok(id)
+        }
+
+        async fn get_by_id(&self, id: i64) -> Result<Option<Epic>, DomainError> {
+            Ok(self.store.read().await.get(&id).cloned())
+        }
+
+        async fn update_status(&self, id: i64, status: EpicStatus) -> Result<(), DomainError> {
+            let mut store = self.store.write().await;
+            if let Some(e) = store.get_mut(&id) {
+                e.status = status;
+                Ok(())
+            } else {
+                Err(DomainError::NotFound(id.to_string()))
+            }
+        }
+
+        async fn list_by_project(&self, project_id: i64) -> Result<Vec<Epic>, DomainError> {
+            Ok(self.store.read().await.values().filter(|e| e.project_id == project_id).cloned().collect())
+        }
+    }
+
+    /// Spy publisher — records emitted events.
+    #[derive(Default)]
+    struct SpyPublisher {
+        events: RwLock<Vec<DomainEvent>>,
+    }
+
+    #[async_trait]
+    impl DomainEventPublisher for SpyPublisher {
+        async fn publish(&self, event: DomainEvent) -> Result<(), DomainError> {
+            self.events.write().await.push(event);
+            Ok(())
+        }
+    }
+
+    impl SpyPublisher {
+        async fn emitted(&self) -> Vec<DomainEvent> {
+            self.events.read().await.clone()
+        }
+    }
+
+    // ── Tests ────────────────────────────────────────────────────────────────
+
+    // --- CreateFeature ---
+
+    #[tokio::test]
+    async fn create_feature_happy_path() {
+        let repo = Arc::new(InMemoryFeatureRepo::default());
+        let pub_ = Arc::new(SpyPublisher::default());
+        let uc = CreateFeature::new(repo.clone(), pub_.clone());
+
+        let out = uc.execute(CreateFeatureCmd {
+            slug: "auth".to_string(),
+            friendly_name: "Authentication".to_string(),
+            spec_hash: None,
+            target_branch: None,
+        }).await.unwrap();
+
+        assert_eq!(out.id, 1);
+        assert_eq!(out.feature.slug, "auth");
+
+        let events = pub_.emitted().await;
+        assert_eq!(events.len(), 1);
+        assert!(matches!(&events[0], DomainEvent::FeatureCreated { slug, .. } if slug == "auth"));
+    }
+
+    // --- AdvanceFeature ---
+
+    #[tokio::test]
+    async fn advance_feature_valid_transition() {
+        let repo = Arc::new(InMemoryFeatureRepo::default());
+        let pub_ = Arc::new(SpyPublisher::default());
+        let create_uc = CreateFeature::new(repo.clone(), pub_.clone());
+        let advance_uc = AdvanceFeature::new(repo.clone(), pub_.clone());
+
+        let out = create_uc.execute(CreateFeatureCmd {
+            slug: "feat-a".to_string(),
+            friendly_name: "Feature A".to_string(),
+            spec_hash: None,
+            target_branch: None,
+        }).await.unwrap();
+
+        advance_uc.execute(AdvanceFeatureCmd {
+            feature_id: out.id,
+            target_state: "specified".to_string(),
+        }).await.unwrap();
+
+        let feature = repo.get_feature_by_id(out.id).await.unwrap().unwrap();
+        assert_eq!(feature.state, FeatureState::Specified);
+
+        let events = pub_.emitted().await;
+        // created + advanced
+        assert_eq!(events.len(), 2);
+        assert!(matches!(&events[1], DomainEvent::FeatureStateAdvanced { from, to, .. }
+            if from == "created" && to == "specified"));
+    }
+
+    #[tokio::test]
+    async fn advance_feature_invalid_transition_rejected() {
+        let repo = Arc::new(InMemoryFeatureRepo::default());
+        let pub_ = Arc::new(SpyPublisher::default());
+        let create_uc = CreateFeature::new(repo.clone(), pub_.clone());
+        let advance_uc = AdvanceFeature::new(repo.clone(), pub_.clone());
+
+        let out = create_uc.execute(CreateFeatureCmd {
+            slug: "feat-b".to_string(),
+            friendly_name: "Feature B".to_string(),
+            spec_hash: None,
+            target_branch: None,
+        }).await.unwrap();
+
+        // Created -> Shipped is not allowed
+        let err = advance_uc.execute(AdvanceFeatureCmd {
+            feature_id: out.id,
+            target_state: "shipped".to_string(),
+        }).await.unwrap_err();
+
+        assert!(matches!(err, AppError::Domain(_)));
+    }
+
+    #[tokio::test]
+    async fn advance_feature_not_found() {
+        let repo = Arc::new(InMemoryFeatureRepo::default());
+        let pub_ = Arc::new(SpyPublisher::default());
+        let uc = AdvanceFeature::new(repo.clone(), pub_.clone());
+
+        let err = uc.execute(AdvanceFeatureCmd {
+            feature_id: 999,
+            target_state: "specified".to_string(),
+        }).await.unwrap_err();
+
+        assert!(matches!(err, AppError::NotFound(_)));
+    }
+
+    // --- CreateStory ---
+
+    #[tokio::test]
+    async fn create_story_happy_path() {
+        let repo = Arc::new(InMemoryStoryRepo::default());
+        let pub_ = Arc::new(SpyPublisher::default());
+        let uc = CreateStory::new(repo.clone(), pub_.clone());
+
+        let out = uc.execute(CreateStoryCmd {
+            epic_id: 1,
+            project_id: 10,
+            title: "User can log in".to_string(),
+            points: Some(3),
+        }).await.unwrap();
+
+        assert_eq!(out.id, 1);
+        assert_eq!(out.story.title, "User can log in");
+
+        let events = pub_.emitted().await;
+        assert_eq!(events.len(), 1);
+        assert!(matches!(&events[0], DomainEvent::StoryCreated { epic_id: 1, .. }));
+    }
+
+    #[tokio::test]
+    async fn create_story_rejects_empty_title() {
+        let repo = Arc::new(InMemoryStoryRepo::default());
+        let pub_ = Arc::new(SpyPublisher::default());
+        let uc = CreateStory::new(repo, pub_);
+
+        let err = uc.execute(CreateStoryCmd {
+            epic_id: 1,
+            project_id: 10,
+            title: "".to_string(),
+            points: None,
+        }).await.unwrap_err();
+
+        assert!(matches!(err, AppError::Domain(agileplus_domain::error::DomainError::Validation(_))));
+    }
+
+    #[tokio::test]
+    async fn create_story_rejects_zero_points() {
+        let repo = Arc::new(InMemoryStoryRepo::default());
+        let pub_ = Arc::new(SpyPublisher::default());
+        let uc = CreateStory::new(repo, pub_);
+
+        let err = uc.execute(CreateStoryCmd {
+            epic_id: 1,
+            project_id: 10,
+            title: "Some story".to_string(),
+            points: Some(0),
+        }).await.unwrap_err();
+
+        assert!(matches!(err, AppError::Domain(_)));
+    }
+
+    // --- TransitionStory ---
+
+    #[tokio::test]
+    async fn transition_story_happy_path() {
+        let repo = Arc::new(InMemoryStoryRepo::default());
+        let pub_ = Arc::new(SpyPublisher::default());
+        let create_uc = CreateStory::new(repo.clone(), pub_.clone());
+        let trans_uc = TransitionStory::new(repo.clone(), pub_.clone());
+
+        let out = create_uc.execute(CreateStoryCmd {
+            epic_id: 2,
+            project_id: 20,
+            title: "Login flow".to_string(),
+            points: None,
+        }).await.unwrap();
+
+        trans_uc.execute(TransitionStoryCmd {
+            story_id: out.id,
+            target_status: StoryStatus::InProgress,
+        }).await.unwrap();
+
+        let story = repo.get_by_id(out.id).await.unwrap().unwrap();
+        assert_eq!(story.status, StoryStatus::InProgress);
+
+        let events = pub_.emitted().await;
+        assert_eq!(events.len(), 2);
+        assert!(matches!(&events[1], DomainEvent::StoryStatusChanged { from, to, .. }
+            if from == "todo" && to == "in_progress"));
+    }
+
+    #[tokio::test]
+    async fn transition_story_invalid_transition_rejected() {
+        let repo = Arc::new(InMemoryStoryRepo::default());
+        let pub_ = Arc::new(SpyPublisher::default());
+        let create_uc = CreateStory::new(repo.clone(), pub_.clone());
+        let trans_uc = TransitionStory::new(repo.clone(), pub_.clone());
+
+        let out = create_uc.execute(CreateStoryCmd {
+            epic_id: 2,
+            project_id: 20,
+            title: "Story skip".to_string(),
+            points: None,
+        }).await.unwrap();
+
+        // Todo -> Done is not allowed
+        let err = trans_uc.execute(TransitionStoryCmd {
+            story_id: out.id,
+            target_status: StoryStatus::Done,
+        }).await.unwrap_err();
+
+        assert!(matches!(err, AppError::Domain(_)));
+    }
+
+    #[tokio::test]
+    async fn transition_story_not_found() {
+        let repo = Arc::new(InMemoryStoryRepo::default());
+        let pub_ = Arc::new(SpyPublisher::default());
+        let uc = TransitionStory::new(repo, pub_);
+
+        let err = uc.execute(TransitionStoryCmd {
+            story_id: 999,
+            target_status: StoryStatus::InProgress,
+        }).await.unwrap_err();
+
+        assert!(matches!(err, AppError::NotFound(_)));
+    }
+
+    // --- CreateEpic ---
+
+    #[tokio::test]
+    async fn create_epic_happy_path() {
+        let repo = Arc::new(InMemoryEpicRepo::default());
+        let pub_ = Arc::new(SpyPublisher::default());
+        let uc = CreateEpic::new(repo.clone(), pub_.clone());
+
+        let out = uc.execute(CreateEpicCmd {
+            project_id: 5,
+            title: "Auth Epic".to_string(),
+        }).await.unwrap();
+
+        assert_eq!(out.id, 1);
+
+        let events = pub_.emitted().await;
+        assert_eq!(events.len(), 1);
+        assert!(matches!(&events[0], DomainEvent::EpicCreated { project_id: 5, .. }));
+    }
+
+    #[tokio::test]
+    async fn create_epic_rejects_empty_title() {
+        let repo = Arc::new(InMemoryEpicRepo::default());
+        let pub_ = Arc::new(SpyPublisher::default());
+        let uc = CreateEpic::new(repo, pub_);
+
+        let err = uc.execute(CreateEpicCmd {
+            project_id: 5,
+            title: "   ".to_string(),
+        }).await.unwrap_err();
+
+        assert!(matches!(err, AppError::Domain(_)));
+    }
+}

--- a/crates/agileplus-application/src/use_cases/advance_feature.rs
+++ b/crates/agileplus-application/src/use_cases/advance_feature.rs
@@ -1,0 +1,54 @@
+//! Use case: Advance a Feature to the next lifecycle state.
+
+use std::str::FromStr;
+use std::sync::Arc;
+
+use agileplus_domain::domain::state_machine::FeatureState;
+use agileplus_domain::ports::events::{DomainEvent, DomainEventPublisher};
+use agileplus_domain::ports::StoragePort;
+
+use crate::dto::AdvanceFeatureCmd;
+use crate::error::AppError;
+
+/// Advances a Feature one step along the lifecycle state machine.
+pub struct AdvanceFeature {
+    repo: Arc<dyn StoragePort>,
+    publisher: Arc<dyn DomainEventPublisher>,
+}
+
+impl AdvanceFeature {
+    pub fn new(repo: Arc<dyn StoragePort>, publisher: Arc<dyn DomainEventPublisher>) -> Self {
+        Self { repo, publisher }
+    }
+
+    pub async fn execute(&self, cmd: AdvanceFeatureCmd) -> Result<(), AppError> {
+        let mut feature = self
+            .repo
+            .get_feature_by_id(cmd.feature_id)
+            .await?
+            .ok_or_else(|| AppError::NotFound(format!("feature {}", cmd.feature_id)))?;
+
+        let target = FeatureState::from_str(&cmd.target_state)
+            .map_err(|e| AppError::Domain(agileplus_domain::error::DomainError::Validation(e)))?;
+
+        let from = feature.state.to_string();
+        // Validate via domain state machine (returns DomainError on bad transition)
+        feature
+            .transition(target)
+            .map_err(|e| AppError::Domain(agileplus_domain::error::DomainError::Validation(e)))?;
+
+        self.repo
+            .update_feature_state(cmd.feature_id, feature.state)
+            .await?;
+
+        self.publisher
+            .publish(DomainEvent::FeatureStateAdvanced {
+                id: cmd.feature_id,
+                from,
+                to: feature.state.to_string(),
+            })
+            .await?;
+
+        Ok(())
+    }
+}

--- a/crates/agileplus-application/src/use_cases/create_epic.rs
+++ b/crates/agileplus-application/src/use_cases/create_epic.rs
@@ -1,0 +1,38 @@
+//! Use case: Create a new Epic aggregate.
+
+use std::sync::Arc;
+
+use agileplus_domain::domain::epic::Epic;
+use agileplus_domain::ports::epic::EpicRepository;
+use agileplus_domain::ports::events::{DomainEvent, DomainEventPublisher};
+
+use crate::dto::{CreateEpicCmd, EpicCreatedOutput};
+use crate::error::AppError;
+
+/// Creates an Epic, persists it, then publishes `EpicCreated`.
+pub struct CreateEpic {
+    repo: Arc<dyn EpicRepository>,
+    publisher: Arc<dyn DomainEventPublisher>,
+}
+
+impl CreateEpic {
+    pub fn new(repo: Arc<dyn EpicRepository>, publisher: Arc<dyn DomainEventPublisher>) -> Self {
+        Self { repo, publisher }
+    }
+
+    pub async fn execute(&self, cmd: CreateEpicCmd) -> Result<EpicCreatedOutput, AppError> {
+        let epic = Epic::new(cmd.project_id, &cmd.title)?;
+
+        let id = self.repo.create(&epic).await?;
+
+        self.publisher
+            .publish(DomainEvent::EpicCreated {
+                id,
+                project_id: epic.project_id,
+                title: epic.title.clone(),
+            })
+            .await?;
+
+        Ok(EpicCreatedOutput { id })
+    }
+}

--- a/crates/agileplus-application/src/use_cases/create_feature.rs
+++ b/crates/agileplus-application/src/use_cases/create_feature.rs
@@ -1,0 +1,49 @@
+//! Use case: Create a new Feature aggregate and persist it.
+
+use std::sync::Arc;
+
+use agileplus_domain::domain::feature::Feature;
+use agileplus_domain::ports::events::{DomainEvent, DomainEventPublisher};
+use agileplus_domain::ports::StoragePort;
+
+use crate::dto::{CreateFeatureCmd, FeatureCreatedOutput};
+use crate::error::AppError;
+
+/// Creates a Feature, persists it, then publishes `FeatureCreated`.
+pub struct CreateFeature {
+    repo: Arc<dyn StoragePort>,
+    publisher: Arc<dyn DomainEventPublisher>,
+}
+
+impl CreateFeature {
+    pub fn new(repo: Arc<dyn StoragePort>, publisher: Arc<dyn DomainEventPublisher>) -> Self {
+        Self { repo, publisher }
+    }
+
+    pub async fn execute(&self, cmd: CreateFeatureCmd) -> Result<FeatureCreatedOutput, AppError> {
+        let spec_hash = cmd.spec_hash.unwrap_or([0u8; 32]);
+        let feature = Feature::new(
+            &cmd.slug,
+            &cmd.friendly_name,
+            spec_hash,
+            cmd.target_branch.as_deref(),
+        );
+
+        let id = self.repo.create_feature(&feature).await?;
+
+        self.publisher
+            .publish(DomainEvent::FeatureCreated {
+                id,
+                slug: feature.slug.clone(),
+            })
+            .await?;
+
+        let mut persisted = feature;
+        persisted.id = id;
+
+        Ok(FeatureCreatedOutput {
+            id,
+            feature: persisted,
+        })
+    }
+}

--- a/crates/agileplus-application/src/use_cases/create_story.rs
+++ b/crates/agileplus-application/src/use_cases/create_story.rs
@@ -1,0 +1,45 @@
+//! Use case: Create a Story under an Epic.
+
+use std::sync::Arc;
+
+use agileplus_domain::domain::story::Story;
+use agileplus_domain::ports::events::{DomainEvent, DomainEventPublisher};
+use agileplus_domain::ports::StoryRepository;
+
+use crate::dto::{CreateStoryCmd, StoryCreatedOutput};
+use crate::error::AppError;
+
+/// Creates a Story, persists it, then publishes `StoryCreated`.
+pub struct CreateStory {
+    repo: Arc<dyn StoryRepository>,
+    publisher: Arc<dyn DomainEventPublisher>,
+}
+
+impl CreateStory {
+    pub fn new(repo: Arc<dyn StoryRepository>, publisher: Arc<dyn DomainEventPublisher>) -> Self {
+        Self { repo, publisher }
+    }
+
+    pub async fn execute(&self, cmd: CreateStoryCmd) -> Result<StoryCreatedOutput, AppError> {
+        // Domain invariants: non-empty title, points > 0 when given.
+        let story = Story::new(cmd.epic_id, cmd.project_id, &cmd.title, cmd.points)?;
+
+        let id = self.repo.create(&story).await?;
+
+        self.publisher
+            .publish(DomainEvent::StoryCreated {
+                id,
+                epic_id: story.epic_id,
+                title: story.title.clone(),
+            })
+            .await?;
+
+        let mut persisted = story;
+        persisted.id = id;
+
+        Ok(StoryCreatedOutput {
+            id,
+            story: persisted,
+        })
+    }
+}

--- a/crates/agileplus-application/src/use_cases/mod.rs
+++ b/crates/agileplus-application/src/use_cases/mod.rs
@@ -1,0 +1,7 @@
+//! Use-case modules — one struct per use case, holding `Arc<dyn Port>` deps.
+
+pub mod advance_feature;
+pub mod create_epic;
+pub mod create_feature;
+pub mod create_story;
+pub mod transition_story;

--- a/crates/agileplus-application/src/use_cases/transition_story.rs
+++ b/crates/agileplus-application/src/use_cases/transition_story.rs
@@ -1,0 +1,48 @@
+//! Use case: Transition a Story's status (e.g. Todo -> InProgress).
+
+use std::sync::Arc;
+
+use agileplus_domain::ports::events::{DomainEvent, DomainEventPublisher};
+use agileplus_domain::ports::StoryRepository;
+
+use crate::dto::TransitionStoryCmd;
+use crate::error::AppError;
+
+/// Advances a Story's status through allowed transitions.
+pub struct TransitionStory {
+    repo: Arc<dyn StoryRepository>,
+    publisher: Arc<dyn DomainEventPublisher>,
+}
+
+impl TransitionStory {
+    pub fn new(repo: Arc<dyn StoryRepository>, publisher: Arc<dyn DomainEventPublisher>) -> Self {
+        Self { repo, publisher }
+    }
+
+    pub async fn execute(&self, cmd: TransitionStoryCmd) -> Result<(), AppError> {
+        let mut story = self
+            .repo
+            .get_by_id(cmd.story_id)
+            .await?
+            .ok_or_else(|| AppError::NotFound(format!("story {}", cmd.story_id)))?;
+
+        let from = story.status.to_string();
+
+        // Domain invariant enforced inside `transition_status`.
+        story.transition_status(cmd.target_status)?;
+
+        self.repo
+            .update_status(cmd.story_id, story.status)
+            .await?;
+
+        self.publisher
+            .publish(DomainEvent::StoryStatusChanged {
+                id: cmd.story_id,
+                from,
+                to: story.status.to_string(),
+            })
+            .await?;
+
+        Ok(())
+    }
+}

--- a/crates/agileplus-domain/src/ports/epic.rs
+++ b/crates/agileplus-domain/src/ports/epic.rs
@@ -1,0 +1,15 @@
+//! Epic repository port.
+
+use async_trait::async_trait;
+
+use crate::domain::epic::{Epic, EpicStatus};
+use crate::error::DomainError;
+
+/// Repository port for Epic aggregates.
+#[async_trait]
+pub trait EpicRepository: Send + Sync {
+    async fn create(&self, epic: &Epic) -> Result<i64, DomainError>;
+    async fn get_by_id(&self, id: i64) -> Result<Option<Epic>, DomainError>;
+    async fn update_status(&self, id: i64, status: EpicStatus) -> Result<(), DomainError>;
+    async fn list_by_project(&self, project_id: i64) -> Result<Vec<Epic>, DomainError>;
+}

--- a/crates/agileplus-domain/src/ports/events.rs
+++ b/crates/agileplus-domain/src/ports/events.rs
@@ -1,0 +1,21 @@
+//! Domain event publisher port.
+
+use async_trait::async_trait;
+
+use crate::error::DomainError;
+
+/// Application-level domain events emitted AFTER persistence.
+#[derive(Debug, Clone)]
+pub enum DomainEvent {
+    FeatureCreated { id: i64, slug: String },
+    FeatureStateAdvanced { id: i64, from: String, to: String },
+    StoryCreated { id: i64, epic_id: i64, title: String },
+    StoryStatusChanged { id: i64, from: String, to: String },
+    EpicCreated { id: i64, project_id: i64, title: String },
+}
+
+/// Output port for publishing domain events to an event bus / message broker.
+#[async_trait]
+pub trait DomainEventPublisher: Send + Sync {
+    async fn publish(&self, event: DomainEvent) -> Result<(), DomainError>;
+}

--- a/crates/agileplus-domain/src/ports/mod.rs
+++ b/crates/agileplus-domain/src/ports/mod.rs
@@ -1,8 +1,15 @@
 //! Hexagonal-architecture ports — async traits implemented by adapters.
 
+pub mod epic;
+pub mod events;
 pub mod observability;
 pub mod storage;
+pub mod story;
 pub mod vcs;
+
+pub use epic::EpicRepository;
+pub use events::{DomainEvent, DomainEventPublisher};
+pub use story::StoryRepository;
 
 use std::path::{Path, PathBuf};
 

--- a/crates/agileplus-domain/src/ports/story.rs
+++ b/crates/agileplus-domain/src/ports/story.rs
@@ -1,0 +1,15 @@
+//! Story repository port.
+
+use async_trait::async_trait;
+
+use crate::domain::story::{Story, StoryStatus};
+use crate::error::DomainError;
+
+/// Repository port for Story aggregates.
+#[async_trait]
+pub trait StoryRepository: Send + Sync {
+    async fn create(&self, story: &Story) -> Result<i64, DomainError>;
+    async fn get_by_id(&self, id: i64) -> Result<Option<Story>, DomainError>;
+    async fn update_status(&self, id: i64, status: StoryStatus) -> Result<(), DomainError>;
+    async fn list_by_epic(&self, epic_id: i64) -> Result<Vec<Story>, DomainError>;
+}


### PR DESCRIPTION
## **User description**
## Summary

- New crate `crates/agileplus-application` — pure application layer, zero axum/sqlx/DI-framework deps
- 5 use cases: `CreateFeature`, `AdvanceFeature`, `CreateStory`, `TransitionStory`, `CreateEpic`
- Each use case holds `Arc<dyn Port + Send + Sync>` deps wired explicitly at call-site
- `AppError` (thiserror) wraps `DomainError` transparently; never leaks storage types
- Added 3 minimal port traits to `agileplus-domain`: `EpicRepository`, `StoryRepository`, `DomainEventPublisher` (`#[async_trait]` for dyn-safety)
- Domain events published **after** persistence (not from domain ctor)
- 12 tests using in-memory `Arc<RwLock<HashMap>>` doubles + spy publisher — zero real I/O

## Test plan
- [x] `cargo test -p agileplus-application` — 12/12 green
- [x] `cargo check --workspace` — clean (only pre-existing warnings in other crates)
- [ ] Route-thinning (wiring API handlers to these use cases) is a **separate follow-up task**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New architectural layer and event ordering (publish after save) will affect future handler wiring; duplicate epic/story access via StoragePort vs narrow repos may need adapter alignment.
> 
> **Overview**
> Introduces **`agileplus-application`**, a framework-free use-case layer (domain + async traits only) and registers it in the workspace.
> 
> **Domain ports:** Adds **`EpicRepository`**, **`StoryRepository`**, and **`DomainEventPublisher`** with a **`DomainEvent`** enum for feature/story/epic lifecycle signals, re-exported from **`ports/mod.rs`**.
> 
> **Use cases:** Five orchestrators—**`CreateFeature`**, **`AdvanceFeature`**, **`CreateStory`**, **`TransitionStory`**, **`CreateEpic`**—take **`Arc<dyn …>`** repos and a publisher, accept **DTO commands**, run domain validation/transitions, **persist then publish** events, and surface **`AppError`** (domain / not-found / opaque storage).
> 
> **Tests:** Twelve **`tokio`** tests in the crate use in-memory repo doubles and a spy publisher (no API/SQL wiring in this PR). **`Cargo.lock`** also picks up routine dependency bumps (e.g. CLI **`tokio-test`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72f144874fbecff3eeea39a58903d34a3fce4467. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Add a framework-free application layer for creating and advancing work items**

### What Changed
- Added a new application layer that lets the app create features, stories, and epics, and move features and stories through their next states
- Actions now return plain results and simple not-found or domain error messages without exposing storage details
- Events are published only after the data is saved, so users see the change and its event in the expected order
- Added reusable repository and event-publisher contracts for epics, stories, and domain events, and included tests with in-memory fakes

### Impact
`✅ Clearer create-and-update flows`
`✅ Fewer leaked storage errors`
`✅ Reliable event ordering after saves`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
