### PR TITLE
feat(api): wire domain entities to REST endpoints

### DIFF
--- a/crates/agileplus-api/Cargo.toml
+++ b/crates/agileplus-api/Cargo.toml
@@ -34,3 +34,7 @@ tokio-stream = { version = "0.1", features = ["sync"] }
 askama       = "0.12"
 rand         = "0.8"
 base64       = "0.22"
+
+[dev-dependencies]
+axum-test    = "17"
+async-trait  = "0.1"

--- a/crates/agileplus-api/src/lib.rs
+++ b/crates/agileplus-api/src/lib.rs
@@ -9,4 +9,5 @@ pub mod router;
 pub mod routes;
 pub mod state;
 
+pub use router::create_router;
 pub use state::AppState;

--- a/crates/agileplus-api/src/responses.rs
+++ b/crates/agileplus-api/src/responses.rs
@@ -9,8 +9,12 @@ use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
 use agileplus_domain::domain::audit::AuditEntry;
+use agileplus_domain::domain::epic::Epic;
 use agileplus_domain::domain::feature::Feature;
 use agileplus_domain::domain::governance::GovernanceContract;
+use agileplus_domain::domain::project::Project;
+use agileplus_domain::domain::story::Story;
+use agileplus_domain::domain::user::User;
 use agileplus_domain::domain::work_package::WorkPackage;
 
 // ----- Features -----
@@ -117,6 +121,124 @@ impl From<AuditEntry> for AuditEntryResponse {
             actor: e.actor,
             transition: e.transition,
             hash: e.hash.iter().map(|b| format!("{b:02x}")).collect(),
+        }
+    }
+}
+
+// ----- Projects -----
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct ProjectResponse {
+    pub id: i64,
+    pub slug: String,
+    pub name: String,
+    pub description: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+impl From<Project> for ProjectResponse {
+    fn from(p: Project) -> Self {
+        Self {
+            id: p.id,
+            slug: p.slug,
+            name: p.name,
+            description: p.description,
+            created_at: p.created_at.to_rfc3339(),
+            updated_at: p.updated_at.to_rfc3339(),
+        }
+    }
+}
+
+// ----- Epics -----
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct EpicResponse {
+    pub id: i64,
+    pub project_id: i64,
+    pub title: String,
+    pub description: Option<String>,
+    pub status: String,
+    pub owner_id: Option<i64>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+impl From<Epic> for EpicResponse {
+    fn from(e: Epic) -> Self {
+        Self {
+            id: e.id,
+            project_id: e.project_id,
+            title: e.title,
+            description: e.description,
+            status: e.status.to_string(),
+            owner_id: e.owner_id,
+            created_at: e.created_at.to_rfc3339(),
+            updated_at: e.updated_at.to_rfc3339(),
+        }
+    }
+}
+
+// ----- Stories -----
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct StoryResponse {
+    pub id: i64,
+    pub epic_id: i64,
+    pub project_id: i64,
+    pub title: String,
+    pub description: Option<String>,
+    pub status: String,
+    pub points: Option<u32>,
+    pub assignee_id: Option<i64>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+impl From<Story> for StoryResponse {
+    fn from(s: Story) -> Self {
+        Self {
+            id: s.id,
+            epic_id: s.epic_id,
+            project_id: s.project_id,
+            title: s.title,
+            description: s.description,
+            status: s.status.to_string(),
+            points: s.points,
+            assignee_id: s.assignee_id,
+            created_at: s.created_at.to_rfc3339(),
+            updated_at: s.updated_at.to_rfc3339(),
+        }
+    }
+}
+
+// ----- Users -----
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct UserResponse {
+    pub id: i64,
+    pub display_name: String,
+    pub email: String,
+    pub role: String,
+    pub status: String,
+    pub avatar_url: Option<String>,
+    pub github_login: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+impl From<User> for UserResponse {
+    fn from(u: User) -> Self {
+        Self {
+            id: u.id,
+            display_name: u.display_name,
+            email: u.email,
+            role: u.role.to_string(),
+            status: u.status.to_string(),
+            avatar_url: u.avatar_url,
+            github_login: u.github_login,
+            created_at: u.created_at.to_rfc3339(),
+            updated_at: u.updated_at.to_rfc3339(),
         }
     }
 }

--- a/crates/agileplus-api/src/router.rs
+++ b/crates/agileplus-api/src/router.rs
@@ -47,7 +47,7 @@ use agileplus_domain::ports::{
 type BoxError = Box<dyn std::error::Error + Send + Sync>;
 
 use crate::responses::{DetailedHealthResponse, SimpleHealthResponse};
-use crate::routes::{audit, cycle, events, features, governance, module, stream, work_packages};
+use crate::routes::{audit, cycle, epics, events, features, governance, module, projects, stories, stream, users, work_packages};
 use crate::state::AppState;
 
 /// Build the axum [`Router`] with all routes, middleware, and shared state.
@@ -91,6 +91,11 @@ where
         .nest("/api/v1/events", events::routes::<S, V, O>())
         // SSE streaming
         .route("/api/v1/stream", get(stream::stream_events::<S, V, O>))
+        // Domain: projects, epics, stories, users
+        .nest("/api/v1/projects", projects::routes::<S, V, O>())
+        .nest("/api/v1/epics", epics::routes::<S, V, O>())
+        .nest("/api/v1/stories", stories::routes::<S, V, O>())
+        .nest("/api/v1/users", users::routes::<S, V, O>())
         .layer(middleware::from_fn_with_state(
             creds,
             crate::middleware::auth::validate_api_key,

--- a/crates/agileplus-api/src/routes/epics.rs
+++ b/crates/agileplus-api/src/routes/epics.rs
@@ -1,0 +1,140 @@
+//! Epic route handlers.
+//!
+//! - GET  /api/v1/epics/{id}              → get epic
+//! - POST /api/v1/epics                  → create epic
+//! - POST /api/v1/epics/{id}/transition   → transition epic status
+//! - GET  /api/v1/epics/{id}/stories      → list stories for epic
+//!
+//! Traceability: WP12-T080 (domain-wiring)
+
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use serde::Deserialize;
+
+use agileplus_domain::domain::epic::{Epic, EpicStatus};
+use agileplus_domain::ports::{
+    observability::ObservabilityPort, storage::StoragePort, vcs::VcsPort,
+};
+
+use crate::error::ApiError;
+use crate::responses::{EpicResponse, StoryResponse};
+use crate::state::AppState;
+
+pub fn routes<S, V, O>() -> Router<AppState<S, V, O>>
+where
+    S: StoragePort + Send + Sync + 'static,
+    V: VcsPort + Send + Sync + 'static,
+    O: ObservabilityPort + Send + Sync + 'static,
+{
+    Router::new()
+        .route("/", post(create_epic::<S, V, O>))
+        .route("/{id}", get(get_epic::<S, V, O>))
+        .route("/{id}/transition", post(transition_epic::<S, V, O>))
+        .route("/{id}/stories", get(list_stories_for_epic::<S, V, O>))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateEpicRequest {
+    pub project_id: i64,
+    pub title: String,
+    pub description: Option<String>,
+}
+
+/// `POST /api/v1/epics`
+pub async fn create_epic<S, V, O>(
+    State(app): State<AppState<S, V, O>>,
+    Json(body): Json<CreateEpicRequest>,
+) -> Result<(StatusCode, Json<EpicResponse>), ApiError>
+where
+    S: StoragePort + Send + Sync + 'static,
+    V: VcsPort + Send + Sync + 'static,
+    O: ObservabilityPort + Send + Sync + 'static,
+{
+    let mut epic = Epic::new(body.project_id, &body.title)
+        .map_err(|e| ApiError::BadRequest(e.to_string()))?;
+    epic.description = body.description;
+
+    let id = app.storage.create_epic(&epic).await.map_err(ApiError::from)?;
+    let created = Epic { id, ..epic };
+    Ok((StatusCode::CREATED, Json(EpicResponse::from(created))))
+}
+
+/// `GET /api/v1/epics/{id}`
+pub async fn get_epic<S, V, O>(
+    State(app): State<AppState<S, V, O>>,
+    Path(id): Path<i64>,
+) -> Result<Json<EpicResponse>, ApiError>
+where
+    S: StoragePort + Send + Sync + 'static,
+    V: VcsPort + Send + Sync + 'static,
+    O: ObservabilityPort + Send + Sync + 'static,
+{
+    let epic = app
+        .storage
+        .get_epic(id)
+        .await
+        .map_err(ApiError::from)?
+        .ok_or_else(|| ApiError::NotFound(format!("Epic {id} not found")))?;
+    Ok(Json(EpicResponse::from(epic)))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TransitionEpicRequest {
+    pub target_status: String,
+}
+
+/// `POST /api/v1/epics/{id}/transition`
+pub async fn transition_epic<S, V, O>(
+    State(app): State<AppState<S, V, O>>,
+    Path(id): Path<i64>,
+    Json(body): Json<TransitionEpicRequest>,
+) -> Result<Json<EpicResponse>, ApiError>
+where
+    S: StoragePort + Send + Sync + 'static,
+    V: VcsPort + Send + Sync + 'static,
+    O: ObservabilityPort + Send + Sync + 'static,
+{
+    let mut epic = app
+        .storage
+        .get_epic(id)
+        .await
+        .map_err(ApiError::from)?
+        .ok_or_else(|| ApiError::NotFound(format!("Epic {id} not found")))?;
+
+    let target: EpicStatus = body
+        .target_status
+        .parse()
+        .map_err(|e: agileplus_domain::error::DomainError| ApiError::BadRequest(e.to_string()))?;
+    epic.transition_status(target).map_err(ApiError::from)?;
+
+    app.storage
+        .update_epic_status(id, epic.status)
+        .await
+        .map_err(ApiError::from)?;
+
+    Ok(Json(EpicResponse::from(epic)))
+}
+
+/// `GET /api/v1/epics/{id}/stories`
+pub async fn list_stories_for_epic<S, V, O>(
+    State(app): State<AppState<S, V, O>>,
+    Path(id): Path<i64>,
+) -> Result<Json<Vec<StoryResponse>>, ApiError>
+where
+    S: StoragePort + Send + Sync + 'static,
+    V: VcsPort + Send + Sync + 'static,
+    O: ObservabilityPort + Send + Sync + 'static,
+{
+    // verify epic exists
+    let _ = app
+        .storage
+        .get_epic(id)
+        .await
+        .map_err(ApiError::from)?
+        .ok_or_else(|| ApiError::NotFound(format!("Epic {id} not found")))?;
+
+    let stories = app.storage.list_stories_by_epic(id).await.map_err(ApiError::from)?;
+    Ok(Json(stories.into_iter().map(StoryResponse::from).collect()))
+}

--- a/crates/agileplus-api/src/routes/mod.rs
+++ b/crates/agileplus-api/src/routes/mod.rs
@@ -2,9 +2,13 @@
 
 pub mod audit;
 pub mod cycle;
+pub mod epics;
 pub mod events;
 pub mod features;
 pub mod governance;
 pub mod module;
+pub mod projects;
+pub mod stories;
 pub mod stream;
+pub mod users;
 pub mod work_packages;

--- a/crates/agileplus-api/src/routes/projects.rs
+++ b/crates/agileplus-api/src/routes/projects.rs
@@ -1,0 +1,119 @@
+//! Project route handlers.
+//!
+//! - GET  /api/v1/projects              → list all projects
+//! - POST /api/v1/projects              → create project
+//! - GET  /api/v1/projects/{slug}        → get project by slug
+//! - GET  /api/v1/projects/{slug}/epics  → list epics for project
+//!
+//! Traceability: WP12-T080 (domain-wiring)
+
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use serde::Deserialize;
+
+use agileplus_domain::domain::project::Project;
+use agileplus_domain::ports::{
+    observability::ObservabilityPort, storage::StoragePort, vcs::VcsPort,
+};
+
+use crate::error::ApiError;
+use crate::responses::{EpicResponse, ProjectResponse};
+use crate::state::AppState;
+
+pub fn routes<S, V, O>() -> Router<AppState<S, V, O>>
+where
+    S: StoragePort + Send + Sync + 'static,
+    V: VcsPort + Send + Sync + 'static,
+    O: ObservabilityPort + Send + Sync + 'static,
+{
+    Router::new()
+        .route("/", get(list_projects::<S, V, O>))
+        .route("/", post(create_project::<S, V, O>))
+        .route("/{slug}", get(get_project::<S, V, O>))
+        .route("/{slug}/epics", get(list_epics_for_project::<S, V, O>))
+}
+
+/// `GET /api/v1/projects`
+pub async fn list_projects<S, V, O>(
+    State(app): State<AppState<S, V, O>>,
+) -> Result<Json<Vec<ProjectResponse>>, ApiError>
+where
+    S: StoragePort + Send + Sync + 'static,
+    V: VcsPort + Send + Sync + 'static,
+    O: ObservabilityPort + Send + Sync + 'static,
+{
+    let projects = app.storage.list_all_projects().await.map_err(ApiError::from)?;
+    Ok(Json(projects.into_iter().map(ProjectResponse::from).collect()))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateProjectRequest {
+    pub name: String,
+    pub slug: Option<String>,
+    pub description: Option<String>,
+}
+
+/// `POST /api/v1/projects`
+pub async fn create_project<S, V, O>(
+    State(app): State<AppState<S, V, O>>,
+    Json(body): Json<CreateProjectRequest>,
+) -> Result<(StatusCode, Json<ProjectResponse>), ApiError>
+where
+    S: StoragePort + Send + Sync + 'static,
+    V: VcsPort + Send + Sync + 'static,
+    O: ObservabilityPort + Send + Sync + 'static,
+{
+    let slug = body.slug.unwrap_or_else(|| Project::slug_from_name(&body.name));
+    let mut project = Project::new(&body.name, &slug).map_err(|e| ApiError::BadRequest(e.to_string()))?;
+    project.description = body.description;
+
+    let id = app.storage.create_project(&project).await.map_err(ApiError::from)?;
+    let created = Project { id, ..project };
+    Ok((StatusCode::CREATED, Json(ProjectResponse::from(created))))
+}
+
+/// `GET /api/v1/projects/{slug}`
+pub async fn get_project<S, V, O>(
+    State(app): State<AppState<S, V, O>>,
+    Path(slug): Path<String>,
+) -> Result<Json<ProjectResponse>, ApiError>
+where
+    S: StoragePort + Send + Sync + 'static,
+    V: VcsPort + Send + Sync + 'static,
+    O: ObservabilityPort + Send + Sync + 'static,
+{
+    let project = app
+        .storage
+        .get_project_by_slug(&slug)
+        .await
+        .map_err(ApiError::from)?
+        .ok_or_else(|| ApiError::NotFound(format!("Project '{slug}' not found")))?;
+    Ok(Json(ProjectResponse::from(project)))
+}
+
+/// `GET /api/v1/projects/{slug}/epics`
+pub async fn list_epics_for_project<S, V, O>(
+    State(app): State<AppState<S, V, O>>,
+    Path(slug): Path<String>,
+) -> Result<Json<Vec<EpicResponse>>, ApiError>
+where
+    S: StoragePort + Send + Sync + 'static,
+    V: VcsPort + Send + Sync + 'static,
+    O: ObservabilityPort + Send + Sync + 'static,
+{
+    let project = app
+        .storage
+        .get_project_by_slug(&slug)
+        .await
+        .map_err(ApiError::from)?
+        .ok_or_else(|| ApiError::NotFound(format!("Project '{slug}' not found")))?;
+
+    let epics = app
+        .storage
+        .list_epics_by_project(project.id)
+        .await
+        .map_err(ApiError::from)?;
+    Ok(Json(epics.into_iter().map(EpicResponse::from).collect()))
+}

--- a/crates/agileplus-api/src/routes/stories.rs
+++ b/crates/agileplus-api/src/routes/stories.rs
@@ -1,0 +1,118 @@
+//! Story route handlers.
+//!
+//! - GET  /api/v1/stories/{id}            → get story
+//! - POST /api/v1/stories                → create story
+//! - POST /api/v1/stories/{id}/transition → transition story status
+//!
+//! Traceability: WP12-T080 (domain-wiring)
+
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use serde::Deserialize;
+
+use agileplus_domain::domain::story::{Story, StoryStatus};
+use agileplus_domain::ports::{
+    observability::ObservabilityPort, storage::StoragePort, vcs::VcsPort,
+};
+
+use crate::error::ApiError;
+use crate::responses::StoryResponse;
+use crate::state::AppState;
+
+pub fn routes<S, V, O>() -> Router<AppState<S, V, O>>
+where
+    S: StoragePort + Send + Sync + 'static,
+    V: VcsPort + Send + Sync + 'static,
+    O: ObservabilityPort + Send + Sync + 'static,
+{
+    Router::new()
+        .route("/", post(create_story::<S, V, O>))
+        .route("/{id}", get(get_story::<S, V, O>))
+        .route("/{id}/transition", post(transition_story::<S, V, O>))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateStoryRequest {
+    pub epic_id: i64,
+    pub project_id: i64,
+    pub title: String,
+    pub description: Option<String>,
+    pub points: Option<u32>,
+}
+
+/// `POST /api/v1/stories`
+pub async fn create_story<S, V, O>(
+    State(app): State<AppState<S, V, O>>,
+    Json(body): Json<CreateStoryRequest>,
+) -> Result<(StatusCode, Json<StoryResponse>), ApiError>
+where
+    S: StoragePort + Send + Sync + 'static,
+    V: VcsPort + Send + Sync + 'static,
+    O: ObservabilityPort + Send + Sync + 'static,
+{
+    let mut story = Story::new(body.epic_id, body.project_id, &body.title, body.points)
+        .map_err(|e| ApiError::BadRequest(e.to_string()))?;
+    story.description = body.description;
+
+    let id = app.storage.create_story(&story).await.map_err(ApiError::from)?;
+    let created = Story { id, ..story };
+    Ok((StatusCode::CREATED, Json(StoryResponse::from(created))))
+}
+
+/// `GET /api/v1/stories/{id}`
+pub async fn get_story<S, V, O>(
+    State(app): State<AppState<S, V, O>>,
+    Path(id): Path<i64>,
+) -> Result<Json<StoryResponse>, ApiError>
+where
+    S: StoragePort + Send + Sync + 'static,
+    V: VcsPort + Send + Sync + 'static,
+    O: ObservabilityPort + Send + Sync + 'static,
+{
+    let story = app
+        .storage
+        .get_story(id)
+        .await
+        .map_err(ApiError::from)?
+        .ok_or_else(|| ApiError::NotFound(format!("Story {id} not found")))?;
+    Ok(Json(StoryResponse::from(story)))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TransitionStoryRequest {
+    pub target_status: String,
+}
+
+/// `POST /api/v1/stories/{id}/transition`
+pub async fn transition_story<S, V, O>(
+    State(app): State<AppState<S, V, O>>,
+    Path(id): Path<i64>,
+    Json(body): Json<TransitionStoryRequest>,
+) -> Result<Json<StoryResponse>, ApiError>
+where
+    S: StoragePort + Send + Sync + 'static,
+    V: VcsPort + Send + Sync + 'static,
+    O: ObservabilityPort + Send + Sync + 'static,
+{
+    let mut story = app
+        .storage
+        .get_story(id)
+        .await
+        .map_err(ApiError::from)?
+        .ok_or_else(|| ApiError::NotFound(format!("Story {id} not found")))?;
+
+    let target: StoryStatus = body
+        .target_status
+        .parse()
+        .map_err(|e: agileplus_domain::error::DomainError| ApiError::BadRequest(e.to_string()))?;
+    story.transition_status(target).map_err(ApiError::from)?;
+
+    app.storage
+        .update_story_status(id, story.status)
+        .await
+        .map_err(ApiError::from)?;
+
+    Ok(Json(StoryResponse::from(story)))
+}

--- a/crates/agileplus-api/src/routes/users.rs
+++ b/crates/agileplus-api/src/routes/users.rs
@@ -1,0 +1,99 @@
+//! User route handlers.
+//!
+//! - GET  /api/v1/users         → list all users
+//! - POST /api/v1/users         → create user
+//! - GET  /api/v1/users/{id}     → get user by id
+//!
+//! Traceability: WP12-T080 (domain-wiring)
+
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use serde::Deserialize;
+
+use agileplus_domain::domain::user::{User, UserRole};
+use agileplus_domain::ports::{
+    observability::ObservabilityPort, storage::StoragePort, vcs::VcsPort,
+};
+
+use crate::error::ApiError;
+use crate::responses::UserResponse;
+use crate::state::AppState;
+
+pub fn routes<S, V, O>() -> Router<AppState<S, V, O>>
+where
+    S: StoragePort + Send + Sync + 'static,
+    V: VcsPort + Send + Sync + 'static,
+    O: ObservabilityPort + Send + Sync + 'static,
+{
+    Router::new()
+        .route("/", get(list_users::<S, V, O>))
+        .route("/", post(create_user::<S, V, O>))
+        .route("/{id}", get(get_user::<S, V, O>))
+}
+
+/// `GET /api/v1/users`
+pub async fn list_users<S, V, O>(
+    State(app): State<AppState<S, V, O>>,
+) -> Result<Json<Vec<UserResponse>>, ApiError>
+where
+    S: StoragePort + Send + Sync + 'static,
+    V: VcsPort + Send + Sync + 'static,
+    O: ObservabilityPort + Send + Sync + 'static,
+{
+    let users = app.storage.list_all_users().await.map_err(ApiError::from)?;
+    Ok(Json(users.into_iter().map(UserResponse::from).collect()))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateUserRequest {
+    pub display_name: String,
+    pub email: String,
+    /// "admin" | "member" | "viewer" — defaults to "member"
+    pub role: Option<String>,
+}
+
+/// `POST /api/v1/users`
+pub async fn create_user<S, V, O>(
+    State(app): State<AppState<S, V, O>>,
+    Json(body): Json<CreateUserRequest>,
+) -> Result<(StatusCode, Json<UserResponse>), ApiError>
+where
+    S: StoragePort + Send + Sync + 'static,
+    V: VcsPort + Send + Sync + 'static,
+    O: ObservabilityPort + Send + Sync + 'static,
+{
+    let role: UserRole = body
+        .role
+        .as_deref()
+        .unwrap_or("member")
+        .parse()
+        .map_err(|e: agileplus_domain::error::DomainError| ApiError::BadRequest(e.to_string()))?;
+
+    let user = User::new(&body.display_name, &body.email, role)
+        .map_err(|e| ApiError::BadRequest(e.to_string()))?;
+
+    let id = app.storage.create_user(&user).await.map_err(ApiError::from)?;
+    let created = User { id, ..user };
+    Ok((StatusCode::CREATED, Json(UserResponse::from(created))))
+}
+
+/// `GET /api/v1/users/{id}`
+pub async fn get_user<S, V, O>(
+    State(app): State<AppState<S, V, O>>,
+    Path(id): Path<i64>,
+) -> Result<Json<UserResponse>, ApiError>
+where
+    S: StoragePort + Send + Sync + 'static,
+    V: VcsPort + Send + Sync + 'static,
+    O: ObservabilityPort + Send + Sync + 'static,
+{
+    let user = app
+        .storage
+        .get_user(id)
+        .await
+        .map_err(ApiError::from)?
+        .ok_or_else(|| ApiError::NotFound(format!("User {id} not found")))?;
+    Ok(Json(UserResponse::from(user)))
+}

--- a/crates/agileplus-api/tests/api_integration.rs
+++ b/crates/agileplus-api/tests/api_integration.rs
@@ -16,7 +16,6 @@ use agileplus_api::{AppState, create_router};
 use agileplus_domain::config::AppConfig;
 use agileplus_domain::credentials::CredentialStore;
 use agileplus_domain::credentials::InMemoryCredentialStore;
-use agileplus_domain::credentials::keys as cred_keys;
 use agileplus_domain::domain::audit::{AuditEntry, hash_entry};
 use agileplus_domain::domain::backlog::{
     BacklogFilters, BacklogItem, BacklogPriority, BacklogStatus,
@@ -26,7 +25,10 @@ use agileplus_domain::domain::feature::Feature;
 use agileplus_domain::domain::governance::{Evidence, GovernanceContract, PolicyRule};
 use agileplus_domain::domain::metric::Metric;
 use agileplus_domain::domain::module::{Module, ModuleFeatureTag, ModuleWithFeatures};
+use agileplus_domain::domain::epic::{Epic, EpicStatus};
 use agileplus_domain::domain::project::Project;
+use agileplus_domain::domain::story::{Story, StoryStatus};
+use agileplus_domain::domain::user::{User, UserRole};
 use agileplus_domain::domain::state_machine::FeatureState;
 use agileplus_domain::domain::sync_mapping::SyncMapping;
 use agileplus_domain::domain::work_package::{WorkPackage, WpDependency, WpState};
@@ -37,6 +39,7 @@ use agileplus_domain::ports::storage::StoragePort;
 use agileplus_domain::ports::vcs::{
     ConflictInfo, FeatureArtifacts, MergeResult, VcsPort, WorktreeInfo,
 };
+use async_trait::async_trait;
 use axum::http::StatusCode;
 use axum_test::TestServer;
 use chrono::Utc;
@@ -49,6 +52,9 @@ struct MockStorage {
     work_packages: Arc<std::sync::Mutex<Vec<WorkPackage>>>,
     governance: Arc<std::sync::Mutex<Vec<GovernanceContract>>>,
     projects: Arc<std::sync::Mutex<Vec<Project>>>,
+    epics: Arc<std::sync::Mutex<Vec<Epic>>>,
+    stories: Arc<std::sync::Mutex<Vec<Story>>>,
+    users: Arc<std::sync::Mutex<Vec<User>>>,
     audit: Arc<std::sync::Mutex<Vec<AuditEntry>>>,
 }
 
@@ -60,6 +66,9 @@ impl Default for MockStorage {
             governance: Arc::new(std::sync::Mutex::new(Vec::new())),
             audit: Arc::new(std::sync::Mutex::new(Vec::new())),
             projects: Arc::new(std::sync::Mutex::new(Vec::new())),
+            epics: Arc::new(std::sync::Mutex::new(Vec::new())),
+            stories: Arc::new(std::sync::Mutex::new(Vec::new())),
+            users: Arc::new(std::sync::Mutex::new(Vec::new())),
         }
     }
 }
@@ -72,7 +81,40 @@ impl MockStorage {
             id: 1,
             slug: "test-project".to_string(),
             name: "Test Project".to_string(),
-            description: "A test project".to_string(),
+            description: Some("A test project".to_string()),
+            created_at: now,
+            updated_at: now,
+        });
+        s.epics.lock().unwrap().push(Epic {
+            id: 1,
+            project_id: 1,
+            title: "Test Epic".to_string(),
+            description: Some("An epic".to_string()),
+            status: EpicStatus::Active,
+            owner_id: None,
+            created_at: now,
+            updated_at: now,
+        });
+        s.stories.lock().unwrap().push(Story {
+            id: 1,
+            epic_id: 1,
+            project_id: 1,
+            title: "Test Story".to_string(),
+            description: None,
+            status: StoryStatus::Todo,
+            points: Some(3),
+            assignee_id: None,
+            created_at: now,
+            updated_at: now,
+        });
+        s.users.lock().unwrap().push(User {
+            id: 1,
+            display_name: "Alice".to_string(),
+            email: "alice@example.com".to_string(),
+            role: UserRole::Admin,
+            status: agileplus_domain::domain::user::UserStatus::Active,
+            avatar_url: None,
+            github_login: None,
             created_at: now,
             updated_at: now,
         });
@@ -163,6 +205,7 @@ impl MockStorage {
     }
 }
 
+#[async_trait]
 impl StoragePort for MockStorage {
     async fn create_feature(&self, _f: &Feature) -> Result<i64, DomainError> {
         let id = (self.features.lock().unwrap().len() + 1) as i64;
@@ -500,21 +543,109 @@ impl StoragePort for MockStorage {
 
     async fn create_project(
         &self,
-        _project: &agileplus_domain::domain::project::Project,
+        project: &agileplus_domain::domain::project::Project,
     ) -> Result<i64, DomainError> {
-        Ok(1)
+        let mut projects = self.projects.lock().unwrap();
+        let id = (projects.len() as i64) + 1;
+        let mut p = project.clone();
+        p.id = id;
+        projects.push(p);
+        Ok(id)
     }
 
     async fn get_project_by_slug(
         &self,
-        _slug: &str,
+        slug: &str,
     ) -> Result<Option<agileplus_domain::domain::project::Project>, DomainError> {
-        Ok(None)
+        let found = self.projects.lock().unwrap().iter().find(|p| p.slug == slug).cloned();
+        Ok(found)
+    }
+
+    async fn list_all_projects(&self) -> Result<Vec<Project>, DomainError> {
+        Ok(self.projects.lock().unwrap().clone())
+    }
+
+    async fn create_epic(&self, epic: &Epic) -> Result<i64, DomainError> {
+        let mut epics = self.epics.lock().unwrap();
+        let id = (epics.len() as i64) + 1;
+        let mut e = epic.clone();
+        e.id = id;
+        epics.push(e);
+        Ok(id)
+    }
+
+    async fn get_epic(&self, id: i64) -> Result<Option<Epic>, DomainError> {
+        let found = self.epics.lock().unwrap().iter().find(|e| e.id == id).cloned();
+        Ok(found)
+    }
+
+    async fn list_epics_by_project(&self, project_id: i64) -> Result<Vec<Epic>, DomainError> {
+        let epics: Vec<Epic> = self.epics.lock().unwrap().iter().filter(|e| e.project_id == project_id).cloned().collect();
+        Ok(epics)
+    }
+
+    async fn update_epic_status(&self, id: i64, status: EpicStatus) -> Result<(), DomainError> {
+        let mut epics = self.epics.lock().unwrap();
+        if let Some(e) = epics.iter_mut().find(|e| e.id == id) {
+            e.status = status;
+        }
+        Ok(())
+    }
+
+    async fn create_story(&self, story: &Story) -> Result<i64, DomainError> {
+        let mut stories = self.stories.lock().unwrap();
+        let id = (stories.len() as i64) + 1;
+        let mut s = story.clone();
+        s.id = id;
+        stories.push(s);
+        Ok(id)
+    }
+
+    async fn get_story(&self, id: i64) -> Result<Option<Story>, DomainError> {
+        let found = self.stories.lock().unwrap().iter().find(|s| s.id == id).cloned();
+        Ok(found)
+    }
+
+    async fn list_stories_by_epic(&self, epic_id: i64) -> Result<Vec<Story>, DomainError> {
+        let stories: Vec<Story> = self.stories.lock().unwrap().iter().filter(|s| s.epic_id == epic_id).cloned().collect();
+        Ok(stories)
+    }
+
+    async fn update_story_status(&self, id: i64, status: StoryStatus) -> Result<(), DomainError> {
+        let mut stories = self.stories.lock().unwrap();
+        if let Some(s) = stories.iter_mut().find(|s| s.id == id) {
+            s.status = status;
+        }
+        Ok(())
+    }
+
+    async fn create_user(&self, user: &User) -> Result<i64, DomainError> {
+        let mut users = self.users.lock().unwrap();
+        let id = (users.len() as i64) + 1;
+        let mut u = user.clone();
+        u.id = id;
+        users.push(u);
+        Ok(id)
+    }
+
+    async fn get_user(&self, id: i64) -> Result<Option<User>, DomainError> {
+        let found = self.users.lock().unwrap().iter().find(|u| u.id == id).cloned();
+        Ok(found)
+    }
+
+    async fn get_user_by_email(&self, email: &str) -> Result<Option<User>, DomainError> {
+        let found = self.users.lock().unwrap().iter().find(|u| u.email == email).cloned();
+        Ok(found)
+    }
+
+    async fn list_all_users(&self) -> Result<Vec<User>, DomainError> {
+        Ok(self.users.lock().unwrap().clone())
     }
 }
 
 // ── ContentStoragePort for MockStorage ───────────────────────────────────────
 
+#[async_trait]
 impl ContentStoragePort for MockStorage {
     async fn create_feature(
         &self,
@@ -678,6 +809,7 @@ impl ContentStoragePort for MockStorage {
 #[derive(Clone)]
 struct MockVcs;
 
+#[async_trait]
 impl VcsPort for MockVcs {
     async fn create_worktree(&self, _fs: &str, _wp: &str) -> Result<PathBuf, DomainError> {
         Ok(PathBuf::from("/tmp/worktree"))
@@ -694,11 +826,17 @@ impl VcsPort for MockVcs {
     async fn checkout_branch(&self, _b: &str) -> Result<(), DomainError> {
         Ok(())
     }
+    async fn list_branches(&self, _pattern: Option<&str>, _remote: bool) -> Result<Vec<agileplus_domain::ports::vcs::BranchInfo>, DomainError> {
+        Ok(vec![])
+    }
+    async fn delete_branch(&self, _b: &str, _force: bool, _remote: Option<&str>) -> Result<(), DomainError> {
+        Ok(())
+    }
     async fn merge_to_target(&self, _s: &str, _t: &str) -> Result<MergeResult, DomainError> {
         Ok(MergeResult {
             success: true,
-            conflicts: vec![],
-            merged_commit: None,
+            commit: None,
+            message: None,
         })
     }
     async fn detect_conflicts(&self, _s: &str, _t: &str) -> Result<Vec<ConflictInfo>, DomainError> {
@@ -715,9 +853,10 @@ impl VcsPort for MockVcs {
     }
     async fn scan_feature_artifacts(&self, _fs: &str) -> Result<FeatureArtifacts, DomainError> {
         Ok(FeatureArtifacts {
-            meta_json: None,
-            audit_chain: None,
-            evidence_paths: vec![],
+            spec: None,
+            research: None,
+            plan: None,
+            other: vec![],
         })
     }
 }
@@ -757,15 +896,12 @@ async fn setup_test_server() -> TestServer {
     let telemetry = Arc::new(MockObs);
     let config = Arc::new(AppConfig::default());
 
-    let creds_inner = InMemoryCredentialStore::new();
-    creds_inner
-        .set("agileplus", cred_keys::API_KEYS, TEST_API_KEY)
-        .unwrap();
-    let creds: Arc<dyn agileplus_domain::credentials::CredentialStore> = Arc::new(creds_inner);
+    let creds: Arc<dyn agileplus_domain::credentials::CredentialStore> =
+        Arc::new(InMemoryCredentialStore::new(vec![TEST_API_KEY.to_string()]));
 
     let state = AppState::new(storage, vcs, telemetry, config, creds);
     let app = create_router(state);
-    TestServer::new(app)
+    TestServer::new(app).expect("failed to create test server")
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -773,7 +909,8 @@ async fn setup_test_server() -> TestServer {
 #[tokio::test]
 async fn health_no_auth_required() {
     let server = setup_test_server().await;
-    let resp = server.get("/health").await;
+    // /health returns simple health; /detailed-health returns full status
+    let resp = server.get("/detailed-health").await;
     resp.assert_status_ok();
     let body: serde_json::Value = resp.json();
     // Health endpoint returns "healthy" or "degraded" (not "ok") as of WP11-T070.
@@ -941,4 +1078,300 @@ async fn response_content_type_is_json() {
         ct.contains("application/json"),
         "Expected application/json, got: {ct}"
     );
+}
+
+// ── Domain-wiring tests: Projects ─────────────────────────────────────────────
+
+#[tokio::test]
+async fn list_projects_happy_path() {
+    let server = setup_test_server().await;
+    let resp = server
+        .get("/api/v1/projects")
+        .add_header("X-API-Key", TEST_API_KEY)
+        .await;
+    resp.assert_status_ok();
+    let body: serde_json::Value = resp.json();
+    let arr = body.as_array().unwrap();
+    assert!(!arr.is_empty());
+    assert_eq!(arr[0]["slug"], "test-project");
+    assert_eq!(arr[0]["name"], "Test Project");
+}
+
+#[tokio::test]
+async fn get_project_found() {
+    let server = setup_test_server().await;
+    let resp = server
+        .get("/api/v1/projects/test-project")
+        .add_header("X-API-Key", TEST_API_KEY)
+        .await;
+    resp.assert_status_ok();
+    let body: serde_json::Value = resp.json();
+    assert_eq!(body["slug"], "test-project");
+}
+
+#[tokio::test]
+async fn get_project_not_found_returns_404() {
+    let server = setup_test_server().await;
+    let resp = server
+        .get("/api/v1/projects/nonexistent-project")
+        .add_header("X-API-Key", TEST_API_KEY)
+        .await;
+    resp.assert_status(StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn create_project_happy_path() {
+    let server = setup_test_server().await;
+    let resp = server
+        .post("/api/v1/projects")
+        .add_header("X-API-Key", TEST_API_KEY)
+        .json(&serde_json::json!({ "name": "New Project", "slug": "new-project" }))
+        .await;
+    resp.assert_status(StatusCode::CREATED);
+    let body: serde_json::Value = resp.json();
+    assert_eq!(body["slug"], "new-project");
+    assert_eq!(body["name"], "New Project");
+}
+
+#[tokio::test]
+async fn create_project_invalid_slug_returns_400() {
+    let server = setup_test_server().await;
+    let resp = server
+        .post("/api/v1/projects")
+        .add_header("X-API-Key", TEST_API_KEY)
+        .json(&serde_json::json!({ "name": "Bad Project", "slug": "Invalid SLUG!" }))
+        .await;
+    resp.assert_status(StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn list_epics_for_project() {
+    let server = setup_test_server().await;
+    let resp = server
+        .get("/api/v1/projects/test-project/epics")
+        .add_header("X-API-Key", TEST_API_KEY)
+        .await;
+    resp.assert_status_ok();
+    let body: serde_json::Value = resp.json();
+    let arr = body.as_array().unwrap();
+    assert!(!arr.is_empty());
+    assert_eq!(arr[0]["title"], "Test Epic");
+    assert_eq!(arr[0]["project_id"], 1);
+}
+
+// ── Domain-wiring tests: Epics ────────────────────────────────────────────────
+
+#[tokio::test]
+async fn get_epic_happy_path() {
+    let server = setup_test_server().await;
+    let resp = server
+        .get("/api/v1/epics/1")
+        .add_header("X-API-Key", TEST_API_KEY)
+        .await;
+    resp.assert_status_ok();
+    let body: serde_json::Value = resp.json();
+    assert_eq!(body["id"], 1);
+    assert_eq!(body["title"], "Test Epic");
+    assert_eq!(body["status"], "active");
+}
+
+#[tokio::test]
+async fn get_epic_not_found_returns_404() {
+    let server = setup_test_server().await;
+    let resp = server
+        .get("/api/v1/epics/999")
+        .add_header("X-API-Key", TEST_API_KEY)
+        .await;
+    resp.assert_status(StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn create_epic_happy_path() {
+    let server = setup_test_server().await;
+    let resp = server
+        .post("/api/v1/epics")
+        .add_header("X-API-Key", TEST_API_KEY)
+        .json(&serde_json::json!({ "project_id": 1, "title": "New Epic" }))
+        .await;
+    resp.assert_status(StatusCode::CREATED);
+    let body: serde_json::Value = resp.json();
+    assert_eq!(body["title"], "New Epic");
+    assert_eq!(body["status"], "backlog");
+}
+
+#[tokio::test]
+async fn create_epic_empty_title_returns_400() {
+    let server = setup_test_server().await;
+    let resp = server
+        .post("/api/v1/epics")
+        .add_header("X-API-Key", TEST_API_KEY)
+        .json(&serde_json::json!({ "project_id": 1, "title": "   " }))
+        .await;
+    resp.assert_status(StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn transition_epic_invalid_transition_returns_409() {
+    let server = setup_test_server().await;
+    // Epic 1 is Active; Active -> Done is not a valid transition
+    let resp = server
+        .post("/api/v1/epics/1/transition")
+        .add_header("X-API-Key", TEST_API_KEY)
+        .json(&serde_json::json!({ "target_status": "done" }))
+        .await;
+    resp.assert_status(StatusCode::CONFLICT);
+}
+
+#[tokio::test]
+async fn list_stories_for_epic() {
+    let server = setup_test_server().await;
+    let resp = server
+        .get("/api/v1/epics/1/stories")
+        .add_header("X-API-Key", TEST_API_KEY)
+        .await;
+    resp.assert_status_ok();
+    let body: serde_json::Value = resp.json();
+    let arr = body.as_array().unwrap();
+    assert!(!arr.is_empty());
+    assert_eq!(arr[0]["title"], "Test Story");
+}
+
+// ── Domain-wiring tests: Stories ─────────────────────────────────────────────
+
+#[tokio::test]
+async fn get_story_happy_path() {
+    let server = setup_test_server().await;
+    let resp = server
+        .get("/api/v1/stories/1")
+        .add_header("X-API-Key", TEST_API_KEY)
+        .await;
+    resp.assert_status_ok();
+    let body: serde_json::Value = resp.json();
+    assert_eq!(body["id"], 1);
+    assert_eq!(body["title"], "Test Story");
+    assert_eq!(body["status"], "todo");
+}
+
+#[tokio::test]
+async fn get_story_not_found_returns_404() {
+    let server = setup_test_server().await;
+    let resp = server
+        .get("/api/v1/stories/999")
+        .add_header("X-API-Key", TEST_API_KEY)
+        .await;
+    resp.assert_status(StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn create_story_happy_path() {
+    let server = setup_test_server().await;
+    let resp = server
+        .post("/api/v1/stories")
+        .add_header("X-API-Key", TEST_API_KEY)
+        .json(&serde_json::json!({ "epic_id": 1, "project_id": 1, "title": "New Story", "points": 5 }))
+        .await;
+    resp.assert_status(StatusCode::CREATED);
+    let body: serde_json::Value = resp.json();
+    assert_eq!(body["title"], "New Story");
+    assert_eq!(body["points"], 5);
+    assert_eq!(body["status"], "todo");
+}
+
+#[tokio::test]
+async fn create_story_zero_points_returns_400() {
+    let server = setup_test_server().await;
+    let resp = server
+        .post("/api/v1/stories")
+        .add_header("X-API-Key", TEST_API_KEY)
+        .json(&serde_json::json!({ "epic_id": 1, "project_id": 1, "title": "Bad Story", "points": 0 }))
+        .await;
+    resp.assert_status(StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn transition_story_invalid_transition_returns_409() {
+    let server = setup_test_server().await;
+    // Story 1 is Todo; Todo -> Done is not a valid transition
+    let resp = server
+        .post("/api/v1/stories/1/transition")
+        .add_header("X-API-Key", TEST_API_KEY)
+        .json(&serde_json::json!({ "target_status": "done" }))
+        .await;
+    resp.assert_status(StatusCode::CONFLICT);
+}
+
+// ── Domain-wiring tests: Users ────────────────────────────────────────────────
+
+#[tokio::test]
+async fn list_users_happy_path() {
+    let server = setup_test_server().await;
+    let resp = server
+        .get("/api/v1/users")
+        .add_header("X-API-Key", TEST_API_KEY)
+        .await;
+    resp.assert_status_ok();
+    let body: serde_json::Value = resp.json();
+    let arr = body.as_array().unwrap();
+    assert!(!arr.is_empty());
+    assert_eq!(arr[0]["display_name"], "Alice");
+    assert_eq!(arr[0]["email"], "alice@example.com");
+}
+
+#[tokio::test]
+async fn get_user_happy_path() {
+    let server = setup_test_server().await;
+    let resp = server
+        .get("/api/v1/users/1")
+        .add_header("X-API-Key", TEST_API_KEY)
+        .await;
+    resp.assert_status_ok();
+    let body: serde_json::Value = resp.json();
+    assert_eq!(body["id"], 1);
+    assert_eq!(body["email"], "alice@example.com");
+}
+
+#[tokio::test]
+async fn get_user_not_found_returns_404() {
+    let server = setup_test_server().await;
+    let resp = server
+        .get("/api/v1/users/999")
+        .add_header("X-API-Key", TEST_API_KEY)
+        .await;
+    resp.assert_status(StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn create_user_happy_path() {
+    let server = setup_test_server().await;
+    let resp = server
+        .post("/api/v1/users")
+        .add_header("X-API-Key", TEST_API_KEY)
+        .json(&serde_json::json!({ "display_name": "Bob", "email": "bob@example.com", "role": "member" }))
+        .await;
+    resp.assert_status(StatusCode::CREATED);
+    let body: serde_json::Value = resp.json();
+    assert_eq!(body["display_name"], "Bob");
+    assert_eq!(body["role"], "member");
+}
+
+#[tokio::test]
+async fn create_user_invalid_email_returns_400() {
+    let server = setup_test_server().await;
+    let resp = server
+        .post("/api/v1/users")
+        .add_header("X-API-Key", TEST_API_KEY)
+        .json(&serde_json::json!({ "display_name": "Charlie", "email": "not-an-email" }))
+        .await;
+    resp.assert_status(StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn create_user_invalid_role_returns_400() {
+    let server = setup_test_server().await;
+    let resp = server
+        .post("/api/v1/users")
+        .add_header("X-API-Key", TEST_API_KEY)
+        .json(&serde_json::json!({ "display_name": "Dave", "email": "dave@example.com", "role": "superadmin" }))
+        .await;
+    resp.assert_status(StatusCode::BAD_REQUEST);
 }

--- a/crates/agileplus-api/tests/api_integration/support/storage.rs
+++ b/crates/agileplus-api/tests/api_integration/support/storage.rs
@@ -1,6 +1,7 @@
 use std::sync::{Arc, Mutex};
 
 use agileplus_domain::domain::audit::{AuditEntry, hash_entry};
+use agileplus_domain::domain::epic::Epic;
 use agileplus_domain::domain::project::Project;
 use agileplus_domain::domain::backlog::BacklogItem;
 use agileplus_domain::domain::cycle::{Cycle, CycleFeature};
@@ -8,6 +9,8 @@ use agileplus_domain::domain::feature::Feature;
 use agileplus_domain::domain::governance::GovernanceContract;
 use agileplus_domain::domain::module::{Module, ModuleFeatureTag};
 use agileplus_domain::domain::state_machine::FeatureState;
+use agileplus_domain::domain::story::Story;
+use agileplus_domain::domain::user::User;
 use agileplus_domain::domain::work_package::{WorkPackage, WpState};
 use chrono::Utc;
 
@@ -23,6 +26,9 @@ pub(crate) struct MockStorage {
     pub(crate) governance: Arc<Mutex<Vec<GovernanceContract>>>,
     pub(crate) audit: Arc<Mutex<Vec<AuditEntry>>>,
     pub(crate) projects: Arc<Mutex<Vec<Project>>>,
+    pub(crate) epics: Arc<Mutex<Vec<Epic>>>,
+    pub(crate) stories: Arc<Mutex<Vec<Story>>>,
+    pub(crate) users: Arc<Mutex<Vec<User>>>,
 }
 
 impl MockStorage {

--- a/crates/agileplus-api/tests/api_integration/support/storage_port_impl/storage_impl.rs
+++ b/crates/agileplus-api/tests/api_integration/support/storage_port_impl/storage_impl.rs
@@ -2,11 +2,14 @@ use std::future::Future;
 
 use agileplus_domain::domain::audit::AuditEntry;
 use agileplus_domain::domain::cycle::{Cycle, CycleFeature, CycleState, CycleWithFeatures};
+use agileplus_domain::domain::epic::{Epic, EpicStatus};
 use agileplus_domain::domain::governance::{Evidence, GovernanceContract, PolicyRule};
 use agileplus_domain::domain::metric::Metric;
 use agileplus_domain::domain::module::{Module, ModuleFeatureTag, ModuleWithFeatures};
 use agileplus_domain::domain::project::Project;
+use agileplus_domain::domain::story::{Story, StoryStatus};
 use agileplus_domain::domain::sync_mapping::SyncMapping;
+use agileplus_domain::domain::user::{User, UserRole};
 use agileplus_domain::error::DomainError;
 use agileplus_domain::ports::storage::StoragePort;
 
@@ -300,4 +303,90 @@ impl StoragePort for MockStorage {
         async move { Ok(found) }
     }
 
+    fn list_all_projects(&self) -> impl Future<Output = Result<Vec<Project>, DomainError>> + Send {
+        let all = self.projects.lock().expect("projects lock poisoned").clone();
+        async move { Ok(all) }
+    }
+
+    fn create_epic(&self, epic: &Epic) -> impl Future<Output = Result<i64, DomainError>> + Send {
+        let mut epics = self.epics.lock().expect("epics lock poisoned");
+        let id = (epics.len() as i64) + 1;
+        let mut e = epic.clone();
+        e.id = id;
+        epics.push(e);
+        async move { Ok(id) }
+    }
+
+    fn get_epic(&self, id: i64) -> impl Future<Output = Result<Option<Epic>, DomainError>> + Send {
+        let found = self.epics.lock().expect("epics lock poisoned").iter().find(|e| e.id == id).cloned();
+        async move { Ok(found) }
+    }
+
+    fn list_epics_by_project(&self, project_id: i64) -> impl Future<Output = Result<Vec<Epic>, DomainError>> + Send {
+        let epics: Vec<Epic> = self.epics.lock().expect("epics lock poisoned").iter().filter(|e| e.project_id == project_id).cloned().collect();
+        async move { Ok(epics) }
+    }
+
+    fn update_epic_status(&self, id: i64, status: EpicStatus) -> impl Future<Output = Result<(), DomainError>> + Send {
+        {
+            let mut epics = self.epics.lock().expect("epics lock poisoned");
+            if let Some(e) = epics.iter_mut().find(|e| e.id == id) {
+                e.status = status;
+            }
+        }
+        async move { Ok(()) }
+    }
+
+    fn create_story(&self, story: &Story) -> impl Future<Output = Result<i64, DomainError>> + Send {
+        let mut stories = self.stories.lock().expect("stories lock poisoned");
+        let id = (stories.len() as i64) + 1;
+        let mut s = story.clone();
+        s.id = id;
+        stories.push(s);
+        async move { Ok(id) }
+    }
+
+    fn get_story(&self, id: i64) -> impl Future<Output = Result<Option<Story>, DomainError>> + Send {
+        let found = self.stories.lock().expect("stories lock poisoned").iter().find(|s| s.id == id).cloned();
+        async move { Ok(found) }
+    }
+
+    fn list_stories_by_epic(&self, epic_id: i64) -> impl Future<Output = Result<Vec<Story>, DomainError>> + Send {
+        let stories: Vec<Story> = self.stories.lock().expect("stories lock poisoned").iter().filter(|s| s.epic_id == epic_id).cloned().collect();
+        async move { Ok(stories) }
+    }
+
+    fn update_story_status(&self, id: i64, status: StoryStatus) -> impl Future<Output = Result<(), DomainError>> + Send {
+        {
+            let mut stories = self.stories.lock().expect("stories lock poisoned");
+            if let Some(s) = stories.iter_mut().find(|s| s.id == id) {
+                s.status = status;
+            }
+        }
+        async move { Ok(()) }
+    }
+
+    fn create_user(&self, user: &User) -> impl Future<Output = Result<i64, DomainError>> + Send {
+        let mut users = self.users.lock().expect("users lock poisoned");
+        let id = (users.len() as i64) + 1;
+        let mut u = user.clone();
+        u.id = id;
+        users.push(u);
+        async move { Ok(id) }
+    }
+
+    fn get_user(&self, id: i64) -> impl Future<Output = Result<Option<User>, DomainError>> + Send {
+        let found = self.users.lock().expect("users lock poisoned").iter().find(|u| u.id == id).cloned();
+        async move { Ok(found) }
+    }
+
+    fn get_user_by_email(&self, email: &str) -> impl Future<Output = Result<Option<User>, DomainError>> + Send {
+        let found = self.users.lock().expect("users lock poisoned").iter().find(|u| u.email == email).cloned();
+        async move { Ok(found) }
+    }
+
+    fn list_all_users(&self) -> impl Future<Output = Result<Vec<User>, DomainError>> + Send {
+        let all = self.users.lock().expect("users lock poisoned").clone();
+        async move { Ok(all) }
+    }
 }

--- a/crates/agileplus-domain/src/ports/mod.rs
+++ b/crates/agileplus-domain/src/ports/mod.rs
@@ -12,13 +12,16 @@ use crate::domain::{
     audit::AuditEntry,
     backlog::{BacklogFilters, BacklogItem, BacklogPriority, BacklogStatus},
     cycle::{Cycle, CycleFeature, CycleWithFeatures, CycleState},
+    epic::{Epic, EpicStatus},
     feature::Feature,
     governance::{Evidence, GovernanceContract, PolicyRule},
     metric::Metric,
     module::{Module, ModuleFeatureTag, ModuleWithFeatures},
     project::Project,
     state_machine::FeatureState,
+    story::{Story, StoryStatus},
     sync_mapping::SyncMapping,
+    user::User,
     work_package::{WorkPackage, WpDependency, WpState},
 };
 use crate::error::DomainError;
@@ -96,6 +99,25 @@ pub trait StoragePort: Send + Sync {
     // --- Projects ---
     async fn create_project(&self, project: &Project) -> Result<i64, DomainError>;
     async fn get_project_by_slug(&self, slug: &str) -> Result<Option<Project>, DomainError>;
+    async fn list_all_projects(&self) -> Result<Vec<Project>, DomainError>;
+
+    // --- Epics ---
+    async fn create_epic(&self, epic: &Epic) -> Result<i64, DomainError>;
+    async fn get_epic(&self, id: i64) -> Result<Option<Epic>, DomainError>;
+    async fn list_epics_by_project(&self, project_id: i64) -> Result<Vec<Epic>, DomainError>;
+    async fn update_epic_status(&self, id: i64, status: EpicStatus) -> Result<(), DomainError>;
+
+    // --- Stories ---
+    async fn create_story(&self, story: &Story) -> Result<i64, DomainError>;
+    async fn get_story(&self, id: i64) -> Result<Option<Story>, DomainError>;
+    async fn list_stories_by_epic(&self, epic_id: i64) -> Result<Vec<Story>, DomainError>;
+    async fn update_story_status(&self, id: i64, status: StoryStatus) -> Result<(), DomainError>;
+
+    // --- Users ---
+    async fn create_user(&self, user: &User) -> Result<i64, DomainError>;
+    async fn get_user(&self, id: i64) -> Result<Option<User>, DomainError>;
+    async fn get_user_by_email(&self, email: &str) -> Result<Option<User>, DomainError>;
+    async fn list_all_users(&self) -> Result<Vec<User>, DomainError>;
 }
 
 /// Content storage port — subset used by the dashboard/content layer.

--- a/crates/agileplus-sqlite/src/lib.rs
+++ b/crates/agileplus-sqlite/src/lib.rs
@@ -419,6 +419,58 @@ impl StoragePort for SqliteStorageAdapter {
         let conn = self.lock()?;
         projects::get_project_by_slug(&conn, slug)
     }
+
+    async fn list_all_projects(&self) -> Result<Vec<agileplus_domain::domain::project::Project>, DomainError> {
+        Err(DomainError::NotImplemented)
+    }
+
+    async fn create_epic(&self, _epic: &agileplus_domain::domain::epic::Epic) -> Result<i64, DomainError> {
+        Err(DomainError::NotImplemented)
+    }
+
+    async fn get_epic(&self, _id: i64) -> Result<Option<agileplus_domain::domain::epic::Epic>, DomainError> {
+        Err(DomainError::NotImplemented)
+    }
+
+    async fn list_epics_by_project(&self, _project_id: i64) -> Result<Vec<agileplus_domain::domain::epic::Epic>, DomainError> {
+        Err(DomainError::NotImplemented)
+    }
+
+    async fn update_epic_status(&self, _id: i64, _status: agileplus_domain::domain::epic::EpicStatus) -> Result<(), DomainError> {
+        Err(DomainError::NotImplemented)
+    }
+
+    async fn create_story(&self, _story: &agileplus_domain::domain::story::Story) -> Result<i64, DomainError> {
+        Err(DomainError::NotImplemented)
+    }
+
+    async fn get_story(&self, _id: i64) -> Result<Option<agileplus_domain::domain::story::Story>, DomainError> {
+        Err(DomainError::NotImplemented)
+    }
+
+    async fn list_stories_by_epic(&self, _epic_id: i64) -> Result<Vec<agileplus_domain::domain::story::Story>, DomainError> {
+        Err(DomainError::NotImplemented)
+    }
+
+    async fn update_story_status(&self, _id: i64, _status: agileplus_domain::domain::story::StoryStatus) -> Result<(), DomainError> {
+        Err(DomainError::NotImplemented)
+    }
+
+    async fn create_user(&self, _user: &agileplus_domain::domain::user::User) -> Result<i64, DomainError> {
+        Err(DomainError::NotImplemented)
+    }
+
+    async fn get_user(&self, _id: i64) -> Result<Option<agileplus_domain::domain::user::User>, DomainError> {
+        Err(DomainError::NotImplemented)
+    }
+
+    async fn get_user_by_email(&self, _email: &str) -> Result<Option<agileplus_domain::domain::user::User>, DomainError> {
+        Err(DomainError::NotImplemented)
+    }
+
+    async fn list_all_users(&self) -> Result<Vec<agileplus_domain::domain::user::User>, DomainError> {
+        Err(DomainError::NotImplemented)
+    }
 }
 
 #[async_trait::async_trait]


### PR DESCRIPTION
## **User description**
## Summary
- Added GET/POST REST endpoints for Projects, Epics, Stories, and Users backed by injected `StoragePort` trait (hexagonal port, no concrete store)
- Extended `StoragePort` with 13 new async methods (Epic/Story/User CRUD + list_all_projects)
- Added state-machine transition endpoints for Epics and Stories returning 409 on invalid transitions
- Added sqlite adapter stubs and fixed pre-existing test infrastructure bugs (VcsPort fields, credentials API, health endpoint URL)

## Test plan
- [ ] `cargo test -p agileplus-api` — 37 tests pass (22 new domain-wiring tests)
- [ ] `cargo check --workspace` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New public API surface and user-creation paths expand attack/validation scope; SQLite adapter stubs mean real deployments using SQLite will fail on these routes until persistence is implemented.
> 
> **Overview**
> This PR exposes **projects, epics, stories, and users** over authenticated `/api/v1/*` routes, wired through the existing `StoragePort` abstraction and new JSON response types.
> 
> **Projects** support list/create, get-by-slug, and nested epic listing. **Epics** support create/get, status transitions via domain state machines (invalid moves → **409**), and listing stories under an epic. **Stories** mirror that pattern with create/get/transition. **Users** support list/create/get with domain validation on email and role.
> 
> The **`StoragePort` trait** gains Epic/Story/User CRUD plus `list_all_projects`; mock test storage implements these fully, while **`SqliteStorageAdapter` still returns `NotImplemented`** for most of the new methods—so production SQLite will not serve these endpoints until follow-up work lands.
> 
> Also re-exports **`create_router`**, adds **`axum-test`** integration coverage for happy paths and error cases, and fixes test harness details (credentials API, VCS mock shapes, detailed-health URL).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad22e86c4879fb7f6b85f3dcafab80a50ab3b25f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Expose projects, epics, stories, and users through the API, with status changes and input checks**

### What Changed
- Added API routes to list, create, and fetch projects, epics, stories, and users
- Added project-to-epic and epic-to-story listing endpoints so related items can be viewed together
- Added epic and story status change actions that reject invalid moves with a conflict response
- Added basic validation for project, epic, story, and user creation so bad input is rejected with clear errors
- Extended integration coverage for the new routes and fixed existing test setup issues

### Impact
`✅ Can manage projects, epics, stories, and users from the REST API`
`✅ Fewer invalid status changes for epics and stories`
`✅ Clearer errors when creating items with bad input`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
