### PR TITLE
feat(requirements): ingest FR/NFR catalogs as Epics/Stories with Tracera cross-refs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,10 +88,12 @@ version = "0.1.0"
 dependencies = [
  "agileplus-domain",
  "agileplus-github",
+ "agileplus-sqlite",
  "anyhow",
  "async-trait",
  "chrono",
  "clap",
+ "rusqlite",
  "tokio",
  "tokio-test",
  "tracing",

--- a/crates/agileplus-cli/Cargo.toml
+++ b/crates/agileplus-cli/Cargo.toml
@@ -18,6 +18,8 @@ clap = { version = "4", features = ["derive", "env"] }
 chrono.workspace = true
 agileplus-domain = { path = "../agileplus-domain" }
 agileplus-github = { path = "../agileplus-github" }
+agileplus-sqlite = { path = "../agileplus-sqlite" }
+rusqlite = { version = "0.32", features = ["bundled"] }
 async-trait.workspace = true
 
 [dev-dependencies]

--- a/crates/agileplus-cli/src/commands/mod.rs
+++ b/crates/agileplus-cli/src/commands/mod.rs
@@ -12,6 +12,7 @@ pub mod retrospective;
 pub mod review_loop;
 pub mod scheduler;
 pub mod scope;
+pub mod seed_requirements;
 pub mod ship;
 pub mod specify;
 pub mod triage;

--- a/crates/agileplus-cli/src/commands/seed_requirements.rs
+++ b/crates/agileplus-cli/src/commands/seed_requirements.rs
@@ -1,0 +1,94 @@
+//! `seed-requirements` CLI subcommand.
+//!
+//! Ingests the four FR/NFR catalogs (AgilePlus, Tracera, phenotype-voxel, Authvault)
+//! as Epics + Stories into an AgilePlus SQLite database, each cross-referencing its
+//! Tracera Requirement ID.  Idempotent — safe to run multiple times.
+
+use std::path::PathBuf;
+
+use clap::Args;
+
+use agileplus_sqlite::seed::{Initiative, seed_requirements};
+
+/// Embedded catalog markdown files — bundled at compile time.
+/// Paths are relative to this source file:
+///   crates/agileplus-cli/src/commands/seed_requirements.rs
+///   → up 4 dirs → workspace root → docs/requirements/
+const AGILEPLUS_CATALOG: &str = include_str!(
+    "../../../../docs/requirements/agileplus-frnfr.md"
+);
+const TRACERA_CATALOG: &str = include_str!(
+    "../../../../docs/requirements/tracera-frnfr.md"
+);
+const PHENOTYPE_VOXEL_CATALOG: &str = include_str!(
+    "../../../../docs/requirements/phenotype-voxel-frnfr.md"
+);
+const AUTHVAULT_CATALOG: &str = include_str!(
+    "../../../../docs/requirements/authvault-frnfr.md"
+);
+
+/// Arguments for the `seed-requirements` subcommand.
+#[derive(Args, Debug)]
+pub struct SeedRequirementsArgs {
+    /// Path to the SQLite database file. Defaults to `./agileplus.db`.
+    #[arg(long, default_value = "agileplus.db")]
+    pub db: PathBuf,
+
+    /// Print a detailed per-story report.
+    #[arg(long)]
+    pub verbose: bool,
+}
+
+pub fn run(args: &SeedRequirementsArgs) -> anyhow::Result<()> {
+    let conn = rusqlite::Connection::open(&args.db)?;
+    conn.execute_batch("PRAGMA foreign_keys=ON;")?;
+    let runner = agileplus_sqlite::migrations::MigrationRunner::new(&conn);
+    runner.run_all().map_err(|e| anyhow::anyhow!("{e}"))?;
+
+    let initiatives = vec![
+        Initiative {
+            slug: "agileplus",
+            title: "AgilePlus",
+            catalog_markdown: AGILEPLUS_CATALOG,
+        },
+        Initiative {
+            slug: "tracera",
+            title: "Tracera",
+            catalog_markdown: TRACERA_CATALOG,
+        },
+        Initiative {
+            slug: "phenotype-voxel",
+            title: "phenotype-voxel",
+            catalog_markdown: PHENOTYPE_VOXEL_CATALOG,
+        },
+        Initiative {
+            slug: "authvault",
+            title: "Authvault",
+            catalog_markdown: AUTHVAULT_CATALOG,
+        },
+    ];
+
+    let report = seed_requirements(&conn, &initiatives)
+        .map_err(|e| anyhow::anyhow!("seed failed: {e}"))?;
+
+    println!(
+        "Seeded {} epic(s) and {} story/stories across {} initiative(s).",
+        report.epics_upserted,
+        report.stories_upserted,
+        report.initiatives.len()
+    );
+
+    if args.verbose {
+        for init in &report.initiatives {
+            println!("\n  Epic [{}] id={}", init.epic_requirement_id, init.epic_id);
+            for s in &init.stories {
+                println!(
+                    "    Story [{}] id={} status={:?}",
+                    s.requirement_id, s.story_id, s.status
+                );
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/crates/agileplus-cli/src/main.rs
+++ b/crates/agileplus-cli/src/main.rs
@@ -2,6 +2,8 @@
 
 mod sync_cmd;
 
+pub mod commands;
+
 use clap::{Parser, Subcommand};
 
 use agileplus_domain::domain::{
@@ -48,6 +50,8 @@ enum Command {
     Version,
     /// Sync a GitHub repository with an AgilePlus project
     Sync(SyncArgs),
+    /// Seed FR/NFR catalogs as Epics + Stories (Tracera traceability)
+    SeedRequirements(commands::seed_requirements::SeedRequirementsArgs),
 }
 
 #[derive(Subcommand)]
@@ -212,6 +216,9 @@ async fn main() {
             Command::Version => cmd_version(),
             Command::Sync(args) => {
                 sync_cmd::run(args, None).await?;
+            }
+            Command::SeedRequirements(args) => {
+                commands::seed_requirements::run(&args)?;
             }
         }
         Ok(())

--- a/crates/agileplus-domain/src/domain/epic.rs
+++ b/crates/agileplus-domain/src/domain/epic.rs
@@ -72,6 +72,9 @@ pub struct Epic {
     pub status: EpicStatus,
     /// Optional owner (user id).
     pub owner_id: Option<i64>,
+    /// External requirement reference (e.g. Tracera FR/NFR catalog ID).
+    /// Additive, optional — existing epics default to `None`.
+    pub requirement_id: Option<String>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -93,6 +96,7 @@ impl Epic {
             description: None,
             status: EpicStatus::Backlog,
             owner_id: None,
+            requirement_id: None,
             created_at: now,
             updated_at: now,
         })

--- a/crates/agileplus-domain/src/domain/story.rs
+++ b/crates/agileplus-domain/src/domain/story.rs
@@ -83,6 +83,9 @@ pub struct Story {
     pub points: Option<u32>,
     /// Assignee (user id).
     pub assignee_id: Option<i64>,
+    /// External requirement reference (e.g. Tracera FR/NFR catalog ID).
+    /// Additive, optional — existing stories default to `None`.
+    pub requirement_id: Option<String>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -116,6 +119,7 @@ impl Story {
             status: StoryStatus::Todo,
             points,
             assignee_id: None,
+            requirement_id: None,
             created_at: now,
             updated_at: now,
         })

--- a/crates/agileplus-sqlite/src/lib.rs
+++ b/crates/agileplus-sqlite/src/lib.rs
@@ -6,6 +6,7 @@
 pub mod migrations;
 pub mod rebuild;
 pub mod repository;
+pub mod seed;
 
 use std::path::Path;
 use std::sync::{Arc, Mutex};

--- a/crates/agileplus-sqlite/src/migrations/021_add_requirement_id.sql
+++ b/crates/agileplus-sqlite/src/migrations/021_add_requirement_id.sql
@@ -1,0 +1,16 @@
+-- UP
+-- Additive migration: external Tracera requirement ID cross-reference.
+-- NULL means no requirement is linked (all existing rows get NULL).
+ALTER TABLE epics   ADD COLUMN requirement_id TEXT;
+ALTER TABLE stories ADD COLUMN requirement_id TEXT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_epics_requirement_id
+    ON epics (requirement_id) WHERE requirement_id IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_stories_requirement_id
+    ON stories (requirement_id) WHERE requirement_id IS NOT NULL;
+
+-- DOWN
+DROP INDEX IF EXISTS idx_stories_requirement_id;
+DROP INDEX IF EXISTS idx_epics_requirement_id;
+-- SQLite does not support DROP COLUMN in older versions; columns are left nullable.

--- a/crates/agileplus-sqlite/src/migrations/mod.rs
+++ b/crates/agileplus-sqlite/src/migrations/mod.rs
@@ -27,6 +27,7 @@ const MIGRATION_017: &str = include_str!("017_create_projects.sql");
 const MIGRATION_018: &str = include_str!("018_create_users.sql");
 const MIGRATION_019: &str = include_str!("019_create_epics.sql");
 const MIGRATION_020: &str = include_str!("020_create_stories.sql");
+const MIGRATION_021: &str = include_str!("021_add_requirement_id.sql");
 
 /// All migrations in order: (name, up_sql, down_sql)
 const MIGRATIONS: &[(&str, &str)] = &[
@@ -49,6 +50,7 @@ const MIGRATIONS: &[(&str, &str)] = &[
     ("018_create_users", MIGRATION_018),
     ("019_create_epics", MIGRATION_019),
     ("020_create_stories", MIGRATION_020),
+    ("021_add_requirement_id", MIGRATION_021),
 ];
 
 /// Parse the UP section from a migration SQL file.

--- a/crates/agileplus-sqlite/src/repository/epics.rs
+++ b/crates/agileplus-sqlite/src/repository/epics.rs
@@ -8,6 +8,19 @@ use rusqlite::{Connection, params};
 use agileplus_domain::domain::epic::{Epic, EpicStatus};
 use agileplus_domain::error::DomainError;
 
+trait OptionalExt<T> {
+    fn optional(self) -> rusqlite::Result<Option<T>>;
+}
+impl<T> OptionalExt<T> for rusqlite::Result<T> {
+    fn optional(self) -> rusqlite::Result<Option<T>> {
+        match self {
+            Ok(v) => Ok(Some(v)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+}
+
 fn map_err(e: rusqlite::Error) -> DomainError {
     DomainError::Storage(e.to_string())
 }
@@ -29,6 +42,7 @@ fn row_to_epic(row: &rusqlite::Row<'_>) -> rusqlite::Result<Epic> {
         description: row.get(3)?,
         status: status_str.parse().unwrap_or(EpicStatus::Backlog),
         owner_id: row.get(5)?,
+        requirement_id: row.get(8).unwrap_or(None),
         created_at: parse_dt(&created_at),
         updated_at: parse_dt(&updated_at),
     })
@@ -38,14 +52,15 @@ fn row_to_epic(row: &rusqlite::Row<'_>) -> rusqlite::Result<Epic> {
 pub fn create_epic(conn: &Connection, epic: &Epic) -> Result<i64, DomainError> {
     let now = chrono::Utc::now().to_rfc3339();
     conn.execute(
-        "INSERT INTO epics (project_id, title, description, status, owner_id, created_at, updated_at)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+        "INSERT INTO epics (project_id, title, description, status, owner_id, requirement_id, created_at, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
         params![
             epic.project_id,
             epic.title,
             epic.description,
             epic.status.to_string(),
             epic.owner_id,
+            epic.requirement_id,
             now,
             now,
         ],
@@ -54,11 +69,66 @@ pub fn create_epic(conn: &Connection, epic: &Epic) -> Result<i64, DomainError> {
     Ok(conn.last_insert_rowid())
 }
 
+/// Upsert an epic by `requirement_id` — creates if absent, updates title/description/status if present.
+/// Returns the row ID (new or existing).
+///
+/// Uses manual get-then-insert/update because `requirement_id` is added via ALTER TABLE
+/// (no inline UNIQUE constraint); SQLite upsert `ON CONFLICT(col)` requires a declared
+/// table-level constraint that ALTER TABLE cannot add.
+pub fn upsert_epic_by_requirement_id(conn: &Connection, epic: &Epic) -> Result<i64, DomainError> {
+    let req_id = epic.requirement_id.as_deref().ok_or_else(|| {
+        DomainError::Validation("upsert_epic_by_requirement_id requires requirement_id".to_string())
+    })?;
+    let now = chrono::Utc::now().to_rfc3339();
+    // Check if a row with this requirement_id already exists.
+    let existing_id: Option<i64> = conn
+        .query_row(
+            "SELECT id FROM epics WHERE requirement_id = ?1",
+            params![req_id],
+            |r| r.get(0),
+        )
+        .optional()
+        .map_err(map_err)?;
+
+    if let Some(id) = existing_id {
+        // Update title, description, status.
+        conn.execute(
+            "UPDATE epics SET title = ?1, description = ?2, status = ?3, updated_at = ?4 WHERE id = ?5",
+            params![
+                epic.title,
+                epic.description,
+                epic.status.to_string(),
+                now,
+                id,
+            ],
+        )
+        .map_err(map_err)?;
+        Ok(id)
+    } else {
+        create_epic(conn, epic)
+    }
+}
+
+/// Look up an epic by `requirement_id`. Returns `None` if not found.
+pub fn get_epic_by_requirement_id(conn: &Connection, req_id: &str) -> Result<Option<Epic>, DomainError> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, project_id, title, description, status, owner_id, created_at, updated_at, requirement_id \
+             FROM epics WHERE requirement_id = ?1",
+        )
+        .map_err(map_err)?;
+    match stmt.query_row(params![req_id], row_to_epic) {
+        Ok(e) => Ok(Some(e)),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(e) => Err(map_err(e)),
+    }
+}
+
 /// Look up an epic by ID. Returns `None` if not found.
 pub fn get_epic_by_id(conn: &Connection, id: i64) -> Result<Option<Epic>, DomainError> {
     let mut stmt = conn
         .prepare(
-            "SELECT id, project_id, title, description, status, owner_id, created_at, updated_at \
+            "SELECT id, project_id, title, description, status, owner_id, created_at, updated_at, requirement_id \
              FROM epics WHERE id = ?1",
         )
         .map_err(map_err)?;
@@ -89,7 +159,7 @@ pub fn update_epic_status(conn: &Connection, id: i64, status: EpicStatus) -> Res
 pub fn list_epics_by_project(conn: &Connection, project_id: i64) -> Result<Vec<Epic>, DomainError> {
     let mut stmt = conn
         .prepare(
-            "SELECT id, project_id, title, description, status, owner_id, created_at, updated_at \
+            "SELECT id, project_id, title, description, status, owner_id, created_at, updated_at, requirement_id \
              FROM epics WHERE project_id = ?1 ORDER BY created_at ASC",
         )
         .map_err(map_err)?;

--- a/crates/agileplus-sqlite/src/repository/stories.rs
+++ b/crates/agileplus-sqlite/src/repository/stories.rs
@@ -8,6 +8,19 @@ use rusqlite::{Connection, params};
 use agileplus_domain::domain::story::{Story, StoryStatus};
 use agileplus_domain::error::DomainError;
 
+trait OptionalExt<T> {
+    fn optional(self) -> rusqlite::Result<Option<T>>;
+}
+impl<T> OptionalExt<T> for rusqlite::Result<T> {
+    fn optional(self) -> rusqlite::Result<Option<T>> {
+        match self {
+            Ok(v) => Ok(Some(v)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+}
+
 fn map_err(e: rusqlite::Error) -> DomainError {
     DomainError::Storage(e.to_string())
 }
@@ -32,6 +45,7 @@ fn row_to_story(row: &rusqlite::Row<'_>) -> rusqlite::Result<Story> {
         status: status_str.parse().unwrap_or(StoryStatus::Todo),
         points: points_raw.map(|p| p as u32),
         assignee_id: row.get(6)?,
+        requirement_id: row.get(10).unwrap_or(None),
         created_at: parse_dt(&created_at),
         updated_at: parse_dt(&updated_at),
     })
@@ -41,8 +55,8 @@ fn row_to_story(row: &rusqlite::Row<'_>) -> rusqlite::Result<Story> {
 pub fn create_story(conn: &Connection, story: &Story) -> Result<i64, DomainError> {
     let now = chrono::Utc::now().to_rfc3339();
     conn.execute(
-        "INSERT INTO stories (epic_id, project_id, title, description, status, points, assignee_id, created_at, updated_at)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+        "INSERT INTO stories (epic_id, project_id, title, description, status, points, assignee_id, requirement_id, created_at, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
         params![
             story.epic_id,
             story.project_id,
@@ -51,6 +65,7 @@ pub fn create_story(conn: &Connection, story: &Story) -> Result<i64, DomainError
             story.status.to_string(),
             story.points.map(|p| p as i64),
             story.assignee_id,
+            story.requirement_id,
             now,
             now,
         ],
@@ -59,11 +74,66 @@ pub fn create_story(conn: &Connection, story: &Story) -> Result<i64, DomainError
     Ok(conn.last_insert_rowid())
 }
 
+/// Upsert a story by `requirement_id` — creates if absent, updates title/description/status if present.
+/// Returns the row ID (new or existing).
+///
+/// Uses manual get-then-insert/update because `requirement_id` is added via ALTER TABLE
+/// (no inline UNIQUE constraint); SQLite upsert `ON CONFLICT(col)` requires a declared
+/// table-level constraint that ALTER TABLE cannot add.
+pub fn upsert_story_by_requirement_id(conn: &Connection, story: &Story) -> Result<i64, DomainError> {
+    let req_id = story.requirement_id.as_deref().ok_or_else(|| {
+        DomainError::Validation("upsert_story_by_requirement_id requires requirement_id".to_string())
+    })?;
+    let now = chrono::Utc::now().to_rfc3339();
+    // Check if a row with this requirement_id already exists.
+    let existing_id: Option<i64> = conn
+        .query_row(
+            "SELECT id FROM stories WHERE requirement_id = ?1",
+            params![req_id],
+            |r| r.get(0),
+        )
+        .optional()
+        .map_err(map_err)?;
+
+    if let Some(id) = existing_id {
+        conn.execute(
+            "UPDATE stories SET epic_id = ?1, title = ?2, description = ?3, status = ?4, updated_at = ?5 WHERE id = ?6",
+            params![
+                story.epic_id,
+                story.title,
+                story.description,
+                story.status.to_string(),
+                now,
+                id,
+            ],
+        )
+        .map_err(map_err)?;
+        Ok(id)
+    } else {
+        create_story(conn, story)
+    }
+}
+
+/// Look up a story by `requirement_id`. Returns `None` if not found.
+pub fn get_story_by_requirement_id(conn: &Connection, req_id: &str) -> Result<Option<Story>, DomainError> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, epic_id, project_id, title, status, points, assignee_id, created_at, updated_at, description, requirement_id \
+             FROM stories WHERE requirement_id = ?1",
+        )
+        .map_err(map_err)?;
+    match stmt.query_row(params![req_id], row_to_story) {
+        Ok(s) => Ok(Some(s)),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(e) => Err(map_err(e)),
+    }
+}
+
 /// Look up a story by ID. Returns `None` if not found.
 pub fn get_story_by_id(conn: &Connection, id: i64) -> Result<Option<Story>, DomainError> {
     let mut stmt = conn
         .prepare(
-            "SELECT id, epic_id, project_id, title, status, points, assignee_id, created_at, updated_at, description \
+            "SELECT id, epic_id, project_id, title, status, points, assignee_id, created_at, updated_at, description, requirement_id \
              FROM stories WHERE id = ?1",
         )
         .map_err(map_err)?;
@@ -94,7 +164,7 @@ pub fn update_story_status(conn: &Connection, id: i64, status: StoryStatus) -> R
 pub fn list_stories_by_epic(conn: &Connection, epic_id: i64) -> Result<Vec<Story>, DomainError> {
     let mut stmt = conn
         .prepare(
-            "SELECT id, epic_id, project_id, title, status, points, assignee_id, created_at, updated_at, description \
+            "SELECT id, epic_id, project_id, title, status, points, assignee_id, created_at, updated_at, description, requirement_id \
              FROM stories WHERE epic_id = ?1 ORDER BY created_at ASC",
         )
         .map_err(map_err)?;
@@ -111,7 +181,7 @@ pub fn list_stories_by_epic(conn: &Connection, epic_id: i64) -> Result<Vec<Story
 pub fn list_stories_by_project(conn: &Connection, project_id: i64) -> Result<Vec<Story>, DomainError> {
     let mut stmt = conn
         .prepare(
-            "SELECT id, epic_id, project_id, title, status, points, assignee_id, created_at, updated_at, description \
+            "SELECT id, epic_id, project_id, title, status, points, assignee_id, created_at, updated_at, description, requirement_id \
              FROM stories WHERE project_id = ?1 ORDER BY created_at ASC",
         )
         .map_err(map_err)?;

--- a/crates/agileplus-sqlite/src/seed/catalog.rs
+++ b/crates/agileplus-sqlite/src/seed/catalog.rs
@@ -1,0 +1,298 @@
+//! Catalog parser: extracts `(fr_id, title, status)` triples from an FR/NFR markdown file.
+//!
+//! Format recognised (as used in all four catalogs):
+//!   ### FR-XXX-NNN — Title text
+//!   ...
+//!   | **Status** | SHIPPED |   (optional; AgilePlus / Authvault catalogs)
+//!   | **Status** | PLANNED |
+//!   | Status      | planned |
+//!
+//! For catalogs without an explicit Status column (Tracera, phenotype-voxel) the
+//! status defaults to `Todo` unless a "## Gap" / "PLANNED" heading later contains
+//! the FR id.
+
+/// Parsed status from the catalog.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CatalogStatus {
+    /// The requirement has been shipped / implemented.
+    Shipped,
+    /// The requirement is planned (or status unknown).
+    Planned,
+}
+
+/// A single FR (or NFR) entry parsed from the catalog.
+#[derive(Debug, Clone)]
+pub struct CatalogEntry {
+    /// The canonical requirement ID, e.g. "FR-AGP-001".
+    pub id: String,
+    /// Human-readable title (everything after the " — " separator).
+    pub title: String,
+    /// Derived status.
+    pub status: CatalogStatus,
+}
+
+/// Parse a markdown catalog and return all FR/NFR entries found.
+pub fn parse_catalog(markdown: &str) -> Vec<CatalogEntry> {
+    let mut entries: Vec<CatalogEntry> = Vec::new();
+
+    // Collect all IDs that appear in "PLANNED" gap tables / sections.
+    let planned_in_gaps: std::collections::HashSet<String> = collect_planned_ids(markdown);
+
+    let mut current_id: Option<String> = None;
+    let mut current_title: Option<String> = None;
+    let mut current_status: Option<CatalogStatus> = None;
+
+    for line in markdown.lines() {
+        let trimmed = line.trim();
+
+        // Match heading lines: `### FR-XXX-NNN — Title`
+        // Also handle `### FR-XXX-NNN\n\n**Title:** ...` (Authvault style via next line)
+        if let Some(id_and_rest) = extract_heading_id(trimmed) {
+            // Flush previous entry
+            if let (Some(id), Some(title)) = (current_id.take(), current_title.take()) {
+                let status = current_status.take().unwrap_or_else(|| {
+                    if planned_in_gaps.contains(&id) {
+                        CatalogStatus::Planned
+                    } else {
+                        CatalogStatus::Shipped
+                    }
+                });
+                entries.push(CatalogEntry { id, title, status });
+            }
+            current_id = Some(id_and_rest.0);
+            current_title = Some(id_and_rest.1);
+            current_status = None;
+            continue;
+        }
+
+        // Inside an entry — look for **Title:** line (Authvault style)
+        if current_id.is_some() && current_title.as_deref().map(str::is_empty).unwrap_or(false) {
+            if let Some(t) = extract_title_field(trimmed) {
+                current_title = Some(t);
+                continue;
+            }
+        }
+
+        // Look for Status table cell
+        if current_id.is_some() && current_status.is_none() {
+            if let Some(s) = extract_status_cell(trimmed) {
+                current_status = Some(s);
+            }
+        }
+    }
+
+    // Flush last entry
+    if let (Some(id), Some(title)) = (current_id, current_title) {
+        let status = current_status.unwrap_or_else(|| {
+            if planned_in_gaps.contains(&id) {
+                CatalogStatus::Planned
+            } else {
+                CatalogStatus::Shipped
+            }
+        });
+        entries.push(CatalogEntry { id, title, status });
+    }
+
+    entries
+}
+
+/// Extract `(id, title)` from a heading line like:
+///   `### FR-AGP-001 — Rich domain aggregates with enforced invariants`
+///   `### FR-AGP-001\n` (title-only variant; title = id for now, overridden later)
+fn extract_heading_id(line: &str) -> Option<(String, String)> {
+    // Must start with one or more '#'
+    let stripped = line.trim_start_matches('#').trim();
+    // Must look like an ID: starts with two uppercase words separated by '-'
+    // Pattern: WORD-WORD-NNN (e.g. FR-AGP-001, NFR-TRC-002, FR-VOXEL-003)
+    let (id_part, title_part) = if let Some(pos) = stripped.find(" \u{2014} ") {
+        // " — " separator (em-dash)
+        (&stripped[..pos], stripped[pos + " \u{2014} ".len()..].trim())
+    } else if let Some(pos) = stripped.find(" - ") {
+        // Plain hyphen separator fallback
+        (&stripped[..pos], stripped[pos + 3..].trim())
+    } else {
+        // No separator — the whole thing is the id; title will be filled later
+        (stripped, "")
+    };
+
+    if looks_like_req_id(id_part.trim()) {
+        Some((
+            id_part.trim().to_string(),
+            title_part.to_string(),
+        ))
+    } else {
+        None
+    }
+}
+
+fn looks_like_req_id(s: &str) -> bool {
+    // Accepts: FR-AGP-001, NFR-TRC-002, FR-VOXEL-003, FR-AUTHV-010, etc.
+    let parts: Vec<&str> = s.split('-').collect();
+    if parts.len() < 3 {
+        return false;
+    }
+    let prefix = parts[0];
+    if prefix != "FR" && prefix != "NFR" {
+        return false;
+    }
+    // Last part should be digits
+    parts.last().map(|p| p.chars().all(|c| c.is_ascii_digit())).unwrap_or(false)
+}
+
+/// Try to find `**Title:** Some title text` in a line.
+fn extract_title_field(line: &str) -> Option<String> {
+    let line = line
+        .trim_start_matches('|')
+        .trim_end_matches('|')
+        .trim();
+    if let Some(rest) = line.strip_prefix("**Title:**") {
+        let t = rest.trim().to_string();
+        if !t.is_empty() {
+            return Some(t);
+        }
+    }
+    // Also handle table cell: `| **Title** | Some title |`
+    None
+}
+
+/// Extract status from lines like:
+///   `| **Status** | SHIPPED |`
+///   `| **Status** | PLANNED |`
+///   `| **Status** | PARTIAL — ... |`
+fn extract_status_cell(line: &str) -> Option<CatalogStatus> {
+    if !line.contains("**Status**") && !line.to_lowercase().contains("status") {
+        return None;
+    }
+    let upper = line.to_uppercase();
+    if upper.contains("SHIPPED") {
+        return Some(CatalogStatus::Shipped);
+    }
+    if upper.contains("PLANNED") || upper.contains("PARTIAL") {
+        return Some(CatalogStatus::Planned);
+    }
+    None
+}
+
+/// Collect FR IDs that appear in Gap/Planned sections of the catalog.
+/// These are IDs that will be treated as Planned even if no explicit status cell
+/// is present.
+fn collect_planned_ids(markdown: &str) -> std::collections::HashSet<String> {
+    let mut ids = std::collections::HashSet::new();
+    let mut in_gap_section = false;
+
+    for line in markdown.lines() {
+        let trimmed = line.trim();
+        // Gap sections start with a heading containing "Gap" or "Planned"
+        if trimmed.starts_with('#') {
+            let upper = trimmed.to_uppercase();
+            in_gap_section = upper.contains("GAP") || upper.contains("PLANNED");
+        }
+        if in_gap_section {
+            // Extract any FR/NFR IDs mentioned in this line
+            for word in trimmed.split_whitespace() {
+                let clean = word.trim_matches(|c: char| !c.is_alphanumeric() && c != '-');
+                if looks_like_req_id(clean) {
+                    ids.insert(clean.to_string());
+                }
+            }
+        }
+    }
+    ids
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE_CATALOG: &str = r#"
+# Test Catalog
+
+## Functional Requirements
+
+### FR-TEST-001 — Rich domain model
+
+| Field | Value |
+|---|---|
+| **ID** | FR-TEST-001 |
+| **Title** | Rich domain model |
+| **Status** | SHIPPED |
+
+---
+
+### FR-TEST-002 — Planned feature
+
+| Field | Value |
+|---|---|
+| **ID** | FR-TEST-002 |
+| **Title** | Planned feature |
+| **Status** | PLANNED |
+
+---
+
+### NFR-TEST-001 — Performance
+
+No status field here; should default to Shipped.
+
+---
+
+## Gaps / PLANNED
+
+| FR-TEST-003 | Some planned thing | PLANNED |
+"#;
+
+    #[test]
+    fn parses_fr_ids() {
+        let entries = parse_catalog(SAMPLE_CATALOG);
+        let ids: Vec<&str> = entries.iter().map(|e| e.id.as_str()).collect();
+        assert!(ids.contains(&"FR-TEST-001"), "missing FR-TEST-001: {ids:?}");
+        assert!(ids.contains(&"FR-TEST-002"), "missing FR-TEST-002: {ids:?}");
+        assert!(ids.contains(&"NFR-TEST-001"), "missing NFR-TEST-001: {ids:?}");
+    }
+
+    #[test]
+    fn status_shipped_mapped_correctly() {
+        let entries = parse_catalog(SAMPLE_CATALOG);
+        let e = entries.iter().find(|e| e.id == "FR-TEST-001").unwrap();
+        assert_eq!(e.status, CatalogStatus::Shipped);
+    }
+
+    #[test]
+    fn status_planned_mapped_correctly() {
+        let entries = parse_catalog(SAMPLE_CATALOG);
+        let e = entries.iter().find(|e| e.id == "FR-TEST-002").unwrap();
+        assert_eq!(e.status, CatalogStatus::Planned);
+    }
+
+    #[test]
+    fn title_extracted() {
+        let entries = parse_catalog(SAMPLE_CATALOG);
+        let e = entries.iter().find(|e| e.id == "FR-TEST-001").unwrap();
+        assert_eq!(e.title, "Rich domain model");
+    }
+
+    #[test]
+    fn gap_section_id_treated_as_planned() {
+        let entries = parse_catalog(SAMPLE_CATALOG);
+        let e = entries.iter().find(|e| e.id == "FR-TEST-003");
+        // FR-TEST-003 only appears in gaps table, not as a heading — so it may
+        // not be parsed as a full entry but its ID is collected as planned.
+        // The planned_ids collection is used to override status for entries
+        // that DO have headings.
+        // NFR-TEST-001 has no status cell → should default to Shipped (not in gap section).
+        let nfr = entries.iter().find(|e| e.id == "NFR-TEST-001").unwrap();
+        assert_eq!(nfr.status, CatalogStatus::Shipped);
+        // FR-TEST-003 won't appear because it has no heading
+        assert!(e.is_none());
+    }
+
+    #[test]
+    fn looks_like_req_id_correct() {
+        assert!(looks_like_req_id("FR-AGP-001"));
+        assert!(looks_like_req_id("NFR-TRC-007"));
+        assert!(looks_like_req_id("FR-VOXEL-009"));
+        assert!(looks_like_req_id("FR-AUTHV-011"));
+        assert!(!looks_like_req_id("some-random-text"));
+        assert!(!looks_like_req_id("PLAN-VOXEL-001")); // Not FR/NFR prefix
+        assert!(!looks_like_req_id("FR-AGP")); // Too few parts
+    }
+}

--- a/crates/agileplus-sqlite/src/seed/mod.rs
+++ b/crates/agileplus-sqlite/src/seed/mod.rs
@@ -1,0 +1,13 @@
+//! Requirements seed — parse FR/NFR catalogs and upsert Epics + Stories.
+//!
+//! Traceability: FR-AGP-001, FR-TRC-016 (AgilePlus ↔ Tracera wiring)
+//!
+//! Each initiative maps to one Epic (upserted by `requirement_id = "EPIC-<slug>"`).
+//! Each FR entry maps to one Story (upserted by `requirement_id = <fr-id>`).
+//! Status mapping: "SHIPPED" → Done, everything else → Todo.
+//! The seed is idempotent: re-running produces no duplicates.
+
+pub mod catalog;
+pub mod runner;
+
+pub use runner::{Initiative, SeedReport, seed_requirements};

--- a/crates/agileplus-sqlite/src/seed/runner.rs
+++ b/crates/agileplus-sqlite/src/seed/runner.rs
@@ -1,0 +1,328 @@
+//! Seed runner: drives Epic + Story upserts for the 4 FR/NFR catalogs.
+//!
+//! Each initiative gets one Epic (upserted by `requirement_id = "EPIC-<slug>"`).
+//! Each FR/NFR entry under that initiative gets one Story (upserted by
+//! `requirement_id = <fr-id>`).
+//!
+//! Status mapping:
+//!   CatalogStatus::Shipped → StoryStatus::Done
+//!   CatalogStatus::Planned → StoryStatus::Todo
+
+use rusqlite::Connection;
+
+use agileplus_domain::{
+    domain::{
+        epic::Epic,
+        story::{Story, StoryStatus},
+    },
+    error::DomainError,
+};
+
+use crate::{
+    repository::{epics, projects, stories},
+    seed::catalog::{CatalogEntry, CatalogStatus, parse_catalog},
+};
+
+/// Describes one initiative to seed.
+pub struct Initiative<'a> {
+    /// Short slug used for project/epic lookup, e.g. "agileplus".
+    pub slug: &'a str,
+    /// Human-readable epic title, e.g. "AgilePlus".
+    pub title: &'a str,
+    /// The raw markdown content of the FR/NFR catalog for this initiative.
+    pub catalog_markdown: &'a str,
+}
+
+/// Summary of what was seeded.
+#[derive(Debug, Default)]
+pub struct SeedReport {
+    pub epics_upserted: usize,
+    pub stories_upserted: usize,
+    pub initiatives: Vec<InitiativeReport>,
+}
+
+/// Per-initiative seed result.
+#[derive(Debug)]
+pub struct InitiativeReport {
+    pub initiative_slug: String,
+    pub epic_id: i64,
+    pub epic_requirement_id: String,
+    pub stories: Vec<StoryReport>,
+}
+
+/// Per-story seed result.
+#[derive(Debug)]
+pub struct StoryReport {
+    pub requirement_id: String,
+    pub story_id: i64,
+    pub status: StoryStatus,
+}
+
+/// Seed all four FR/NFR catalogs into the database.
+///
+/// For each initiative:
+/// 1. Ensure a `Project` row exists (created if absent; upsert by slug).
+/// 2. Upsert one `Epic` with `requirement_id = "EPIC-<slug>"`.
+/// 3. For each FR/NFR entry, upsert one `Story` cross-referencing the requirement ID.
+///
+/// The connection must have migration 021 applied (requirement_id columns exist).
+pub fn seed_requirements(
+    conn: &Connection,
+    initiatives: &[Initiative<'_>],
+) -> Result<SeedReport, DomainError> {
+    let mut report = SeedReport::default();
+
+    for initiative in initiatives {
+        let project_id = ensure_project(conn, initiative.slug, initiative.title)?;
+        let epic_req_id = format!("EPIC-{}", initiative.slug);
+
+        // Build epic
+        let mut epic = Epic::new(project_id, initiative.title)?;
+        epic.requirement_id = Some(epic_req_id.clone());
+        epic.description = Some(format!(
+            "Initiative epic for {} FR/NFR catalog",
+            initiative.title
+        ));
+
+        let epic_id = epics::upsert_epic_by_requirement_id(conn, &epic)?;
+        report.epics_upserted += 1;
+
+        let entries = parse_catalog(initiative.catalog_markdown);
+        let mut story_reports = Vec::new();
+
+        for entry in &entries {
+            let story_status = map_status(entry.status);
+            let story = build_story(epic_id, project_id, entry, story_status)?;
+            let story_id = stories::upsert_story_by_requirement_id(conn, &story)?;
+            report.stories_upserted += 1;
+            story_reports.push(StoryReport {
+                requirement_id: entry.id.clone(),
+                story_id,
+                status: story_status,
+            });
+        }
+
+        report.initiatives.push(InitiativeReport {
+            initiative_slug: initiative.slug.to_string(),
+            epic_id,
+            epic_requirement_id: epic_req_id,
+            stories: story_reports,
+        });
+    }
+
+    Ok(report)
+}
+
+fn map_status(catalog_status: CatalogStatus) -> StoryStatus {
+    match catalog_status {
+        CatalogStatus::Shipped => StoryStatus::Done,
+        CatalogStatus::Planned => StoryStatus::Todo,
+    }
+}
+
+fn build_story(
+    epic_id: i64,
+    project_id: i64,
+    entry: &CatalogEntry,
+    status: StoryStatus,
+) -> Result<Story, DomainError> {
+    let title = if entry.title.is_empty() {
+        entry.id.clone()
+    } else {
+        format!("[{}] {}", entry.id, entry.title)
+    };
+
+    let mut story = Story::new(epic_id, project_id, &title, None)?;
+    story.requirement_id = Some(entry.id.clone());
+    story.description = Some(format!("Tracera requirement cross-reference: {}", entry.id));
+    // Override the default Todo status that Story::new() sets.
+    story.status = status;
+    Ok(story)
+}
+
+/// Ensure a project row exists for the initiative and return its ID.
+/// Creates one if absent; does NOT update if already present (idempotent).
+fn ensure_project(conn: &Connection, slug: &str, title: &str) -> Result<i64, DomainError> {
+    // Try to find existing
+    if let Some(p) = projects::get_project_by_slug(conn, slug)? {
+        return Ok(p.id);
+    }
+    use agileplus_domain::domain::project::Project;
+    let project = Project::new(title, slug)
+        .map_err(|e| DomainError::Validation(format!("project creation failed: {e}")))?;
+    projects::create_project(conn, &project)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::SqliteStorageAdapter;
+    use agileplus_domain::domain::story::StoryStatus;
+
+    fn in_memory_conn() -> rusqlite::Connection {
+        let adapter = SqliteStorageAdapter::in_memory().expect("in-memory adapter");
+        // Extract the underlying connection for synchronous seed calls.
+        // We use conn_for_bench which returns a MutexGuard; we need to re-open
+        // a fresh in-memory db for the sync tests.
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        conn.execute_batch("PRAGMA foreign_keys=ON;").unwrap();
+        let runner = crate::migrations::MigrationRunner::new(&conn);
+        runner.run_all().unwrap();
+        // drop adapter to avoid unused warning
+        drop(adapter);
+        conn
+    }
+
+    const MINI_CATALOG: &str = r#"
+# Mini Test Catalog
+
+## Functional Requirements
+
+### FR-MINI-001 — Shipped feature
+
+| Field | Value |
+|---|---|
+| **Status** | SHIPPED |
+
+---
+
+### FR-MINI-002 — Planned feature
+
+| Field | Value |
+|---|---|
+| **Status** | PLANNED |
+
+---
+
+### NFR-MINI-001 — No status field (defaults Shipped)
+
+Some description without a status row.
+"#;
+
+    #[test]
+    fn seed_creates_epic_and_stories() {
+        let conn = in_memory_conn();
+        let initiatives = vec![Initiative {
+            slug: "mini",
+            title: "Mini Initiative",
+            catalog_markdown: MINI_CATALOG,
+        }];
+        let report = seed_requirements(&conn, &initiatives).unwrap();
+        assert_eq!(report.epics_upserted, 1);
+        // FR-MINI-001, FR-MINI-002, NFR-MINI-001
+        assert_eq!(report.stories_upserted, 3);
+    }
+
+    #[test]
+    fn seed_status_mapping_shipped_to_done() {
+        let conn = in_memory_conn();
+        let initiatives = vec![Initiative {
+            slug: "mini2",
+            title: "Mini2",
+            catalog_markdown: MINI_CATALOG,
+        }];
+        let report = seed_requirements(&conn, &initiatives).unwrap();
+        let initiative = &report.initiatives[0];
+        let shipped = initiative
+            .stories
+            .iter()
+            .find(|s| s.requirement_id == "FR-MINI-001")
+            .unwrap();
+        assert_eq!(shipped.status, StoryStatus::Done);
+    }
+
+    #[test]
+    fn seed_status_mapping_planned_to_todo() {
+        let conn = in_memory_conn();
+        let initiatives = vec![Initiative {
+            slug: "mini3",
+            title: "Mini3",
+            catalog_markdown: MINI_CATALOG,
+        }];
+        let report = seed_requirements(&conn, &initiatives).unwrap();
+        let initiative = &report.initiatives[0];
+        let planned = initiative
+            .stories
+            .iter()
+            .find(|s| s.requirement_id == "FR-MINI-002")
+            .unwrap();
+        assert_eq!(planned.status, StoryStatus::Todo);
+    }
+
+    #[test]
+    fn seed_is_idempotent() {
+        let conn = in_memory_conn();
+        let initiatives = vec![Initiative {
+            slug: "mini4",
+            title: "Mini4",
+            catalog_markdown: MINI_CATALOG,
+        }];
+        let r1 = seed_requirements(&conn, &initiatives).unwrap();
+        let r2 = seed_requirements(&conn, &initiatives).unwrap();
+        // Same counts — no duplicates
+        assert_eq!(r1.epics_upserted, r2.epics_upserted);
+        assert_eq!(r1.stories_upserted, r2.stories_upserted);
+        // Verify epic by requirement_id still unique
+        let epic = epics::get_epic_by_requirement_id(&conn, "EPIC-mini4")
+            .unwrap()
+            .unwrap();
+        assert_eq!(epic.title, "Mini4");
+    }
+
+    #[test]
+    fn story_requirement_id_set_correctly() {
+        let conn = in_memory_conn();
+        let initiatives = vec![Initiative {
+            slug: "mini5",
+            title: "Mini5",
+            catalog_markdown: MINI_CATALOG,
+        }];
+        seed_requirements(&conn, &initiatives).unwrap();
+        let story = stories::get_story_by_requirement_id(&conn, "FR-MINI-001")
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            story.requirement_id.as_deref(),
+            Some("FR-MINI-001")
+        );
+    }
+
+    #[test]
+    fn epic_requirement_id_set_correctly() {
+        let conn = in_memory_conn();
+        let initiatives = vec![Initiative {
+            slug: "mini6",
+            title: "Mini6",
+            catalog_markdown: MINI_CATALOG,
+        }];
+        seed_requirements(&conn, &initiatives).unwrap();
+        let epic = epics::get_epic_by_requirement_id(&conn, "EPIC-mini6")
+            .unwrap()
+            .unwrap();
+        assert_eq!(epic.requirement_id.as_deref(), Some("EPIC-mini6"));
+    }
+
+    #[test]
+    fn invariants_preserved_nonempty_titles() {
+        let conn = in_memory_conn();
+        let initiatives = vec![Initiative {
+            slug: "mini7",
+            title: "Mini7",
+            catalog_markdown: MINI_CATALOG,
+        }];
+        seed_requirements(&conn, &initiatives).unwrap();
+        // All stories must have non-empty titles
+        let all_stories = stories::list_stories_by_project(
+            &conn,
+            // project id will be 1 (first created)
+            projects::get_project_by_slug(&conn, "mini7")
+                .unwrap()
+                .unwrap()
+                .id,
+        )
+        .unwrap();
+        for s in &all_stories {
+            assert!(!s.title.is_empty(), "story has empty title: {s:?}");
+        }
+    }
+}

--- a/docs/requirements/authvault-frnfr.md
+++ b/docs/requirements/authvault-frnfr.md
@@ -1,0 +1,509 @@
+# Authvault — Functional & Non-Functional Requirements
+
+**Version:** 1.0.0  
+**Date:** 2026-05-29  
+**Status:** Backfilled from merged PRs #30, #31, #32 + existing codebase.  
+**Intended consumers:** Tracera, AgilePlus (ingestion via shared auth middleware).
+
+---
+
+## 1. Functional Requirements
+
+### FR-AUTHV-001 — PKCE Code-Verifier Generation
+
+| Field | Value |
+|-------|-------|
+| **Title** | RFC 7636-compliant PKCE code-verifier generation |
+| **PR** | #30 (`feat(pkce): RFC 7636-compliant PKCE + CSRF state hardening`) |
+| **RFC** | RFC 7636 §4.1 |
+
+**Description**  
+The system SHALL generate a cryptographically-random code verifier consisting of 32 entropy bytes
+base64url-encoded (no padding) to produce a 43-character string composed exclusively of unreserved
+ASCII characters (`A-Z a-z 0-9 - . _ ~`).
+
+**Acceptance Criteria**
+
+1. Generated verifier length is in `[43, 128]` (RFC 7636 §4.1 bounds).
+2. Every character is an unreserved ASCII character per RFC 7636 §4.1.
+3. Two independently-generated verifiers are statistically unique (collision probability ≤ 2⁻²⁵⁶).
+4. Entropy source is `OsRng` (CSPRNG); no deterministic fallback.
+
+**Traceability**  
+`src/domain/pkce.rs` — `CodeVerifier::new()`, constants `VERIFIER_MIN_LEN`/`VERIFIER_MAX_LEN`.  
+Tests: `test_verifier_length_is_rfc_compliant`, `test_verifier_charset_is_unreserved_ascii`,
+`test_verifier_uniqueness`.
+
+---
+
+### FR-AUTHV-002 — PKCE Code-Verifier Ingestion & Validation
+
+| Field | Value |
+|-------|-------|
+| **Title** | Server-side validation of client-supplied code verifier |
+| **PR** | #30 |
+| **RFC** | RFC 7636 §4.1 |
+
+**Description**  
+The system SHALL accept a client-supplied verifier string and validate its length
+(`[43, 128]`) and character set before accepting it into the PKCE flow.  Out-of-range or
+non-unreserved-ASCII inputs MUST return `AuthError::ValidationError`.
+
+**Acceptance Criteria**
+
+1. Valid 43-char alphabetic string: accepted.
+2. Strings shorter than 43 chars: rejected.
+3. Strings longer than 128 chars: rejected.
+4. Strings containing `+`, space, or non-ASCII: rejected.
+
+**Traceability**  
+`CodeVerifier::from_string()`.  
+Tests: `test_verifier_from_string_valid`, `test_verifier_from_string_too_short_rejected`,
+`test_verifier_from_string_too_long_rejected`, `test_verifier_from_string_bad_chars_rejected`.
+
+---
+
+### FR-AUTHV-003 — PKCE S256 Challenge Derivation
+
+| Field | Value |
+|-------|-------|
+| **Title** | S256 code-challenge derivation |
+| **PR** | #30 |
+| **RFC** | RFC 7636 §4.2, §4.6, Appendix B |
+
+**Description**  
+The system SHALL derive an S256 code challenge as
+`BASE64URL(SHA-256(ASCII(code_verifier)))` (RFC 7636 §4.6).  The `plain` method is
+explicitly unsupported to prevent downgrade attacks.
+
+**Acceptance Criteria**
+
+1. RFC 7636 Appendix B known-answer vector passes:
+   verifier `dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk` → challenge
+   `E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM`.
+2. Challenge derived from the same verifier verifies successfully.
+3. Challenge derived from a different verifier fails verification.
+
+**Traceability**  
+`CodeVerifier::to_challenge()`, `CodeChallenge::verify()`.  
+Tests: `test_s256_challenge_derivation_known_vector`,
+`test_challenge_verify_correct_verifier_succeeds`,
+`test_challenge_verify_wrong_verifier_fails`.
+
+---
+
+### FR-AUTHV-004 — PKCE Constant-Time Challenge Verification
+
+| Field | Value |
+|-------|-------|
+| **Title** | Constant-time verifier-challenge comparison |
+| **PR** | #30 |
+| **RFC** | RFC 7636 §4.6 |
+
+**Description**  
+Challenge verification SHALL use a byte-by-byte XOR accumulation pattern equivalent to
+`subtle::ConstantTimeEq` to prevent timing-oracle attacks.  A length mismatch fails
+immediately (length is public information and does not constitute an oracle).
+
+**Acceptance Criteria**
+
+1. Correct verifier → `Ok(())`.
+2. Wrong verifier → `Err(ValidationError("code_challenge mismatch"))`.
+3. No early-exit branch on content bytes (XOR-fold, single conditional at end).
+
+**Traceability**  
+`CodeChallenge::verify()` (lines 107-126 `src/domain/pkce.rs`).
+
+---
+
+### FR-AUTHV-005 — CSRF State Generation & Constant-Time Verification
+
+| Field | Value |
+|-------|-------|
+| **Title** | Opaque OAuth2 state parameter (CSRF protection) |
+| **PR** | #30 |
+| **RFC** | RFC 6749 §10.12 |
+
+**Description**  
+The system SHALL generate a 32-byte cryptographically-random state value
+(base64url-encoded) for binding authorization requests to client sessions.
+Incoming state MUST be verified with constant-time comparison; mismatch MUST return
+`AuthError::ValidationError("state parameter mismatch (CSRF check failed)")`.
+
+**Acceptance Criteria**
+
+1. Two independently-generated states are unique.
+2. `state.verify(state.as_str())` succeeds.
+3. `state.verify(other_state.as_str())` fails.
+4. `state.verify("")` fails.
+
+**Traceability**  
+`OAuthState::new()`, `OAuthState::verify()`.  
+Tests: `test_state_uniqueness`, `test_state_verify_matching_state_passes`,
+`test_state_verify_wrong_state_rejected`, `test_state_verify_empty_rejected`.
+
+---
+
+### FR-AUTHV-006 — Secret Vault AEAD Encryption at Rest
+
+| Field | Value |
+|-------|-------|
+| **Title** | ChaCha20-Poly1305 AEAD at-rest encryption for secrets |
+| **PR** | #31 (`feat(vault): ChaCha20-Poly1305 AEAD at-rest encryption for secrets`) |
+| **RFC** | RFC 8439 (ChaCha20-Poly1305) |
+
+**Description**  
+The system SHALL encrypt every secret with ChaCha20-Poly1305 AEAD using a fresh
+96-bit (12-byte) random nonce per seal operation.  The on-wire/on-disk envelope is
+`nonce (12 B) || ciphertext+tag`.  The 256-bit master key never leaves the `VaultKey`
+struct and is zeroed on drop.
+
+**Acceptance Criteria**
+
+1. Round-trip encrypt/decrypt returns original bytes (byte, Unicode, empty value).
+2. Decryption with a wrong key returns `VaultError::DecryptionFailed`.
+3. Bit-flip in ciphertext body returns `VaultError::DecryptionFailed` (AEAD tag rejection).
+4. Bit-flip in AEAD tag returns `VaultError::DecryptionFailed`.
+5. Bit-flip in nonce returns `VaultError::DecryptionFailed`.
+6. Two encryptions of identical plaintext produce different ciphertexts (nonce uniqueness).
+7. 1000 consecutive seal operations produce 1000 unique nonces.
+
+**Traceability**  
+`src/domain/vault.rs` — `EncryptedBlob::seal()`, `EncryptedBlob::open()`, `VaultKey`.  
+Tests: `round_trip_bytes`, `round_trip_unicode`, `round_trip_empty_value`,
+`wrong_key_fails_to_decrypt`, `tampered_ciphertext_rejected`, `tampered_tag_rejected`,
+`tampered_nonce_rejected`, `nonces_are_unique_across_encryptions`,
+`same_plaintext_yields_different_ciphertexts`.
+
+---
+
+### FR-AUTHV-007 — Secret Vault TTL / Expiry
+
+| Field | Value |
+|-------|-------|
+| **Title** | Optional TTL with automatic expiry enforcement |
+| **PR** | #31 |
+
+**Description**  
+`SecretVault::put()` SHALL accept an optional `ttl_seconds: Option<i64>`.  When
+`Some(secs)`, `expires_at` is set to `Utc::now() + secs`.  Any `get()` on an expired
+entry MUST return `VaultError::Expired` without decrypting.
+
+**Acceptance Criteria**
+
+1. Secret with `ttl=60` is readable immediately.
+2. Secret with `ttl=-1` (already expired) returns `VaultError::Expired` on `get()`.
+3. `list()` excludes expired entries.
+
+**Traceability**  
+`SecretVault::put()`, `SecretVault::get()`, `SecretVault::list()`, `VaultEntry::is_expired()`.  
+Tests: `ttl_secret_accessible_before_expiry`, `expired_secret_returns_error`,
+`list_excludes_expired_entries`.
+
+---
+
+### FR-AUTHV-008 — Secret Vault Key Rotation
+
+| Field | Value |
+|-------|-------|
+| **Title** | In-place secret rotation with fresh nonce and version increment |
+| **PR** | #31 |
+
+**Description**  
+`SecretVault::rotate()` SHALL re-encrypt the existing plaintext with a fresh random
+nonce, increment the version counter, and preserve the plaintext value.
+
+**Acceptance Criteria**
+
+1. Nonce before and after rotation differ.
+2. Version increments by 1 on each `put()` or `rotate()` call.
+3. Plaintext is still recoverable after rotation.
+4. `rotate()` on an expired or missing entry returns an error.
+
+**Traceability**  
+`SecretVault::rotate()`.  
+Tests: `rotate_re_encrypts_with_new_nonce`, `rotate_increments_version`,
+`version_increments_on_put`.
+
+---
+
+### FR-AUTHV-009 — Secret Vault Key Construction
+
+| Field | Value |
+|-------|-------|
+| **Title** | VaultKey generation and import |
+| **PR** | #31 |
+
+**Description**  
+`VaultKey::generate()` SHALL produce a fresh CSPRNG 256-bit key.
+`VaultKey::from_bytes()` SHALL accept exactly 32 bytes (e.g., from a KMS);
+other lengths MUST return `VaultError::InvalidKeyLength`.
+
+**Acceptance Criteria**
+
+1. `from_bytes(&[0u8; 16])` → `Err(InvalidKeyLength)`.
+2. Key generated → exported raw → re-imported → encrypts/decrypts correctly.
+
+**Traceability**  
+`VaultKey::generate()`, `VaultKey::from_bytes()`.  
+Tests: `vault_key_from_bytes_wrong_length_fails`, `vault_key_from_bytes_round_trip`.
+
+---
+
+### FR-AUTHV-010 — Bearer Token Validation
+
+| Field | Value |
+|-------|-------|
+| **Title** | HTTP `Authorization: Bearer <jwt>` validation |
+| **PR** | #32 (`feat: add bearer token validation`) |
+| **RFC** | RFC 6750 §2.1, RFC 7519 (JWT), RFC 7662 (token introspection concepts) |
+
+**Description**  
+The system SHALL parse an `Authorization` header value of the form `Bearer <token>`,
+validate the JWT signature, expiry (`exp`), not-before (`nbf`), issuer (`iss`), and
+audience (`aud`) claims, and return decoded `Claims` on success.  Any deviation MUST
+return a typed `AuthError` variant.
+
+**Acceptance Criteria**
+
+1. Valid `Bearer <jwt>` with correct issuer/audience → `Ok(Claims)`.
+2. Expired token → `Err(AuthError::Expired)`.
+3. Wrong signing key → `Err(AuthError::BadSignature)`.
+4. Wrong audience → `Err(AuthError::WrongAudience)`.
+5. Non-`Bearer` scheme or extra whitespace-separated tokens → `Err(AuthError::Malformed)`.
+6. Missing scheme token → `Err(AuthError::Malformed)`.
+
+**Traceability**  
+`src/domain/auth.rs` — `Authenticator::validate_bearer_token()`,
+`Authenticator::validation()`.  
+Integration tests: `test_validate_bearer_token` (integration_tests.rs line 134),  
+Unit tests: `test_validate_bearer_token_success`, `test_validate_bearer_token_expired`,
+`test_validate_bearer_token_bad_signature`, `test_validate_bearer_token_wrong_audience`,
+`test_validate_bearer_token_malformed`.
+
+---
+
+### FR-AUTHV-011 — JWT Generation with Standard Claims
+
+| Field | Value |
+|-------|-------|
+| **Title** | JWT access-token generation with `sub`, `iss`, `aud`, `exp`, `iat`, `nbf`, `jti`, `roles` |
+| **PR** | Pre-existing; hardened by #32 |
+| **RFC** | RFC 7519 §4.1 |
+
+**Description**  
+`Authenticator::generate_token()` SHALL produce a signed JWT containing all registered
+claim names (`sub`, `iss`, `aud`, `exp`, `iat`, `nbf`, `jti`) plus a `roles` array.
+The default expiry is 24 hours.  Custom expiry is available via
+`generate_token_with_expiry()`.
+
+**Acceptance Criteria**
+
+1. Generated token verifies with the same `Authenticator`.
+2. Decoded `claims.sub` matches the source `UserId`.
+3. Decoded `claims.roles` contains supplied role names.
+4. Custom expiry produces a token with the correct `exp` timestamp.
+
+**Traceability**  
+`Claims::new()`, `Authenticator::generate_token()`,
+`Authenticator::generate_token_with_expiry()`.  
+Tests: `test_generate_and_verify_token`, `test_expired_token`.
+
+---
+
+## 2. Non-Functional Requirements
+
+### NFR-AUTHV-001 — Cryptographic Correctness: S256 Only
+
+| Field | Value |
+|-------|-------|
+| **Title** | Exclusive use of S256 PKCE method; no `plain` downgrade |
+| **PR** | #30 |
+| **RFC** | RFC 7636 §4.2 |
+
+**Description**  
+The PKCE implementation SHALL support only the S256 method.  The `plain`
+method MUST NOT be accepted, preventing downgrade attacks.
+
+**Evidence**  
+`CodeVerifier::to_challenge()` always computes `SHA-256`; no `method` parameter exists.
+
+---
+
+### NFR-AUTHV-002 — Cryptographic Correctness: Constant-Time Comparisons
+
+| Field | Value |
+|-------|-------|
+| **Title** | All secret-comparison paths are constant-time |
+| **PR** | #30 |
+
+**Description**  
+All comparisons of cryptographic material (PKCE challenge, OAuth state) SHALL use
+accumulator-XOR or `subtle::ConstantTimeEq` patterns.  No early-exit on content bytes
+is permitted.
+
+**Evidence**  
+`CodeChallenge::verify()` and `OAuthState::verify()` both use
+`fold(0u8, |acc, (a, b)| acc | (a ^ b))` — single exit after full scan.
+
+---
+
+### NFR-AUTHV-003 — Cryptographic Correctness: Random Nonce per Seal
+
+| Field | Value |
+|-------|-------|
+| **Title** | Fresh 96-bit CSPRNG nonce for every ChaCha20-Poly1305 seal |
+| **PR** | #31 |
+
+**Description**  
+Each call to `EncryptedBlob::seal()` SHALL generate a fresh nonce via
+`ChaCha20Poly1305::generate_nonce(&mut OsRng)`.  Nonce reuse under the same key MUST
+be operationally impossible.
+
+**Evidence**  
+`nonces_are_unique_across_encryptions` — 1000 seals with identical plaintext produce
+1000 distinct nonces (probability of collision ≤ 2⁻⁹⁶).
+
+---
+
+### NFR-AUTHV-004 — Cryptographic Correctness: ZeroizeOnDrop for Key Material
+
+| Field | Value |
+|-------|-------|
+| **Title** | Master vault key zeroed from memory on drop |
+| **PR** | #31 |
+
+**Description**  
+`VaultKey` SHALL derive `zeroize::ZeroizeOnDrop` so its 32-byte raw array is
+overwritten with zeros when the struct is dropped, preventing key material from
+lingering in heap/stack memory.
+
+**Evidence**  
+`#[derive(Clone, ZeroizeOnDrop)]` on `VaultKey`; `zeroize` crate in `Cargo.toml`.
+
+---
+
+### NFR-AUTHV-005 — No Hand-Rolled Cryptography
+
+| Field | Value |
+|-------|-------|
+| **Title** | Vetted crate usage for all cryptographic primitives |
+| **PR** | #30, #31 |
+
+**Description**  
+All cryptographic operations SHALL use vetted RustCrypto ecosystem crates:
+
+| Primitive | Crate |
+|-----------|-------|
+| AEAD | `chacha20poly1305` |
+| Hash | `sha2` |
+| Base64url | `base64` (general_purpose::URL_SAFE_NO_PAD) |
+| CSPRNG | `rand` (OsRng) |
+| Zeroize | `zeroize` |
+| JWT | `jsonwebtoken` |
+
+No custom implementations of AES, SHA, or MAC are permitted.
+
+---
+
+### NFR-AUTHV-006 — Tamper Detection via AEAD Authentication Tag
+
+| Field | Value |
+|-------|-------|
+| **Title** | Any single-bit mutation in ciphertext, tag, or nonce is detected |
+| **PR** | #31 |
+
+**Description**  
+The Poly1305 authentication tag SHALL ensure that any modification to the
+ciphertext envelope — body, tag, or nonce — causes decryption to fail with
+`VaultError::DecryptionFailed` before any plaintext is returned.
+
+**Evidence**  
+Tests: `tampered_ciphertext_rejected`, `tampered_tag_rejected`,
+`tampered_nonce_rejected`.
+
+---
+
+### NFR-AUTHV-007 — JWT Claim Validation (Expiry, Issuer, Audience)
+
+| Field | Value |
+|-------|-------|
+| **Title** | JWT decoder enforces `exp`, `nbf`, `iss`, `aud` |
+| **PR** | #32 |
+| **RFC** | RFC 7519 §4.1, RFC 6750 |
+
+**Description**  
+`Authenticator::validation()` SHALL configure `jsonwebtoken::Validation` with
+`validate_exp = true`, `validate_nbf = true`, explicit issuer, and explicit audience.
+Each failure maps to a distinct `AuthError` variant for consumer diagnostic clarity.
+
+**Evidence**  
+`Authenticator::validation()` (`auth.rs` lines 144-151); `decode_token()` error mapping
+(lines 157-168).
+
+---
+
+### NFR-AUTHV-008 — Bearer Token Header Strict Parsing
+
+| Field | Value |
+|-------|-------|
+| **Title** | `Bearer` scheme check is case-insensitive; extra tokens rejected |
+| **PR** | #32 |
+| **RFC** | RFC 6750 §2.1 |
+
+**Description**  
+The bearer token parser SHALL accept `Bearer` (case-insensitive) followed by exactly
+one token.  Headers with a different scheme, no token, or extra whitespace-separated
+tokens SHALL return `AuthError::Malformed`.
+
+**Evidence**  
+`validate_bearer_token()` uses `eq_ignore_ascii_case("Bearer")` and checks
+`parts.next().is_some()` after extracting scheme+token.
+
+---
+
+### NFR-AUTHV-009 — Test Coverage: Cryptographic Rejection Paths
+
+| Field | Value |
+|-------|-------|
+| **Title** | All cryptographic failure paths have dedicated regression tests |
+| **PR** | #30, #31, #32 |
+
+**Description**  
+Every rejection path for PKCE, vault AEAD, and bearer-token validation SHALL have at
+least one dedicated unit test exercising that exact failure mode (not just the success
+path).
+
+**Evidence**  
+Tests covering rejection paths:
+
+- PKCE: `test_verifier_from_string_too_short_rejected`,
+  `test_verifier_from_string_too_long_rejected`,
+  `test_verifier_from_string_bad_chars_rejected`,
+  `test_challenge_verify_wrong_verifier_fails`,
+  `test_state_verify_wrong_state_rejected`,
+  `test_state_verify_empty_rejected`.
+- Vault: `wrong_key_fails_to_decrypt`, `tampered_ciphertext_rejected`,
+  `tampered_tag_rejected`, `tampered_nonce_rejected`, `expired_secret_returns_error`,
+  `missing_secret_returns_not_found`, `vault_key_from_bytes_wrong_length_fails`.
+- Bearer: `test_validate_bearer_token_expired`,
+  `test_validate_bearer_token_bad_signature`,
+  `test_validate_bearer_token_wrong_audience`,
+  `test_validate_bearer_token_malformed`.
+
+---
+
+## 3. Gaps / PLANNED
+
+| ID | Area | Gap | Status |
+|----|------|-----|--------|
+| GAP-001 | PKCE | `code_challenge_method` negotiation — server must reject `plain` at the protocol level, not just by omission | PLANNED |
+| GAP-002 | Vault | Persistent backend (e.g., Redis/Postgres) — current `SecretVault` is in-memory only; restarts lose all secrets | PLANNED |
+| GAP-003 | Vault | Key-wrapping / KMS integration — `VaultKey` can be loaded from bytes but there is no KMS plugin interface | PLANNED |
+| GAP-004 | Vault | Audit log — no record of `put`, `rotate`, `get`, or `remove` operations with caller identity | PLANNED |
+| GAP-005 | Tokens | Refresh-token rotation — `refresh_token()` re-uses the same `sub`/`roles` without invalidating the prior token | PLANNED |
+| GAP-006 | Tokens | Token revocation list — no mechanism to revoke a non-expired JWT before its `exp` | PLANNED |
+| GAP-007 | Bearer | Asymmetric (RS256/ES256) signing key support — current implementation is HMAC-only | PLANNED |
+| GAP-008 | PKCE | State binding to server session — `OAuthState` is generated but the server-side session association is not enforced at the middleware layer | PLANNED |
+| GAP-009 | General | Rate-limiting on failed auth attempts — no brute-force protection for verifier/state/bearer endpoints | PLANNED |
+| GAP-010 | General | Tracera / AgilePlus middleware adapter — wiring of these requirements into Axum tower layers for consumer repos not yet documented | PLANNED |

--- a/docs/requirements/phenotype-voxel-frnfr.md
+++ b/docs/requirements/phenotype-voxel-frnfr.md
@@ -1,0 +1,324 @@
+# phenotype-voxel — Functional & Non-Functional Requirements
+
+**Scope:** Backfilled catalog for Tracera + AgilePlus ingestion.
+**Schema version:** 1 (matches `SCHEMA_VERSION` constant in `src/lib.rs`).
+**Test baseline:** 91 lib tests passing (1 doctest skipped — prose comment, not executable).
+
+---
+
+## Functional Requirements
+
+### FR-VOXEL-001 — Chunk Storage
+
+**Title:** Dense 16³ leaf chunk storage parameterised over voxel type.
+
+**Description:** The substrate stores voxels as dense 16³ arrays (`CHUNK_EDGE=16`,
+`CHUNK_VOXELS=4096`) wrapped in `Chunk<T: Default + Clone>`. Chunks are indexed by
+deterministic `ChunkId(u64)`. A borrowed `ChunkView<'a, T>` provides zero-copy
+access to the voxel slice plus the stable `ChunkId` for meshing.
+
+**Acceptance criteria:**
+- `Chunk::default()` produces exactly 4096 voxels all set to `T::default()`.
+- `CHUNK_VOXELS == CHUNK_EDGE³` is enforced at compile+test time.
+- `ChunkView` carries a valid `&[T]` of length `CHUNK_VOXELS`.
+
+**Traceability:**
+- PR #1 (format), PR #3 (generic parameterisation)
+- In-code: `FR-PHENO-VOXEL-CHUNK-000`, `FR-PHENO-VOXEL-CHUNK-001` (`src/chunk.rs`)
+
+---
+
+### FR-VOXEL-002 — Compact RLE Chunk Serialization / Deserialization
+
+**Title:** Binary PVOX RLE round-trip for scene persistence.
+
+**Description:** `save_chunk<T, W>` / `load_chunk<T, R>` serialize/deserialize a
+`Chunk<T: Pod + Eq + Default + Clone>` using a self-describing binary PVOX format
+(magic `b"PVOX"`, format version `u8`, element size `u32 LE`, RLE run count `u32 LE`,
+then `(run_length: u16 LE, value bytes)*`). A fully uniform chunk serializes to a
+single run (16 bytes for `u8`). Type-size mismatches are detected before reading
+voxel data.
+
+**Acceptance criteria:**
+- Empty (uniform-default) chunk serializes to exactly 16 bytes for `T=u8`.
+- Fully dense alternating chunk round-trips losslessly (4096 runs of length 1).
+- Bad magic returns `io::ErrorKind::InvalidData`.
+- Element-size mismatch detected before voxel data is consumed.
+- Run-length sum != `CHUNK_VOXELS` returns an error.
+
+**Traceability:**
+- PR #2 (RLE implementation)
+- In-code: `FR-PHENO-VOXEL-SERIAL-000..003` (`src/serial.rs`)
+
+---
+
+### FR-VOXEL-003 — Pluggable Mesher Trait
+
+**Title:** Engine-agnostic `Mesher` trait with associated `VoxelKind`.
+
+**Description:** `Mesher` is a Rust trait with two associated types:
+`VoxelKind: Default + Clone` (pins the voxel type) and `Mesh` (engine artifact).
+The single required method `mesh_chunk(chunk, lod) -> MeshResult<Self::Mesh>` must
+be deterministic for a given `(chunk, lod)` pair. The `CubicVoxel` sub-trait
+(`is_solid()`, `material()`) enables the reference meshers; blanket impl for
+`MaterialId` is provided.
+
+**Acceptance criteria:**
+- `Mesher::VoxelKind` prevents mixing voxel types at the trait boundary (compile-time enforcement).
+- Any `T: CubicVoxel` can be wired to `CubicMesher<T>` or `GreedyMesher<T>`.
+- Determinism: calling `mesh_chunk` twice on equal `(chunk, lod)` inputs returns bit-identical buffers.
+
+**Traceability:**
+- PR #3 (VoxelKind associated type + generic CubicMesher)
+- In-code: `FR-PHENO-VOXEL-CUBIC-002`, `FR-PHENO-VOXEL-CUBIC-011` (`src/cubic_mesher.rs`)
+
+---
+
+### FR-VOXEL-004 — Cubic Reference Mesher
+
+**Title:** Axis-aligned cubic mesher emitting only exposed faces.
+
+**Description:** `CubicMesher<V: CubicVoxel>` iterates each solid voxel and emits
+up to 6 quad faces (2 triangles each). A face is suppressed when the adjacent voxel
+is solid. Outward normals are the canonical axis unit vectors. Each face vertex
+carries `position`, `normal`, `uv`, and `material` from the voxel's `CubicVoxel`
+impl. Index buffer is consistent (no out-of-range references).
+
+**Acceptance criteria:**
+- Single solid voxel in empty chunk → exactly 6 faces (12 triangles).
+- Two adjacent solid voxels → shared face suppressed (10 faces).
+- Fully surrounded voxel (all 6 neighbours solid) → 0 faces.
+- Each face normal equals the correct outward axis vector.
+- Material ID propagated to all 4 vertices of each face.
+- `indices` only reference valid vertex slots.
+
+**Traceability:**
+- PR #3 (generic CubicMesher)
+- In-code: `FR-PHENO-VOXEL-CUBIC-001..010` (`src/cubic_mesher.rs`)
+
+---
+
+### FR-VOXEL-005 — Greedy (Maximal-Rect) Mesher
+
+**Title:** Greedy quad-merging mesher for reduced triangle count.
+
+**Description:** `GreedyMesher<V: CubicVoxel>` sweeps each of the 6 axis-aligned
+face directions, builds a 2-D material mask of visible faces per slice, and merges
+coplanar same-material faces into maximal rectangles (greedy width-then-height
+extension). One quad (2 triangles) is emitted per rectangle. Implements the same
+`Mesher` trait as `CubicMesher`.
+
+**Acceptance criteria:**
+- Produces the same visible surface (watertight; no T-junctions on flat regions)
+  as `CubicMesher` for identical inputs.
+- Triangle count ≤ cubic count for any chunk (regression guard — see NFR-VOXEL-002).
+- Same-material coplanar faces are merged; different-material or non-coplanar faces
+  are not merged.
+- `ao` field of produced `MeshBuffer` is all-3 (fully lit; see PLANNED section).
+
+**Traceability:**
+- PR #5 (GreedyMesher), PR #6 (benchmark + regression guard)
+- In-code: `FR-PHENO-VOXEL-*` tests in `src/greedy_mesher.rs`
+
+---
+
+### FR-VOXEL-006 — Per-Vertex Ambient Occlusion
+
+**Title:** AO values in `MeshBuffer.ao` for cubic meshing.
+
+**Description:** `CubicMesher` populates `MeshBuffer.ao` (a `Vec<u8>` parallel to
+`vertices`) with classic voxel AO per vertex. Value range: 0 (maximum occlusion, both
+side neighbours solid) to 3 (fully lit, no neighbours). Formula:
+`ao = if side1 && side2 { 0 } else { 3 - (side1 + side2 + corner) }`.
+`ao.len()` always equals `vertices.len()`.
+
+**Acceptance criteria:**
+- Fully exposed single voxel → all AO values = 3.
+- `ao.len() == vertices.len()` for any mesh output.
+- Triangle count is unchanged relative to non-AO cubic output.
+- Voxel in a right-angle crevice (two perpendicular solid neighbours) → corner
+  vertices have AO value < 3.
+- Empty chunk → `ao` is empty (all-3 trivially).
+
+**Traceability:**
+- PR #7 (per-vertex AO)
+- In-code: `FR-PHENO-VOXEL-CUBIC-AO-001..005` (`src/cubic_mesher.rs`)
+
+---
+
+### FR-VOXEL-007 — Engine-Agnostic Mesh Export API
+
+**Title:** `MeshBuffer` export surface: iterators + `to_interleaved()`.
+
+**Description:** `MeshBuffer` exposes zero-copy iterator accessors
+(`positions()`, `normals()`, `uvs()`, `ao()`, `indices()`) plus
+`vertex_count()`, `index_count()`, `triangle_count()`, `is_empty()`.
+`to_interleaved() -> Vec<f32>` packs all vertices into a flat stride-9 buffer
+`[px, py, pz, nx, ny, nz, u, v, ao]` (36 bytes/vertex) suitable for a single
+GPU VBO upload.
+
+**Acceptance criteria:**
+- `to_interleaved().len() == vertex_count() * 9`.
+- Interleaved AO values at offset 8 of each stride match `ao()`.
+- Interleaved positions match `vertices[i].position`.
+- Empty mesh → empty interleaved buffer.
+- All accessor counts equal `vertices.len()` / `indices.len()`.
+
+**Traceability:**
+- PR #8 (engine-agnostic export API)
+- In-code: `FR-PHENO-VOXEL-MESH-EXPORT-000..005` (`src/mesh.rs`)
+
+---
+
+### FR-VOXEL-008 — SVO Node Compaction
+
+**Title:** Greedy upward merging of uniform sibling nodes in `VoxelOctree`.
+
+**Description:** `VoxelOctree<T>` stores `OctreeNode::Uniform(T)` or
+`OctreeNode::Dense` per `ChunkCoord` in a deterministic `BTreeMap`.
+`compact()` performs a fixpoint greedy upward merge: any complete 8-sibling
+group where all members are `Uniform` with the same value collapses to one
+parent-level `Uniform` node. Passes repeat until no further collapses occur.
+Returns total nodes removed. Operation is idempotent.
+
+**Acceptance criteria:**
+- 8 uniform siblings → 8 nodes removed, 1 parent node inserted.
+- Mixed-value group → 0 nodes removed.
+- Idempotent: second call on compacted tree → 0 removed, state unchanged.
+- Multi-level pyramid (64 leaves) → 72 nodes removed, 1 root remains.
+- Incomplete group (7/8 siblings) → 0 removed.
+- Query semantics preserved: parent node carries merged material.
+
+**Traceability:**
+- PR #9 (SVO node compaction)
+- In-code: `FR-PHENO-VOXEL-OCTREE-000..015` (`src/octree.rs`)
+
+---
+
+### FR-VOXEL-009 — Deterministic Dirty-Event Queue
+
+**Title:** `DirtyChunkEvent` ordered by `(chunk_id, write_seq)`.
+
+**Description:** Every voxel write on `VoxelWorld` produces a `DirtyChunkEvent`
+tagged with a monotonically increasing `WriteSeq`. Consumers drain events via
+`drain_dirty()`. Events sort by `(chunk_id, write_seq)` so replay is order-stable
+across implementations. Idempotent writes (same value already present) do not emit
+events. `DirtyChunkEvent` and `WriteSeq` are `Serialize/Deserialize`.
+
+**Acceptance criteria:**
+- `WriteSeq::next()` is strictly monotonic.
+- Two events with different `(chunk_id, write_seq)` sort predictably.
+- Idempotent write (same value) → no event emitted.
+- Replaying the same write sequence on a fresh `VoxelWorld` yields
+  bit-identical chunk state.
+
+**Traceability:**
+- PR #2 (introduced dirty events), PR #9 (world compaction integration)
+- In-code: `FR-PHENO-VOXEL-DELTA-000..001` (`src/delta.rs`),
+  `FR-PHENO-VOXEL-WORLD-001..016` (`src/world.rs`)
+
+---
+
+## Non-Functional Requirements
+
+### NFR-VOXEL-001 — Determinism
+
+**Title:** All public operations are deterministic across runs and platforms.
+
+**Description:** World coordinates are fixed-point `i64` at `10^6` scale; no
+`f32/f64` crosses the public API boundary. Internal collections use `BTreeMap`
+(deterministic iteration order), never `HashMap`. Mesher output is bit-identical
+for equal `(chunk, lod)` inputs. Dirty events are ordered, not set-like.
+`#![forbid(unsafe_code)]` enforced crate-wide.
+
+**Evidence:** `src/lib.rs` determinism contract comment; `VoxelOctree` uses
+`BTreeMap`; `FR-PHENO-VOXEL-CUBIC-002` determinism test; `FR-PHENO-VOXEL-WORLD-005`
+replay bit-identity test.
+
+---
+
+### NFR-VOXEL-002 — Greedy ≤ Cubic Triangle Count (Regression Guard)
+
+**Title:** `GreedyMesher` never produces more triangles than `CubicMesher` for any chunk.
+
+**Description:** Greedy meshing merges coplanar faces; the triangle count for any
+input chunk must not exceed the cubic count. A Criterion benchmark (`benches/`) and
+a dedicated triangle-count regression test enforce this invariant on every CI run.
+
+**Evidence:** PR #6 (benchmark + regression guard); `benches/` Criterion suite; test
+`greedy_triangle_count_le_cubic` (or equivalent) in `src/greedy_mesher.rs`.
+
+---
+
+### NFR-VOXEL-003 — Zero-Dependency Export Surface
+
+**Title:** `MeshBuffer` export API has no engine-specific dependencies.
+
+**Description:** `MeshBuffer` and its export methods (`to_interleaved`, iterators,
+counts) depend only on `std` + `serde`. No Bevy, Godot, or Unreal crates appear in
+the dependency tree of the core `phenotype-voxel` crate. Engine adapters are
+consumer-side.
+
+**Evidence:** `Cargo.toml` deps: `bytemuck`, `serde`, `thiserror`, `log` only; PR #8
+confirms no engine deps added.
+
+---
+
+### NFR-VOXEL-004 — Watertight Meshes (No Duplicate / Missing Faces)
+
+**Title:** Both meshers produce watertight, non-degenerate geometry.
+
+**Description:** Exposed faces are emitted exactly once. Internal (solid-to-solid)
+faces are never emitted. Normals are unit vectors on the correct outward axis.
+Index buffer references only valid vertex slots.
+
+**Evidence:** `FR-PHENO-VOXEL-CUBIC-003` (internal face suppression),
+`FR-PHENO-VOXEL-CUBIC-006` (corner voxel), `FR-PHENO-VOXEL-CUBIC-007` (fully
+surrounded → 0 faces), `FR-PHENO-VOXEL-CUBIC-008` (outward normals),
+`FR-PHENO-VOXEL-CUBIC-010` (index validity).
+
+---
+
+### NFR-VOXEL-005 — Test Suite Coverage (91+ Tests Green)
+
+**Title:** All lib tests pass on every merge to `main`.
+
+**Description:** The test suite must maintain ≥ 91 passing lib tests. Doctest failures
+caused by prose comment blocks (not executable code) are excluded. CI enforces
+`cargo test --lib` on PR merge.
+
+**Evidence:** `cargo test --lib` output: `91 passed; 0 failed` (2026-05-29).
+
+---
+
+## Test-ID to Catalog Mapping
+
+| In-code test series | Catalog FR/NFR |
+|---|---|
+| `FR-PHENO-VOXEL-CHUNK-000..001` | FR-VOXEL-001 |
+| `FR-PHENO-VOXEL-SERIAL-000..003` | FR-VOXEL-002 |
+| `FR-PHENO-VOXEL-CUBIC-001..011` | FR-VOXEL-003, FR-VOXEL-004, NFR-VOXEL-004 |
+| `FR-PHENO-VOXEL-CUBIC-AO-001..005` | FR-VOXEL-006 |
+| `FR-PHENO-VOXEL-MESH-000`, `MESH-EXPORT-000..005` | FR-VOXEL-007 |
+| `FR-PHENO-VOXEL-OCTREE-000..015` | FR-VOXEL-008 |
+| `FR-PHENO-VOXEL-DELTA-000..001` | FR-VOXEL-009 |
+| `FR-PHENO-VOXEL-WORLD-001..016` | FR-VOXEL-009, NFR-VOXEL-001 |
+| `FR-PHENO-VOXEL-COORD-000..001` | (coordinate contract, underpins FR-VOXEL-001/009) |
+| `FR-PHENO-VOXEL-LOD-000..006` | (LOD selection, underpins FR-VOXEL-004/005) |
+| `FR-PHENO-VOXEL-MATERIAL-000` | (palette, underpins FR-VOXEL-004/005) |
+| `FR-PHENO-VOXEL-SHAPEHINT-001..009` | (shape-hint registry, not yet in catalog — see PLANNED) |
+| `FR-PHENO-VOXEL-SPRITEVOX-001..006` | (sprite voxelizer, not yet in catalog — see PLANNED) |
+
+---
+
+## Gaps / PLANNED
+
+| ID | Title | Notes |
+|---|---|---|
+| PLAN-VOXEL-001 | Greedy-mesher per-vertex AO | `MeshBuffer.ao` all-3 for GreedyMesher; `TODO` noted in `src/mesh.rs` |
+| PLAN-VOXEL-002 | Bevy adapter crate | `phenotype-voxel-bevy` consuming `MeshBuffer.to_interleaved()`; zero engine deps in core (NFR-VOXEL-003) |
+| PLAN-VOXEL-003 | Performance under load | No bench for world-scale writes or SVO traversal; Criterion suite covers mesher only |
+| PLAN-VOXEL-004 | Shape-hint registry FR | `FR-PHENO-VOXEL-SHAPEHINT-*` tests exist but no catalog entry; formalize as FR-VOXEL-010 |
+| PLAN-VOXEL-005 | Sprite voxelizer FR | `FR-PHENO-VOXEL-SPRITEVOX-*` tests exist but no catalog entry; formalize as FR-VOXEL-011 |
+| PLAN-VOXEL-006 | Full recursive SVO subdivision | `octree.rs` notes "8-way branches reserved for follow-up PR"; current model is flat `BTreeMap` |
+| PLAN-VOXEL-007 | Doctest hygiene | 1 doctest fails on Windows (prose comment mistaken for code block in `cubic_mesher.rs`); fix or mark `ignore` |

--- a/docs/requirements/tracera-frnfr.md
+++ b/docs/requirements/tracera-frnfr.md
@@ -1,0 +1,324 @@
+# Tracera FR/NFR Catalog — Backfilled Requirements
+
+**Version:** 1.0.0
+**Date:** 2026-05-29
+**Status:** Active
+
+> **Meta — Dog-fooding note:** Tracera IS the traceability tool. This catalog is designed to be ingested into Tracera's own Requirement / Artifact / TraceLink model, making it a self-referential demonstration of the platform's value. Every FR listed here corresponds to a `Requirement` node, every PR/test reference becomes an `Artifact`, and every (FR→PR) / (FR→test) pair becomes a `TraceLink` with `VERIFIES` or `IMPLEMENTS` semantics. This is the canonical seed dataset for Tracera's own dog-food project in AgilePlus.
+
+---
+
+## Functional Requirements
+
+### FR-TRC-001 — Canonical TraceLink Domain Model
+
+**Title:** Canonical Requirement / Artifact / TraceLink value objects with ISO-29148-aligned vocabulary
+
+**Description:** The system shall expose a canonical domain layer (`tracertm.models.trace_link`) that defines `TraceLinkType` (SATISFIES, VERIFIES, IMPLEMENTS, DERIVES_FROM, REFINES, CONFLICTS_WITH, DUPLICATES), `ArtifactKind` (REQUIREMENT, DESIGN, CODE, TEST, EVIDENCE, RISK, RATIONALE), and lightweight Pydantic value objects (`TraceLink`, `Requirement`, `Artifact`) used at API, RAG, and pipeline boundaries.
+
+**Acceptance Criteria:**
+- `TraceLinkType` enum values match Neo4j relationship labels exactly (SCREAMING_SNAKE).
+- `ArtifactKind` partitions Items into ISO 29148 / DO-178C traceability roles.
+- Pydantic models are wire-format-clean (JSON-serialisable, no ORM dependencies).
+- `Neo4jSchema` provides declarative Cypher constraints and index declarations.
+
+**Traceability:**
+- PR: #458 (feat(trace-link): canonical domain + Neo4j schema)
+- Source: `src/tracertm/models/trace_link.py`
+- Alembic: `062_add_trace_link_fields.py`
+
+---
+
+### FR-TRC-002 — Confidence-Scored Trace Links with Rationale
+
+**Title:** Persist and query trace links with miner confidence score and natural-language rationale
+
+**Description:** Every trace link shall carry a `confidence` float in [0.0, 1.0] (default 1.0 for human-curated links) and an optional `rationale` text field. The repository shall expose a `list_with_confidence` query supporting filter-by-confidence thresholds for downstream RAG and explainability layers.
+
+**Acceptance Criteria:**
+- `links.confidence` column has DB-level CHECK constraint `[0.0, 1.0]`.
+- `links.rationale` is nullable TEXT.
+- `LinkRepository.create()` rejects out-of-range confidence with `ValueError`.
+- `list_with_confidence` query is exposed and tested.
+- Indexes: `idx_links_confidence`, `idx_links_project_type_confidence`.
+
+**Traceability:**
+- PR: #460 (feat(link-repository): persist confidence + rationale + list_with_confidence)
+- Source: `src/tracertm/repositories/link_repository.py`
+- Tests: `tests/unit/repositories/test_link_repository.py`, `tests/unit/repositories/test_link_repository_comprehensive.py`
+- Alembic: `062_add_trace_link_fields.py`
+
+---
+
+### FR-TRC-003 — Neo4j Trace-Graph Projection Writer
+
+**Title:** Idempotent Neo4j writer for Requirement / Artifact / TraceLink graph projection
+
+**Description:** The system shall provide `tracertm.storage.neo4j_trace_link_writer` with idempotent `MERGE`-based writers (`write_requirement`, `write_artifact`, `write_link`) and an `apply_schema` bootstrap that creates Neo4j constraints and indexes. Writers must be safe to call multiple times without creating duplicates.
+
+**Acceptance Criteria:**
+- All writes use `MERGE` (idempotent) not `CREATE`.
+- `apply_schema` creates uniqueness constraints and indexes declared in `Neo4jSchema`.
+- Integration tests pass against a real Neo4j 5 instance via testcontainers.
+- Module is skipped gracefully when `neo4j` driver or testcontainers is absent.
+
+**Traceability:**
+- PR: #461 (feat(neo4j): idempotent TraceLink projection writer)
+- Source: `src/tracertm/storage/neo4j_trace_link_writer.py` (inferred)
+- Tests: `tests/integration/storage/test_neo4j_trace_link_writer.py`
+
+---
+
+### FR-TRC-004 — Forward and Reverse Impact Analysis via Cypher
+
+**Title:** REST endpoints for Cypher-powered forward/reverse artifact impact traversal
+
+**Description:** The API shall expose two endpoints (`GET /impact/forward/{artifact_id}` and `GET /impact/reverse/{artifact_id}`) that traverse the Neo4j trace-link graph using multi-hop Cypher queries. Forward impact returns all downstream artifacts affected by a change; reverse impact returns all upstream artifacts (requirements, specs) that led to a given artifact.
+
+**Acceptance Criteria:**
+- Forward traversal: `MATCH (src)-[l*1..]->(affected)` collects all reachable downstream nodes.
+- Reverse traversal: `MATCH (affected)-[l*1..]->(src)` collects upstream chain.
+- Response includes `id`, `project_id`, `kind`, `title`, `external_id`, `link_types`.
+- Endpoints are wired into FastAPI router with proper async Neo4j driver dependency injection.
+- Handler correctly closes driver after each request.
+
+**Traceability:**
+- PR: #462 (feat(impact-api): Cypher forward/reverse impact analysis endpoints)
+- Source: `src/tracertm/api/handlers/impact.py`
+- Tests: `tests/integration/graph/test_cypher_impact_api.py`
+
+---
+
+### FR-TRC-005 — Authentication with DB Account Lookup
+
+**Title:** Auth handler resolves authenticated identities against the accounts database table
+
+**Description:** Upon successful OAuth/device-code authentication, the system shall look up the authenticated user's account record in the PostgreSQL `accounts` table via `AccountRepository`, rather than relying solely on the identity provider's token claims. System admin privileges are determined by matching the email against the `TRACERTM_SYSTEM_ADMIN_EMAILS` environment variable (comma-separated).
+
+**Acceptance Criteria:**
+- `AccountRepository` is called post-token-verification to resolve the local account record.
+- Missing account records result in a well-formed 401/403 (not a 500).
+- System admin cache (`_admin_emails_cache`) is populated from env var at startup.
+- Device Authorization Flow (RFC 8628) is supported alongside standard OAuth.
+
+**Traceability:**
+- PR: #463 (feat(auth): implement DB account lookup, closes #223)
+- Source: `src/tracertm/api/handlers/auth.py`, `src/tracertm/repositories/account_repository.py`
+- Tests: `tests/unit/repositories/test_account_repository.py`, `tests/unit/api/test_authentication.py`
+
+---
+
+### FR-TRC-006 — Spatial GiST Index for Graph Viewport Queries
+
+**Title:** PostgreSQL GIST index on item (position_x, position_y) for O(log n) viewport range queries
+
+**Description:** Graph items with positional coordinates shall be indexed using a PostgreSQL GIST index (`idx_items_spatial`) over a `box(point(position_x, position_y), ...)` expression, enabling sub-linear rectangular range queries for graph viewport/frustum culling without full-table scans.
+
+**Acceptance Criteria:**
+- `items.position_x` and `items.position_y` columns exist (NUMERIC 10,2, default 0).
+- GIST index `idx_items_spatial` is created with a `WHERE deleted_at IS NULL` partial filter.
+- Migration is idempotent (uses `CREATE INDEX IF NOT EXISTS` and `ADD COLUMN IF NOT EXISTS`).
+- Index is used by the query planner for bbox queries (verified via `EXPLAIN ANALYZE`).
+
+**Traceability:**
+- PR: #464 (perf: spatial index for edge midpoint distance queries)
+- Source: `alembic/versions/054_add_spatial_gist_index.py`
+
+---
+
+### FR-TRC-007 — UICodeTracePanel Live API Integration
+
+**Title:** UICodeTracePanel React component wired to live traceability chain API
+
+**Description:** The `UICodeTracePanel` component shall fetch live traceability chain data from the backend API (not mock/stub data), displaying the full UI→code→requirement linkage for any selected artifact. The panel shall show loading states, support `CanonicalConcept`, `CanonicalProjection`, `CodeReference`, and `EquivalenceStrategy` typed data from `@tracertm/types`.
+
+**Acceptance Criteria:**
+- Component imports from `@tracertm/types` (not local stubs).
+- API fetch uses the project's shared API client (no raw `fetch` with hardcoded URLs).
+- Loading, error, and empty states are handled.
+- Integration test (`UICodeTracePanel.integration.tsx`) exercises the live API path.
+
+**Traceability:**
+- PR: #465 (feat: wire UICodeTracePanel to live API, closes #226)
+- Source: `frontend/apps/web/src/components/graph/UICodeTracePanel.tsx`
+- Tests: `frontend/apps/web/src/components/graph/UICodeTracePanel.integration.tsx`
+
+---
+
+### FR-TRC-008 — MCP Auth / Config / DB Contract Tests
+
+**Title:** FastMCP server auth, config, and database tool functions verified by contract tests
+
+**Description:** The MCP tool layer (`tracertm.mcp.tools.auth_config_db`) shall be covered by contract tests verifying `auth_status`, `auth_logout`, `config_get`, `config_set`, `config_list`, `config_unset`, and `db_init` functions in isolation, using a lightweight stub for `tracertm.mcp.core` to avoid triggering the full MCP boot sequence during test collection.
+
+**Acceptance Criteria:**
+- All seven tool functions have at least one test assertion.
+- Core MCP bootstrap is fully stubbed (`@mcp.tool()` becomes a pass-through decorator).
+- Tests are importable and runnable in unit-test context (no network/DB required).
+- Tests are collected under `tests/mcp/test_auth_config_db.py`.
+
+**Traceability:**
+- PR: #466 (fix(mcp): implement auth/config/db contract tests, closes #232)
+- Source: `src/tracertm/mcp/tools/auth_config_db.py` (inferred), `src/tracertm/mcp/auth.py`
+- Tests: `tests/mcp/test_auth_config_db.py`
+
+---
+
+### FR-TRC-009 — Live Comment Submission in CommentsTab
+
+**Title:** CommentsTab UI component submits comments to the live backend API
+
+**Description:** The `CommentsTab` component shall POST new comments to the backend `item_comments` REST endpoint and optimistically update the UI on success. The `item_comments` table shall persist `item_id`, `author_id`, `author_name`, `content`, `edited`, `created_at`, and `updated_at`.
+
+**Acceptance Criteria:**
+- POST to `/api/items/{item_id}/comments` creates a persisted record.
+- Comment appears in the thread without a full page reload.
+- `item_comments` table created by alembic revision `063_add_item_comments`.
+- Author attribution uses the authenticated session's identity.
+
+**Traceability:**
+- PR: #469 (feat(comments): live comment submission in CommentsTab, closes #225)
+- Source: `frontend/apps/web/src/` (CommentsTab component), `src/tracertm/api/routers/comments.py`
+- Alembic: `063_add_item_comments.py`
+
+---
+
+### FR-TRC-010 — E2E Project Lifecycle Test Against Real Backend
+
+**Title:** End-to-end project lifecycle test exercises real FastAPI app via HTTPX ASGI transport
+
+**Description:** The E2E test suite shall include a `test_project_lifecycle_roundtrip` test that exercises a full create→list→item→update→link→delete→404 cycle against a real in-process FastAPI application wired to the test database engine via HTTPX ASGI transport (no mocks for business logic).
+
+**Acceptance Criteria:**
+- Test uses `test_db_engine` fixture with real SQLAlchemy repositories.
+- HTTP transport is HTTPX ASGI (real HTTP semantics, no mock client).
+- Auth guard is a fixed-identity stub (not real WorkOS).
+- All lifecycle steps assert correct HTTP status codes and response bodies.
+- Test is marked `@pytest.mark.integration @pytest.mark.slow`.
+- Passes in under 30 seconds on local hardware.
+
+**Traceability:**
+- PR: #470 (feat(e2e): real backend fixture in project lifecycle test, closes #230)
+- Source: `tests/e2e/test_project_lifecycle.py`
+
+---
+
+## Non-Functional Requirements
+
+### NFR-TRC-001 — Spatial Index Query Performance
+
+**Title:** Graph viewport queries execute in O(log n) via GIST index
+
+**Description:** Rectangular range queries over item positions (graph viewport panning/zooming) shall use the `idx_items_spatial` GIST index and must not degrade to sequential scans on datasets of 10,000+ items.
+
+**Evidence:**
+- GIST index created in `alembic/versions/054_add_spatial_gist_index.py`.
+- `WHERE deleted_at IS NULL` partial filter reduces index size by excluding soft-deleted items.
+- PR #464 description: "spatial index for edge midpoint distance queries".
+
+---
+
+### NFR-TRC-002 — Auth Contract Correctness (Fail-Safe Defaults)
+
+**Title:** Authentication layer has no silent failure modes; missing accounts produce explicit errors
+
+**Description:** Auth failures (missing account record, invalid token, revoked device code) shall produce deterministic HTTP error responses (401/403), never 500 errors or silent pass-throughs.
+
+**Evidence:**
+- `WORKOS_HANDLER_ERRORS` and `TOKEN_EXTRACTION_ERRORS` tuples in `auth.py` enumerate all swallowed exception types explicitly.
+- Contract tests in `tests/mcp/test_auth_config_db.py` verify auth tool behavior under error conditions.
+- Unit tests: `tests/unit/api/test_authentication.py`, `tests/unit/api/test_authorization_scenarios.py`.
+
+---
+
+### NFR-TRC-003 — E2E Tests Exercise Real Backend (No Mock Bypass)
+
+**Title:** Integration-marked E2E tests must use real repositories, not mock client stubs
+
+**Description:** Tests marked `@pytest.mark.integration` shall exercise the real SQLAlchemy repository layer and real HTTP semantics. MSW / mock-client patterns are acceptable only in frontend unit tests.
+
+**Evidence:**
+- `tests/e2e/test_project_lifecycle.py` uses HTTPX ASGI transport with `test_db_engine` (PR #470).
+- `tests/integration/storage/test_neo4j_trace_link_writer.py` uses testcontainers-neo4j for real Neo4j (PR #461).
+- `tests/integration/graph/test_cypher_impact_api.py` is marked `integration + slow` with live Neo4j requirement.
+
+---
+
+### NFR-TRC-004 — Neo4j Projection Idempotency
+
+**Title:** All Neo4j writes are idempotent (MERGE semantics)
+
+**Description:** The Neo4j trace-link writer shall use `MERGE` for all node and relationship creation, ensuring that replaying the ingestion pipeline does not create duplicate nodes or relationships.
+
+**Evidence:**
+- `write_requirement`, `write_artifact`, `write_link` in `tracertm.storage.neo4j_trace_link_writer` use `MERGE` (confirmed in `tests/integration/storage/test_neo4j_trace_link_writer.py`).
+- `apply_schema` uses `CREATE CONSTRAINT IF NOT EXISTS` and `CREATE INDEX IF NOT EXISTS`.
+
+---
+
+### NFR-TRC-005 — Confidence Column DB Integrity Constraint
+
+**Title:** links.confidence enforced at DB level; application-layer validation is redundant defence
+
+**Description:** The `confidence` column on the `links` table shall have a `CHECK (confidence >= 0.0 AND confidence <= 1.0)` constraint so out-of-range values are rejected even if application code is bypassed.
+
+**Evidence:**
+- Alembic: `ALTER TABLE links ADD CONSTRAINT links_confidence_range CHECK (...)` in `062_add_trace_link_fields.py`.
+- `LinkRepository.create()` also validates before INSERT (defence-in-depth).
+
+---
+
+### NFR-TRC-006 — MCP Server Boot Isolation in Unit Tests
+
+**Title:** MCP tool unit tests must not trigger the full FastMCP server boot sequence
+
+**Description:** Contract tests for MCP tool functions shall stub `tracertm.mcp.core` before any import of tool modules, ensuring test collection completes in under 5 seconds without network access.
+
+**Evidence:**
+- `_stub_mcp_core()` pattern in `tests/mcp/test_auth_config_db.py` inserts a `ModuleType` stub into `sys.modules` before tool module import.
+
+---
+
+### NFR-TRC-007 — Traceability Model Compliance (ISO 29148 / DO-178C Alignment)
+
+**Title:** TraceLinkType vocabulary is aligned with ISO 29148 §5.2.6 and DO-178C Table A-3
+
+**Description:** The canonical link-type vocabulary shall be documented with its ISO/DO-178C semantic mapping, enabling future compliance audits against aerospace and safety-critical standards.
+
+**Evidence:**
+- Docstring in `TraceLinkType` class (`src/tracertm/models/trace_link.py`) provides per-value ISO 29148 §5.2.6 + DO-178C Table A-3 mapping.
+- `ArtifactKind` docstring references ISO 29148 / DO-178C / IEC 62304 style traces.
+
+---
+
+## Gap Analysis / PLANNED Forward Requirements
+
+| ID | Title | Status | Notes |
+|----|-------|--------|-------|
+| FR-TRC-011 | RAG-layer traceability query (LLM-assisted link suggestion) | PLANNED | Referenced in `trace_link.py` docstring as "later PRs"; miner posterior = `confidence` field |
+| FR-TRC-012 | Automated duplicate / conflict detection via TraceLink miner | PLANNED | `DUPLICATES` and `CONFLICTS_WITH` link types defined but no miner service wired |
+| FR-TRC-013 | Bulk TraceLink ingestion from external sources (Jira, GitHub Issues) | PLANNED | `github_import_service.py`, `jira_import_service.py` exist but TraceLink confidence mapping TBD |
+| FR-TRC-014 | Traceability coverage matrix export (CSV/JSON/PDF) | PLANNED | `traceability_matrix_service.py` and `frontend/apps/web/e2e/traceability-matrix.spec.ts` exist; FR/NFR ingestion path not wired |
+| FR-TRC-015 | Graph-level impact blast-radius scoring (risk-weighted path analysis) | PLANNED | `impact_analysis_service.py`, `critical_path_service.py` exist; no confidence-weighted scoring yet |
+| FR-TRC-016 | AgilePlus integration — push Requirements / TraceLinks to AgilePlus project | PLANNED | Dog-food use case; AgilePlus at `C:/Users/koosh/Dev/AgilePlus`; API contract TBD |
+| FR-TRC-017 | Requirement quality scoring (completeness, ambiguity detection) | PARTIAL | `requirement_quality_service.py` and `requirement_quality_repository.py` exist; needs FR spec |
+| NFR-TRC-008 | Link confidence index selectivity target ≥ 90% for miner-generated links | PLANNED | Baseline TBD once miner ships |
+| NFR-TRC-009 | Neo4j projection sync latency < 500 ms p99 for single-link writes | PLANNED | No SLA defined yet |
+
+---
+
+## Requirement → PR Traceability Map (Summary)
+
+| Requirement | Shipped PRs | Key Tests |
+|-------------|-------------|-----------|
+| FR-TRC-001 | #458 | `test_neo4j_trace_link_writer.py` |
+| FR-TRC-002 | #460 | `test_link_repository*.py` |
+| FR-TRC-003 | #461 | `test_neo4j_trace_link_writer.py` |
+| FR-TRC-004 | #462 | `test_cypher_impact_api.py` |
+| FR-TRC-005 | #463 | `test_account_repository.py`, `test_authentication.py` |
+| FR-TRC-006 | #464 | alembic `054` |
+| FR-TRC-007 | #465 | `UICodeTracePanel.integration.tsx` |
+| FR-TRC-008 | #466 | `test_auth_config_db.py` |
+| FR-TRC-009 | #469 | alembic `063` |
+| FR-TRC-010 | #470 | `test_project_lifecycle.py` |
+| NFR-TRC-001..007 | #458–#470 | (see individual evidences above) |


### PR DESCRIPTION
## **User description**
## Summary

- Adds `requirement_id: Option<String>` to Epic and Story domain aggregates (additive, invariant-preserving)
- SQLite migration 021 adds the column + UNIQUE index via ALTER TABLE to both tables
- Implements idempotent upsert-by-requirement-id helpers in epic/story repos
- Seed module (`agileplus-sqlite::seed`) parses all four FR/NFR catalogs and creates 4 Epics + 72 Stories cross-referencing their Tracera requirement IDs
- `seed-requirements` CLI subcommand wires it all together; catalogs embedded at compile time

## Catalog breakdown

| Initiative | Entries |
|---|---|
| AgilePlus | 21 (14 FR + 7 NFR) |
| Tracera | 17 (10 FR + 7 NFR) |
| phenotype-voxel | 14 (9 FR + 5 NFR) |
| Authvault | 20 (11 FR + 9 NFR) |
| **Total** | **72 stories + 4 epics** |

Status mapping: `SHIPPED` → `Done`, everything else → `Todo`.

## Test plan

- [x] 79 unit tests green (`cargo test -p agileplus-domain -p agileplus-sqlite`)
- [x] `cargo check -p agileplus-domain -p agileplus-sqlite` clean
- [x] Idempotency verified by re-running seed in tests
- [x] requirement_id field set correctly on both Epic and Story (asserted in tests)
- [x] Invariants preserved: no empty titles, status mappings correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a schema migration and bulk upsert logic on core epic/story tables; manual upserts could race under concurrent writers, though the CLI path is typically single-threaded.
> 
> **Overview**
> Adds **Tracera traceability** by linking `Epic` and `Story` rows to external requirement IDs and seeding four FR/NFR markdown catalogs into SQLite as **4 epics + ~72 stories**.
> 
> **Domain & persistence:** Optional `requirement_id` on `Epic` and `Story`; migration **021** adds nullable columns plus partial **UNIQUE** indexes. Epic/story repositories persist the field, expose lookup by `requirement_id`, and add **get-then-insert/update upserts** (used instead of `ON CONFLICT` because the column was added via `ALTER TABLE`).
> 
> **Seed pipeline:** New `agileplus-sqlite::seed` parses catalog headings (`FR-*` / `NFR-*`), status cells, and gap sections; maps **SHIPPED → Done**, otherwise **Todo**; ensures projects by slug; upserts epics as `EPIC-<slug>` and one story per catalog entry. Unit tests cover parsing, status mapping, and idempotent re-runs.
> 
> **CLI:** `seed-requirements` opens the DB, runs migrations, embeds catalogs at compile time, and prints a summary (optional verbose per-story report). **Docs:** Large backfilled FR/NFR catalogs for Tracera, phenotype-voxel, and Authvault support ingestion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4689586fcb234f120cd36b4176918da106e8f504. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Ingest FR/NFR catalogs into Epics and Stories with Tracera requirement links**

### What Changed
- Epics and stories can now store an optional external requirement ID for traceability
- A new database migration adds requirement ID fields and keeps them unique when present
- Seeding the four FR/NFR catalogs now creates or updates the matching epics and stories instead of duplicating them
- Story and epic lookups can now be done by requirement ID, and the CLI exposes a new `seed-requirements` command with a verbose report

### Impact
`✅ Fewer duplicate epics and stories`
`✅ Faster requirement catalog ingestion`
`✅ Clearer Tracera traceability`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
