### PR TITLE
fix(dashboard): wire epics/stories from SQLite to React frontend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,6 +121,7 @@ dependencies = [
  "axum 0.8.9",
  "axum-extra",
  "chrono",
+ "rusqlite",
  "serde",
  "serde_json",
  "sysinfo",
@@ -309,6 +310,7 @@ version = "0.1.0"
 dependencies = [
  "agileplus-domain",
  "agileplus-events",
+ "anyhow",
  "async-trait",
  "chrono",
  "rusqlite",

--- a/crates/agileplus-dashboard/Cargo.toml
+++ b/crates/agileplus-dashboard/Cargo.toml
@@ -13,6 +13,7 @@ agileplus-domain = { path = "../agileplus-domain" }
 agileplus-events = { path = "../agileplus-events" }
 agileplus-sqlite = { path = "../agileplus-sqlite" }
 agileplus-fixtures = { path = "../agileplus-fixtures" }
+rusqlite = { version = "0.32", features = ["bundled"] }
 askama = "0.12"
 axum = { version = "0.8", features = ["json", "macros", "tokio"] }
 async-stream = "0.3"

--- a/crates/agileplus-dashboard/src/routes.rs
+++ b/crates/agileplus-dashboard/src/routes.rs
@@ -68,6 +68,17 @@ pub struct ServiceHealthJson {
     pub last_check: String,
 }
 
+/// JSON response for GET /api/dashboard/work-packages.json
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkPackageJson {
+    pub id: String,
+    pub feature_id: i64,
+    pub title: String,
+    pub status: String,
+    pub priority: String,
+    pub assignee: Option<String>,
+}
+
 /// JSON response for GET /api/dashboard/features/{id}/evidence
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EvidenceGalleryJson {
@@ -2170,6 +2181,119 @@ pub async fn test_plane_connection(axum::Form(form): axum::Form<PlaneSettingsFor
     }
 }
 
+// ── /api/dashboard/work-packages.json ────────────────────────────────────
+
+/// JSON API: GET /api/dashboard/work-packages.json
+/// Returns all work packages across all features as a flat JSON array.
+/// Used by the React dashboard at port 5176 to populate the work-package store.
+pub async fn all_work_packages_json(State(state): State<SharedState>) -> impl IntoResponse {
+    let store = state.read().await;
+    let work_packages: Vec<WorkPackageJson> = store
+        .work_packages
+        .iter()
+        .flat_map(|(feature_id, wps)| {
+            wps.iter().map(|wp| {
+                let status = match wp.state {
+                    agileplus_domain::domain::work_package::WpState::Planned => "planned",
+                    agileplus_domain::domain::work_package::WpState::Doing => "in_progress",
+                    agileplus_domain::domain::work_package::WpState::Review => "in_progress",
+                    agileplus_domain::domain::work_package::WpState::Done => "completed",
+                    agileplus_domain::domain::work_package::WpState::Blocked => "blocked",
+                };
+                WorkPackageJson {
+                    id: wp.id.to_string(),
+                    feature_id: *feature_id,
+                    title: wp.title.clone(),
+                    status: status.to_string(),
+                    priority: "medium".to_string(),
+                    assignee: wp.agent_id.clone(),
+                }
+            })
+        })
+        .collect();
+
+    axum::Json(serde_json::json!({
+        "work_packages": work_packages,
+        "count": work_packages.len(),
+        "timestamp": chrono::Utc::now().to_rfc3339(),
+    }))
+}
+
+// ── /api/dashboard/epics-stories.json ────────────────────────────────────
+
+/// JSON API: GET /api/dashboard/epics-stories.json
+/// Reads Epics + Stories directly from the SQLite database and returns them
+/// as a flat JSON payload. Used by the React dashboard at port 5176.
+pub async fn epics_stories_json() -> impl IntoResponse {
+    // Resolve db path: DATABASE_URL env → DATABASE_PATH env → default agileplus.db
+    let db_path: PathBuf = if let Ok(url) = std::env::var("DATABASE_URL") {
+        url.strip_prefix("sqlite:").unwrap_or(&url).into()
+    } else if let Ok(p) = std::env::var("DATABASE_PATH") {
+        PathBuf::from(p)
+    } else {
+        PathBuf::from("agileplus.db")
+    };
+
+    let conn = match rusqlite::Connection::open(&db_path) {
+        Ok(c) => c,
+        Err(e) => {
+            return axum::Json(serde_json::json!({
+                "epics": [],
+                "stories": [],
+                "epic_count": 0,
+                "story_count": 0,
+                "error": format!("db open failed: {e}"),
+            }));
+        }
+    };
+
+    // Query epics
+    let epics: Vec<serde_json::Value> = {
+        let mut stmt = conn
+            .prepare("SELECT id, title, status, requirement_id FROM epics ORDER BY id")
+            .unwrap_or_else(|_| conn.prepare("SELECT 1 WHERE 0").unwrap());
+        stmt.query_map([], |row| {
+            Ok(serde_json::json!({
+                "id": row.get::<_, i64>(0).unwrap_or(0),
+                "title": row.get::<_, String>(1).unwrap_or_default(),
+                "status": row.get::<_, String>(2).unwrap_or_default(),
+                "requirement_id": row.get::<_, Option<String>>(3).unwrap_or(None),
+            }))
+        })
+        .map(|rows| rows.filter_map(|r| r.ok()).collect())
+        .unwrap_or_default()
+    };
+
+    // Query stories
+    let stories: Vec<serde_json::Value> = {
+        let mut stmt = conn
+            .prepare("SELECT id, epic_id, title, status, requirement_id FROM stories ORDER BY id")
+            .unwrap_or_else(|_| conn.prepare("SELECT 1 WHERE 0").unwrap());
+        stmt.query_map([], |row| {
+            Ok(serde_json::json!({
+                "id": row.get::<_, i64>(0).unwrap_or(0),
+                "epic_id": row.get::<_, Option<i64>>(1).unwrap_or(None),
+                "title": row.get::<_, String>(2).unwrap_or_default(),
+                "status": row.get::<_, String>(3).unwrap_or_default(),
+                "requirement_id": row.get::<_, Option<String>>(4).unwrap_or(None),
+            }))
+        })
+        .map(|rows| rows.filter_map(|r| r.ok()).collect())
+        .unwrap_or_default()
+    };
+
+    let epic_count = epics.len();
+    let story_count = stories.len();
+
+    axum::Json(serde_json::json!({
+        "epics": epics,
+        "stories": stories,
+        "epic_count": epic_count,
+        "story_count": story_count,
+        "timestamp": chrono::Utc::now().to_rfc3339(),
+    }))
+}
+
 pub fn router(state: SharedState) -> Router {
     Router::new()
         .route("/", get(root))
@@ -2221,6 +2345,8 @@ pub fn router(state: SharedState) -> Router {
         // JSON API endpoints (for polling from JavaScript templates)
         .route("/api/dashboard/agents.json", get(agents_json))
         .route("/api/dashboard/health.json", get(health_json))
+        .route("/api/dashboard/work-packages.json", get(all_work_packages_json))
+        .route("/api/dashboard/epics-stories.json", get(epics_stories_json))
         .route("/api/dashboard/projects", get(project_switcher))
         .route(
             "/api/dashboard/projects/{id}/activate",

--- a/crates/agileplus-dashboard/web/src/main.tsx
+++ b/crates/agileplus-dashboard/web/src/main.tsx
@@ -1,11 +1,72 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import ReactDOM from 'react-dom/client';
+import axios from 'axios';
 import { useAgilePlusStore } from './stores/agileplus';
 import './styles/globals.css';
+
+interface Epic {
+  id: number;
+  title: string;
+  status: string;
+  requirement_id: string | null;
+}
+
+interface Story {
+  id: number;
+  epic_id: number | null;
+  title: string;
+  status: string;
+  requirement_id: string | null;
+}
 
 function App() {
   const workPackages = useAgilePlusStore((state) => state.workPackages);
   const loading = useAgilePlusStore((state) => state.loading);
+  const setWorkPackages = useAgilePlusStore((state) => state.setWorkPackages);
+  const setLoading = useAgilePlusStore((state) => state.setLoading);
+
+  const [epics, setEpics] = useState<Epic[]>([]);
+  const [stories, setStories] = useState<Story[]>([]);
+  const [epicStoriesLoading, setEpicStoriesLoading] = useState(true);
+
+  // Fetch work packages (in-memory store)
+  useEffect(() => {
+    setLoading(true);
+    axios
+      .get('/api/dashboard/work-packages.json')
+      .then((res) => {
+        const data = res.data as { work_packages: any[] };
+        setWorkPackages(
+          (data.work_packages ?? []).map((wp: any) => ({
+            id: String(wp.id),
+            title: wp.title ?? '(untitled)',
+            status: wp.status ?? 'planned',
+            priority: wp.priority ?? 'medium',
+            assignee: wp.assignee ?? undefined,
+          }))
+        );
+      })
+      .catch(() => {
+        // backend not available — store stays empty
+      })
+      .finally(() => setLoading(false));
+  }, [setWorkPackages, setLoading]);
+
+  // Fetch epics + stories from SQLite
+  useEffect(() => {
+    setEpicStoriesLoading(true);
+    axios
+      .get('/api/dashboard/epics-stories.json')
+      .then((res) => {
+        const data = res.data as { epics: Epic[]; stories: Story[] };
+        setEpics(data.epics ?? []);
+        setStories(data.stories ?? []);
+      })
+      .catch(() => {
+        // backend not available
+      })
+      .finally(() => setEpicStoriesLoading(false));
+  }, []);
 
   return (
     <main className="container" style={{ padding: '2rem 0' }}>
@@ -16,16 +77,75 @@ function App() {
           padding: '2rem',
           boxShadow: 'var(--shadow-md)',
           border: '1px solid rgba(17, 24, 39, 0.08)',
+          marginBottom: '1.5rem',
         }}
       >
         <p style={{ margin: 0, color: 'var(--color-neutral-500)' }}>AgilePlus</p>
         <h1 style={{ marginTop: '0.25rem' }}>Dashboard</h1>
         <p>
-          {loading
-            ? 'Loading work packages...'
-            : `Work packages loaded: ${workPackages.length}`}
+          {epicStoriesLoading
+            ? 'Loading epics & stories...'
+            : `${epics.length} Epic${epics.length !== 1 ? 's' : ''} · ${stories.length} ${stories.length !== 1 ? 'Stories' : 'Story'}`}
         </p>
       </section>
+
+      {!epicStoriesLoading && epics.length > 0 && (
+        <section
+          style={{
+            background: 'white',
+            borderRadius: 'var(--border-radius-lg)',
+            padding: '2rem',
+            boxShadow: 'var(--shadow-md)',
+            border: '1px solid rgba(17, 24, 39, 0.08)',
+          }}
+        >
+          <h2 style={{ marginTop: 0 }}>Epics &amp; Stories</h2>
+          {epics.map((epic) => {
+            const epicStories = stories.filter((s) => s.epic_id === epic.id);
+            return (
+              <details key={epic.id} style={{ marginBottom: '1rem' }}>
+                <summary
+                  style={{
+                    cursor: 'pointer',
+                    fontWeight: 600,
+                    fontSize: '1rem',
+                    padding: '0.5rem 0',
+                    borderBottom: '1px solid rgba(17,24,39,0.08)',
+                  }}
+                >
+                  {epic.title}
+                  <span
+                    style={{
+                      marginLeft: '0.75rem',
+                      fontSize: '0.8rem',
+                      color: 'var(--color-neutral-500)',
+                      fontWeight: 400,
+                    }}
+                  >
+                    {epicStories.length} stories · {epic.status}
+                  </span>
+                </summary>
+                <ul style={{ marginTop: '0.5rem', paddingLeft: '1.5rem' }}>
+                  {epicStories.map((story) => (
+                    <li key={story.id} style={{ marginBottom: '0.25rem', fontSize: '0.9rem' }}>
+                      <span style={{ color: 'var(--color-neutral-700)' }}>{story.title}</span>
+                      <span
+                        style={{
+                          marginLeft: '0.5rem',
+                          fontSize: '0.75rem',
+                          color: story.status === 'Done' ? 'green' : 'var(--color-neutral-400)',
+                        }}
+                      >
+                        [{story.status}]
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              </details>
+            );
+          })}
+        </section>
+      )}
     </main>
   );
 }

--- a/crates/agileplus-dashboard/web/vite.config.js
+++ b/crates/agileplus-dashboard/web/vite.config.js
@@ -15,7 +15,7 @@ export default defineConfig({
         port: 5173,
         proxy: {
             '/api': {
-                target: 'http://localhost:3000',
+                target: 'http://127.0.0.1:4000',
                 changeOrigin: true,
             },
         },

--- a/crates/agileplus-dashboard/web/vite.config.ts
+++ b/crates/agileplus-dashboard/web/vite.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
     port: 5173,
     proxy: {
       '/api': {
-        target: 'http://localhost:3000',
+        target: 'http://127.0.0.1:4000',
         changeOrigin: true,
       },
     },

--- a/crates/agileplus-sqlite/Cargo.toml
+++ b/crates/agileplus-sqlite/Cargo.toml
@@ -13,6 +13,7 @@ serde.workspace = true
 serde_json.workspace = true
 chrono.workspace = true
 async-trait = "0.1"
+anyhow = "1"
 tokio = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/crates/agileplus-sqlite/src/bin/seed_db.rs
+++ b/crates/agileplus-sqlite/src/bin/seed_db.rs
@@ -1,0 +1,68 @@
+//! Standalone seed binary: apply migrations + seed 4 Epics + N Stories from
+//! the embedded FR/NFR catalogs into the target SQLite database.
+//!
+//! Usage:  cargo run -p agileplus-sqlite --bin seed_db -- [path/to/agileplus.db]
+//! Default db path: agileplus.db  (relative to CWD)
+
+use std::path::PathBuf;
+
+use agileplus_sqlite::{
+    migrations::MigrationRunner,
+    seed::{Initiative, seed_requirements},
+};
+
+const AGILEPLUS_CATALOG: &str = include_str!("../../../../docs/requirements/agileplus-frnfr.md");
+const TRACERA_CATALOG: &str = include_str!("../../../../docs/requirements/tracera-frnfr.md");
+const PHENOTYPE_VOXEL_CATALOG: &str =
+    include_str!("../../../../docs/requirements/phenotype-voxel-frnfr.md");
+const AUTHVAULT_CATALOG: &str =
+    include_str!("../../../../docs/requirements/authvault-frnfr.md");
+
+fn main() -> anyhow::Result<()> {
+    let db_path: PathBuf = std::env::args()
+        .nth(1)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("agileplus.db"));
+
+    println!("Seeding database at: {}", db_path.display());
+
+    let conn = rusqlite::Connection::open(&db_path)?;
+    conn.execute_batch("PRAGMA foreign_keys=ON;")?;
+
+    let runner = MigrationRunner::new(&conn);
+    runner.run_all().map_err(|e| anyhow::anyhow!("migration failed: {e}"))?;
+    println!("Migrations applied.");
+
+    let initiatives = vec![
+        Initiative {
+            slug: "agileplus",
+            title: "AgilePlus",
+            catalog_markdown: AGILEPLUS_CATALOG,
+        },
+        Initiative {
+            slug: "tracera",
+            title: "Tracera",
+            catalog_markdown: TRACERA_CATALOG,
+        },
+        Initiative {
+            slug: "phenotype-voxel",
+            title: "phenotype-voxel",
+            catalog_markdown: PHENOTYPE_VOXEL_CATALOG,
+        },
+        Initiative {
+            slug: "authvault",
+            title: "Authvault",
+            catalog_markdown: AUTHVAULT_CATALOG,
+        },
+    ];
+
+    let report = seed_requirements(&conn, &initiatives)
+        .map_err(|e| anyhow::anyhow!("seed failed: {e}"))?;
+
+    println!(
+        "Done: {} epic(s), {} story/stories across {} initiative(s).",
+        report.epics_upserted, report.stories_upserted, report.initiatives.len()
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## **User description**
## Summary
- Adds `/api/dashboard/epics-stories.json` endpoint to the dashboard Rust server reading directly from `agileplus.db` via rusqlite
- Adds `/api/dashboard/work-packages.json` endpoint reading from in-memory store
- Updates Vite proxy target from `localhost:3000` to `127.0.0.1:4000` (the dashboard server)
- Updates `main.tsx` to fetch and render 4 Epics + 72 Stories from the seeded SQLite DB
- Adds `seed_db` binary to `agileplus-sqlite` for standalone schema-migration + seed runs (used to populate `agileplus.db`)

## Test plan
- [ ] `cargo run -p agileplus-sqlite --bin seed_db -- agileplus.db` seeds 4 epics / 72 stories
- [ ] `sqlite3 agileplus.db "SELECT COUNT(*) FROM stories"` returns 72
- [ ] `curl http://127.0.0.1:4000/api/dashboard/epics-stories.json` returns epic_count:4, story_count:72
- [ ] Refresh http://localhost:5176 → dashboard shows "4 Epics · 72 Stories" with collapsible epic cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only dashboard JSON and local SQLite access; no auth or write paths. Misconfigured DB path only yields empty data or an error field in the response.
> 
> **Overview**
> Connects the React dashboard to the Rust server with **two JSON APIs** and UI that loads epics/stories from SQLite.
> 
> The dashboard server adds **`GET /api/dashboard/work-packages.json`** (flat list from the in-memory store, with domain state mapped to string statuses) and **`GET /api/dashboard/epics-stories.json`** (opens `agileplus.db` via `DATABASE_URL` / `DATABASE_PATH`, queries `epics` and `stories`, returns counts and timestamps or an empty payload with an error on open failure). **`rusqlite`** is added on the dashboard crate for the SQLite path.
> 
> The Vite dev proxy for `/api` now targets **`http://127.0.0.1:4000`** instead of port 3000. **`main.tsx`** fetches both endpoints on mount, hydrates the Zustand work-package store, and renders a collapsible **Epics & Stories** section with epic/story counts in the header.
> 
> **`agileplus-sqlite`** gains a **`seed_db`** binary (migrations + requirement catalogs for four initiatives) and an **`anyhow`** dependency to support standalone DB seeding used by the test plan.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c921c059766d0ac38b17b6efbee7ca6ee73f686. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Load the dashboard from the local SQLite data and show epics and stories**

### What Changed
- The dashboard now loads epics and stories from the local database and shows them as expandable epic sections with their stories underneath
- The summary now displays the number of epics and stories instead of only showing work package loading status
- The dashboard also fetches work packages from the server and maps their status into the UI
- The local dev proxy now points API calls to the dashboard server, and a seed command is available to populate the SQLite database before viewing the dashboard

### Impact
`✅ Dashboard shows seeded epics and stories`
`✅ Local dashboard works with the new backend port`
`✅ Easier local database setup before testing`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
