### PR TITLE
chore: extend seed-requirements to 6 catalogs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,6 +312,7 @@ version = "0.1.0"
 dependencies = [
  "agileplus-domain",
  "agileplus-events",
+ "anyhow",
  "async-trait",
  "chrono",
  "rusqlite",

--- a/crates/agileplus-sqlite/Cargo.toml
+++ b/crates/agileplus-sqlite/Cargo.toml
@@ -14,6 +14,7 @@ serde_json.workspace = true
 chrono.workspace = true
 async-trait = "0.1"
 tokio = { workspace = true, optional = true }
+anyhow = "1"
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }

--- a/crates/agileplus-sqlite/src/bin/seed_requirements.rs
+++ b/crates/agileplus-sqlite/src/bin/seed_requirements.rs
@@ -1,19 +1,14 @@
-//! `seed-requirements` CLI subcommand.
+//! Standalone seed-requirements binary for the agileplus-sqlite crate.
 //!
-//! Ingests the six FR/NFR catalogs (AgilePlus, Tracera, phenotype-voxel, Authvault,
-//! PhenoMCP, PhenoObservability) as Epics + Stories into an AgilePlus SQLite database,
-//! each cross-referencing its Tracera Requirement ID.  Idempotent — safe to run multiple times.
+//! Ingests all 6 FR/NFR catalogs (AgilePlus, Tracera, phenotype-voxel, Authvault,
+//! PhenoMCP, PhenoObservability) into the target SQLite database.
+//! Idempotent — safe to run multiple times (upsert by requirement_id).
+//!
+//! Usage:
+//!   cargo run -p agileplus-sqlite --bin seed_requirements -- --db agileplus.db
 
 use std::path::PathBuf;
 
-use clap::Args;
-
-use agileplus_sqlite::seed::{Initiative, seed_requirements};
-
-/// Embedded catalog markdown files — bundled at compile time.
-/// Paths are relative to this source file:
-///   crates/agileplus-cli/src/commands/seed_requirements.rs
-///   → up 4 dirs → workspace root → docs/requirements/
 const AGILEPLUS_CATALOG: &str = include_str!(
     "../../../../docs/requirements/agileplus-frnfr.md"
 );
@@ -33,23 +28,30 @@ const PHENOOBSERVABILITY_CATALOG: &str = include_str!(
     "../../../../docs/requirements/phenoobservability-frnfr.md"
 );
 
-/// Arguments for the `seed-requirements` subcommand.
-#[derive(Args, Debug)]
-pub struct SeedRequirementsArgs {
-    /// Path to the SQLite database file. Defaults to `./agileplus.db`.
-    #[arg(long, default_value = "agileplus.db")]
-    pub db: PathBuf,
+fn main() -> anyhow::Result<()> {
+    // Simple arg parse: --db <path>
+    let args: Vec<String> = std::env::args().collect();
+    let db_path: PathBuf = {
+        let mut p = PathBuf::from("agileplus.db");
+        let mut i = 1;
+        while i < args.len() {
+            if args[i] == "--db" && i + 1 < args.len() {
+                p = PathBuf::from(&args[i + 1]);
+                break;
+            }
+            i += 1;
+        }
+        p
+    };
 
-    /// Print a detailed per-story report.
-    #[arg(long)]
-    pub verbose: bool,
-}
-
-pub fn run(args: &SeedRequirementsArgs) -> anyhow::Result<()> {
-    let conn = rusqlite::Connection::open(&args.db)?;
+    println!("Opening database: {}", db_path.display());
+    let conn = rusqlite::Connection::open(&db_path)?;
     conn.execute_batch("PRAGMA foreign_keys=ON;")?;
+
     let runner = agileplus_sqlite::migrations::MigrationRunner::new(&conn);
     runner.run_all().map_err(|e| anyhow::anyhow!("{e}"))?;
+
+    use agileplus_sqlite::seed::{Initiative, seed_requirements};
 
     let initiatives = vec![
         Initiative {
@@ -94,16 +96,19 @@ pub fn run(args: &SeedRequirementsArgs) -> anyhow::Result<()> {
         report.initiatives.len()
     );
 
-    if args.verbose {
-        for init in &report.initiatives {
-            println!("\n  Epic [{}] id={}", init.epic_requirement_id, init.epic_id);
-            for s in &init.stories {
-                println!(
-                    "    Story [{}] id={} status={:?}",
-                    s.requirement_id, s.story_id, s.status
-                );
-            }
-        }
+    for init in &report.initiatives {
+        let done_count = init.stories.iter().filter(|s| {
+            matches!(s.status, agileplus_domain::domain::story::StoryStatus::Done)
+        }).count();
+        let todo_count = init.stories.len() - done_count;
+        println!(
+            "  [{}] epic_id={} stories={} (Done={} Todo={})",
+            init.initiative_slug,
+            init.epic_id,
+            init.stories.len(),
+            done_count,
+            todo_count,
+        );
     }
 
     Ok(())

--- a/docs/requirements/phenomcp-frnfr.md
+++ b/docs/requirements/phenomcp-frnfr.md
@@ -1,0 +1,396 @@
+# PhenoMCP — Functional & Non-Functional Requirements
+
+**Scope:** Backfilled catalog for Tracera + AgilePlus ingestion.
+**Schema version:** 1.
+**Test baseline:** 204 Python tests + 19 Rust tests = 223 total passing (2026-05-29).
+**ID namespace:** FR-MCP-NNN / NFR-MCP-NNN.
+
+---
+
+## Functional Requirements
+
+### FR-MCP-001 — pheno_mcp Python Package
+
+**Title:** `pheno_mcp` installable Python package exposing Server, Tool, Resource, Prompt, Client.
+
+**Description:** The `pheno_mcp` package (under `python/src/pheno_mcp/`) is the primary
+FastMCP-convention Python surface for PhenoMCP. It provides `Server`, `ServerConfig`,
+`Tool`, `Resource`, `Prompt`, and `Client` as first-class public symbols re-exported from
+`python/src/pheno_mcp/__init__.py`. The package is managed by `uv`/`pyproject.toml` with
+`py.typed` marker for static-analysis compatibility.
+
+**Acceptance criteria:**
+- `from pheno_mcp import Server, Tool, Resource, Prompt, Client` succeeds after `uv sync`.
+- `pyproject.toml` declares the package and its entry points; `uv.lock` is committed.
+- `py.typed` is present and `mypy` resolves types without `--ignore-missing-imports`.
+- CI (`ubuntu-24.04`, SHA-pinned) runs `uv run pytest` and all tests pass.
+
+**Traceability:**
+- PR #76 (pheno_mcp Python package + workflow hygiene ubuntu-24.04 + SHA pins)
+- Tests: `python/tests/test_init.py`
+
+---
+
+### FR-MCP-002 — MCP Server Registration (Tools / Resources / Prompts)
+
+**Title:** `Server` registers and lists Tools, Resources, and Prompts by unique key.
+
+**Description:** `Server` maintains three in-memory registries keyed by `tool.name`,
+`resource.uri`, and `prompt.name`. Registration is idempotent — re-registering the same
+key overwrites the existing entry. `list_tools()`, `list_resources()`, `list_prompts()`
+return serialised dicts suitable for a JSON-RPC `tools/list` response. Each object's
+`to_dict()` maps to the MCP wire format (`inputSchema`, `mimeType`, etc.).
+
+**Acceptance criteria:**
+- `register_tool(t)` followed by `list_tools()` returns exactly one entry with matching name.
+- Re-registering the same key replaces the prior entry (no duplicates).
+- `list_resources()` / `list_prompts()` follow the same contract.
+- All three `to_dict()` methods serialise correctly to expected MCP field names.
+
+**Traceability:**
+- PR #76, PR #78 (registration wiring)
+- Tests: `python/tests/test_server.py`, `python/tests/test_server_comprehensive.py`
+
+---
+
+### FR-MCP-003 — JSON-RPC Request Dispatch (tools/list, resources/list, prompts/list, tools/call)
+
+**Title:** `Server.handle_request` dispatches MCP JSON-RPC method names to correct handlers.
+
+**Description:** `handle_request(method, params)` is the single async entry point for all
+MCP wire requests. It routes `tools/list`, `resources/list`, `prompts/list`, and
+`tools/call` to the appropriate internal handler. Unknown methods return a
+`-32601 Method not found` error object. Both sync and async tool handlers are supported
+via `inspect.iscoroutinefunction`.
+
+**Acceptance criteria:**
+- `handle_request("tools/list", {})` returns `{"tools": [...]}`.
+- `handle_request("resources/list", {})` returns `{"resources": [...]}`.
+- `handle_request("prompts/list", {})` returns `{"prompts": [...]}`.
+- `handle_request("tools/call", {"name": "x", "arguments": {}})` invokes the registered handler.
+- `handle_request("unknown/method", {})` returns `{"jsonrpc": "2.0", "error": {"code": -32601, ...}}`.
+- Both sync and async handlers execute correctly.
+
+**Traceability:**
+- PR #76, PR #80 (request validation hardening)
+- Tests: `python/tests/test_server.py`, `python/tests/test_server_comprehensive.py`, `python/tests/test_integration.py`
+
+---
+
+### FR-MCP-004 — Request Validation + Structured JSON-RPC Errors
+
+**Title:** Invalid requests return structured JSON-RPC error objects; the server never raises.
+
+**Description:** `handle_request` validates that `method` is a non-empty string (`-32600`)
+and that `params` is a dict or `None` (`-32600`). `_handle_tools_call` validates that
+`name` is a non-empty string (`-32602`) and that `arguments` is a dict (`-32602`). An
+unknown tool name returns `-32601`. Unhandled exceptions inside a handler are caught and
+return `-32603 Internal error` (defensive guard). Every error response carries the
+canonical `{"jsonrpc": "2.0", "error": {"code": N, "message": "...", "data": {...}}, "id": null}` shape.
+
+**Acceptance criteria:**
+- `handle_request(None, {})` → code `-32600`.
+- `handle_request("tools/call", {"name": "", "arguments": {}})` → code `-32602`.
+- `handle_request("tools/call", {"name": "x", "arguments": "bad"})` → code `-32602`.
+- `handle_request("tools/call", {"name": "missing"})` → code `-32601`.
+- Error response always has `jsonrpc`, `error.code`, `error.message`, and `id` fields.
+- A tool handler that raises still returns an error dict (no exception propagated to caller).
+
+**Traceability:**
+- PR #80 (`[codex] harden MCP request validation`)
+- Tests: `python/tests/test_server_comprehensive.py`, `python/tests/test_server.py`
+
+---
+
+### FR-MCP-005 — Governance Tool Bundle (ledger_query + ledger_verify)
+
+**Title:** `governance_tools` bundle exposes `ledger_query` and `ledger_verify` MCP tools backed by Parpoura API.
+
+**Description:** `python/src/pheno_mcp/tools/governance_tools.py` defines two tools:
+`ledger_query` (GET `/api/v1/governance/ledger` with optional filters `from_entry`,
+`to_entry`, `action`, `actor`, `workflow_id`, `limit`) and `ledger_verify`
+(POST `/api/v1/governance/ledger/verify` with required `from_entry`/`to_entry`).
+The Parpoura base URL is read from `PARPOURA_BASE_URL` env var (default `http://localhost:8001`).
+HTTP errors are caught and returned as `{"error": ..., "status_code": ...}` — not raised.
+`register_governance_tools(server)` wires both tools onto any `Server` instance.
+
+**Acceptance criteria:**
+- `ledger_query` input schema has zero required fields; all six filter fields are optional.
+- `ledger_verify` input schema requires exactly `from_entry` and `to_entry`.
+- `handle_ledger_query` issues `GET /api/v1/governance/ledger` and returns parsed JSON.
+- `handle_ledger_verify` issues `POST /api/v1/governance/ledger/verify` and returns parsed JSON.
+- HTTP 4xx/5xx errors return `{"error": ..., "status_code": N}` not an exception.
+- `register_governance_tools(server)` makes both tools visible in `server.list_tools()`.
+
+**Traceability:**
+- PR #77 (wire ledger_query governance tool end-to-end)
+- Tests: `python/tests/test_governance_tools.py`
+
+---
+
+### FR-MCP-006 — Session Tool Bundle (session_suspend + session_resume)
+
+**Title:** `session_tools` bundle exposes `session_suspend` and `session_resume` MCP tools backed by Parpoura API.
+
+**Description:** `python/src/pheno_mcp/tools/session_tools.py` defines:
+`session_suspend` (POST `/api/v1/sessions/{session_id}/suspend` → `bundle_ref`) and
+`session_resume` (POST `/api/v1/sessions/resume` with `bundle_ref` body → new `session_id`).
+Both read `PARPOURA_BASE_URL`. HTTP errors are caught and returned as
+`{"error": ..., "status_code": ...}`.
+
+**Acceptance criteria:**
+- `session_suspend` requires exactly `session_id`.
+- `session_resume` requires exactly `bundle_ref`.
+- `handle_session_suspend` issues `POST /api/v1/sessions/{session_id}/suspend`.
+- `handle_session_resume` issues `POST /api/v1/sessions/resume` with `{"bundle_ref": ...}` body.
+- HTTP errors returned as dict, not raised.
+- `register_session_tools(server)` makes both tools visible in `server.list_tools()`.
+
+**Traceability:**
+- PR #78 (wire all tool bundles + `create_configured_server`)
+- Tests: `python/tests/test_session_tools.py`
+
+---
+
+### FR-MCP-007 — Workflow Tool Bundle (workflow_execute / status / cancel / list)
+
+**Title:** `workflow_tools` bundle exposes four workflow-lifecycle MCP tools backed by Parpoura API.
+
+**Description:** `python/src/pheno_mcp/tools/workflow_tools.py` defines four tools:
+`workflow_execute` (POST `/workflows/{id}/execute`),
+`workflow_status` (GET `/workflows/{id}`),
+`workflow_cancel` (POST `/workflows/{id}/cancel`),
+`workflow_list` (GET `/workflows`).
+`workflow_execute` accepts optional `workflow_type` (default `"default"`).
+`workflow_status` reports lifecycle states `PENDING | RUNNING | SUSPENDED | COMPLETED | FAILED | CANCELLED`.
+HTTP errors are caught and returned as `{"error": ..., "status_code": ...}`.
+
+**Acceptance criteria:**
+- `workflow_execute` requires `workflow_id`; `workflow_type` is optional.
+- `workflow_status` and `workflow_cancel` each require exactly `workflow_id`.
+- `workflow_list` requires no arguments.
+- Each handler issues the correct HTTP verb + path to `PARPOURA_BASE_URL`.
+- HTTP errors returned as dict, not raised.
+- `register_workflow_tools(server)` makes all four tools visible in `server.list_tools()`.
+
+**Traceability:**
+- PR #78
+- Tests: `python/tests/test_workflow_tools.py`
+
+---
+
+### FR-MCP-008 — `create_configured_server` Factory
+
+**Title:** `create_configured_server(config?)` returns a fully-wired `Server` with all 8 tools pre-registered.
+
+**Description:** `server.py::create_configured_server` is a zero-boilerplate factory that
+instantiates a `Server` and calls `register_governance_tools`, `register_session_tools`,
+and `register_workflow_tools` in sequence. This gives callers a ready-to-use server with
+all 8 tools (`ledger_query`, `ledger_verify`, `session_suspend`, `session_resume`,
+`workflow_execute`, `workflow_status`, `workflow_cancel`, `workflow_list`) without
+importing individual bundle modules.
+
+**Acceptance criteria:**
+- `create_configured_server()` returns a `Server` with exactly 8 tools registered.
+- `create_configured_server(ServerConfig(name="test"))` propagates the config to the server.
+- Returned server handles `tools/list` and returns all 8 tool names.
+- No exception raised on construction with default config.
+
+**Traceability:**
+- PR #78 (`feat(tools): wire all tool bundles + create_configured_server factory`)
+- Tests: `python/tests/test_configured_server.py`
+
+---
+
+### FR-MCP-009 — SearchPort Hexagonal Port Trait (Rust)
+
+**Title:** Object-safe `SearchPort` trait with `ensure_index / index_documents / search / delete_document`.
+
+**Description:** `crates/pheno-ports/src/lib.rs` defines `SearchPort` as an async
+object-safe Rust trait (`Box<dyn SearchPort>` compiles). Methods: `ensure_index(index, pk)`,
+`index_documents(index, docs)`, `search(index, query) -> SearchResults`,
+`delete_document(index, id)`. Domain types `SearchDocument` (id + flattened fields) and
+`SearchResults` (hits, estimated_total_hits, processing_time_ms, query) are serde-serialisable.
+`SearchPortError` variants: `Index`, `Search`, `Delete`, `Transport`.
+
+**Acceptance criteria:**
+- `Box<dyn SearchPort>` compiles (object-safety smoke test passes).
+- `InMemorySearchStore` in `doubles` module fully implements the trait.
+- `ensure_index` is idempotent — calling twice on the same index name succeeds.
+- `index_documents` stores all documents; subsequent `search` finds them by substring.
+- `delete_document` removes the document; subsequent search finds nothing.
+- `SearchResults.estimated_total_hits` matches the actual hit count.
+
+**Traceability:**
+- PR #81 (`feat: hexagonal port traits — SearchPort + SkillStoragePort (audit #4)`)
+- Tests: `crates/pheno-ports/src/doubles.rs` (test series `search_double_*`)
+
+---
+
+### FR-MCP-010 — SkillStoragePort Hexagonal Port Trait (Rust)
+
+**Title:** Object-safe `SkillStoragePort` trait with `put / get / list / delete` for `SkillEntry` records.
+
+**Description:** `crates/pheno-ports/src/lib.rs` defines `SkillStoragePort` as an async
+object-safe trait. `SkillEntry` fields: `id`, `name`, `version`, `code`, `runtime`,
+`metadata (serde_json::Value)`. Methods: `put(entry) -> SkillEntry`, `get(id) -> SkillEntry`,
+`list() -> Vec<SkillEntry>`, `delete(id)`. `StoragePortError` variants: `NotFound`,
+`Serialise`, `Backend`.
+
+**Acceptance criteria:**
+- `Box<dyn SkillStoragePort>` compiles (object-safety smoke test passes).
+- `InMemorySkillStore` in `doubles` module fully implements the trait.
+- `put` then `get` returns bit-identical entry.
+- `put` on an existing id replaces the entry (upsert semantics).
+- `get` on a missing id returns `StoragePortError::NotFound`.
+- `list` returns all previously `put` entries.
+- `delete` removes the entry; subsequent `get` returns `NotFound`.
+
+**Traceability:**
+- PR #81
+- Tests: `crates/pheno-ports/src/doubles.rs` (test series `skill_store_*`),
+  `crates/phenotype-surrealdb/src/lib.rs` (test series `test_port_*`, `test_pheno_surreal_*`)
+
+---
+
+### FR-MCP-011 — phenotype-surrealdb SkillStoragePort Adapter (Stub)
+
+**Title:** `PhenoSurreal` implements `SkillStoragePort` via in-memory delegation pending real SurrealDB wiring.
+
+**Description:** `crates/phenotype-surrealdb/src/lib.rs` provides `PhenoSurreal::new(path)`
+which implements `SkillStoragePort` by delegating to `InMemorySkillStore`. The `path`
+parameter is accepted for forward-compatibility but not yet used. Legacy helpers
+`store_skill`, `query_skills`, and `store_embedding` are preserved for callers that
+pre-date the port trait. A `TODO(surreal)` comment marks the delegation site for the
+real SurrealDB driver swap.
+
+**Acceptance criteria:**
+- `PhenoSurreal::new(path).await` succeeds without a running SurrealDB instance.
+- `Box<dyn SkillStoragePort> = Box::new(PhenoSurreal::new(...).await.unwrap())` compiles.
+- Legacy `store_skill` round-trips correctly via `store_skill` → `query_skills`.
+- `SkillStoragePort::put/get/list/delete` all work correctly via in-memory delegation.
+- `store_embedding` returns an `EmbeddingRecord` with a prefixed id (stub).
+
+**Traceability:**
+- PR #81 (SurrealDB stub introduced alongside port traits)
+- Tests: `crates/phenotype-surrealdb/src/lib.rs` (all `#[tokio::test]` functions)
+
+---
+
+## Non-Functional Requirements
+
+### NFR-MCP-001 — Object-Safe Port Traits
+
+**Title:** All hexagonal port traits in `pheno-ports` must be usable as `Box<dyn Trait>`.
+
+**Description:** Rust's object-safety rules require that async methods use `async_trait`
+macro and that no associated-type ambiguity exists. Both `SearchPort` and `SkillStoragePort`
+carry the `#[async_trait]` attribute. Object-safety is verified by a compilation smoke test
+in each crate's test suite: `let _: Box<dyn SearchPort> = Box::new(InMemorySearchStore::new())`.
+
+**Evidence:** `search_double_is_object_safe` and `skill_store_is_object_safe` tests in
+`crates/pheno-ports/src/doubles.rs`; `test_pheno_surreal_is_skill_storage_port` in
+`crates/phenotype-surrealdb/src/lib.rs`.
+
+---
+
+### NFR-MCP-002 — FastMCP / MCP Convention Compliance
+
+**Title:** Python package follows FastMCP naming and structural conventions for compatibility with MCP clients.
+
+**Description:** Tool `input_schema` is returned under the key `inputSchema` (camelCase)
+per MCP wire format. Resource `mime_type` is serialised as `mimeType`. Handler dispatch
+detects async callables via `inspect.iscoroutinefunction` to avoid blocking the event loop.
+`PARPOURA_BASE_URL` is an env-var override, not a hard-coded URL, matching Phenotype
+config-via-env policy.
+
+**Evidence:** `Server.to_dict()` in `server.py`; async dispatch in `_handle_tools_call`;
+`governance_tools._client()` env-var pattern replicated in all three tool bundles.
+
+---
+
+### NFR-MCP-003 — Errors Never Crash the Server
+
+**Title:** No unhandled exception from a tool handler may propagate past `handle_request`.
+
+**Description:** `_handle_tools_call` wraps handler invocation in a `try/except Exception`
+guard. Any exception returns a `-32603 Internal error` JSON-RPC object. The server process
+continues normally. This rule applies to both sync and async handlers.
+
+**Evidence:** `server.py` lines 294–298 (defensive guard); `python/tests/test_server_comprehensive.py`
+covers handler-exception path.
+
+---
+
+### NFR-MCP-004 — Test Suite Coverage (223+ Tests Green)
+
+**Title:** All 223 tests (204 Python + 19 Rust) pass on every merge to `main`.
+
+**Description:** CI must run `uv run pytest python/` (≥ 204 passing) and
+`cargo test --workspace` (≥ 19 passing) on every PR. Failures block merge.
+Test files trace to at least one FR via naming convention (`test_governance_tools.py` → FR-MCP-005, etc.).
+
+**Evidence:** `uv run pytest` output: `204 passed in 2.23s`; `cargo test --workspace` output:
+`19 passed` across `pheno-ports` (11) + `phenotype-surrealdb` (5) + `pheno-meilisearch` (2) + `pheno_mcp` crate (1).
+
+---
+
+### NFR-MCP-005 — SurrealDB Stub Annotated with TODO
+
+**Title:** The in-memory SurrealDB stub is clearly labelled as temporary and upgrade path documented.
+
+**Description:** `phenotype-surrealdb/src/lib.rs` carries a `TODO(surreal)` comment at every
+site where the real `surrealdb::Surreal<…>` driver replaces in-memory delegation. The `surrealdb`
+crate dependency is already declared in `Cargo.toml` so the swap requires only source changes,
+not a dependency addition. Existing callers compile and test against the stub without modification.
+
+**Evidence:** `TODO(surreal)` annotations in `crates/phenotype-surrealdb/src/lib.rs` (two sites);
+`surrealdb` listed in workspace `Cargo.toml`; PR #81 description.
+
+---
+
+### NFR-MCP-006 — CI Security Baseline (SHA-Pinned Actions, ubuntu-24.04)
+
+**Title:** All GitHub Actions workflows use SHA-pinned action references on ubuntu-24.04 runners.
+
+**Description:** Per Phenotype org governance, all `uses:` references in `.github/workflows/`
+must be pinned to full commit SHAs. The main CI pipeline targets `ubuntu-24.04` (not
+`ubuntu-latest`) for reproducibility. TruffleHog secret scanning and Scorecard action
+are required CI steps.
+
+**Evidence:** PR #76 (`chore: PhenoMCP workflow hygiene ubuntu-24.04 + SHA pins`);
+`.github/workflows/` files contain SHA-format action pins.
+
+---
+
+## Test-ID to Catalog Mapping
+
+| Test file / series | Catalog FR/NFR |
+|---|---|
+| `test_init.py` | FR-MCP-001 |
+| `test_server.py`, `test_server_comprehensive.py` | FR-MCP-002, FR-MCP-003, FR-MCP-004, NFR-MCP-003 |
+| `test_integration.py` | FR-MCP-003 |
+| `test_governance_tools.py` | FR-MCP-005 |
+| `test_session_tools.py` | FR-MCP-006 |
+| `test_workflow_tools.py` | FR-MCP-007 |
+| `test_configured_server.py` | FR-MCP-008 |
+| `test_client.py`, `test_client_connected.py` | FR-MCP-001 (Client symbol) |
+| `test_models.py`, `test_models_edge_cases.py` | FR-MCP-002 (domain types) |
+| `doubles.rs :: search_double_*` | FR-MCP-009, NFR-MCP-001 |
+| `doubles.rs :: skill_store_*` | FR-MCP-010, NFR-MCP-001 |
+| `phenotype-surrealdb :: test_*` | FR-MCP-010, FR-MCP-011, NFR-MCP-001, NFR-MCP-005 |
+
+---
+
+## Gaps / PLANNED
+
+| ID | Title | Notes |
+|---|---|---|
+| PLAN-MCP-001 | Real SurrealDB client wiring | `TODO(surreal)` in `phenotype-surrealdb/src/lib.rs`; `surrealdb` crate already in `Cargo.toml`; only source swap needed |
+| PLAN-MCP-002 | pheno-qdrant SearchPort adapter | `crates/pheno-qdrant/` exists (stub); needs `SearchPort` impl backed by `qdrant_client` |
+| PLAN-MCP-003 | pheno-meilisearch SearchPort adapter | `crates/pheno-meilisearch/` exists (stub); needs `SearchPort` impl backed by `meilisearch-sdk` |
+| PLAN-MCP-004 | Additional Parpoura tool bundles | Only governance/session/workflow wired; agent, knowledge, policy tool groups are PLANNED epics |
+| PLAN-MCP-005 | MCP ↔ Claude SDK contract hardening | No schema-level validation between MCP request shape and SDK client expectations; property-based tests needed |
+| PLAN-MCP-006 | Transport layer (stdio / HTTP / WS) | `Server.handle_request` has no transport binding yet; wire to FastMCP transport adapters |
+| PLAN-MCP-007 | Resource + Prompt handler end-to-end | Registration is wired; no Parpoura-backed handlers exist for `resources/read` or `prompts/get` |
+| PLAN-MCP-008 | FR coverage matrix auto-update | `docs/reference/fr_coverage_matrix.md` is empty; auto-population from test annotations needed |

--- a/docs/requirements/phenoobservability-frnfr.md
+++ b/docs/requirements/phenoobservability-frnfr.md
@@ -1,0 +1,709 @@
+# PhenoObservability — FR/NFR Catalog
+
+Auto-generated from `docs/FUNCTIONAL_REQUIREMENTS.md` for Tracera traceability ingestion.
+
+---
+
+## 1. Tracing
+
+### FR-OBS-001 — Configurable tracing with log levels
+
+| Field | Value |
+|-------|-------|
+| **Status** | SHIPPED |
+
+**Description** System must support configurable tracing with log levels (TRACE, DEBUG, INFO, WARN, ERROR).
+
+**Acceptance Criteria**
+- Configurable log level accepted at initialization
+- Each log level filters output correctly
+
+**Traceability**
+- Crate: `pheno-tracing`
+- tests/unit/pheno-tracing/test_config_level_validation.rs
+
+---
+
+### FR-OBS-002 — Unique span IDs and trace IDs via UUID v4
+
+| Field | Value |
+|-------|-------|
+| **Status** | SHIPPED |
+
+**Description** System must generate unique span IDs and trace IDs using UUID v4.
+
+**Traceability**
+- Crate: `pheno-tracing`
+- tests/unit/pheno-tracing/test_span_id_generation.rs
+- tests/unit/pheno-tracing/test_trace_id_generation.rs
+
+---
+
+### FR-OBS-003 — Async-safe trace context propagation
+
+| Field | Value |
+|-------|-------|
+| **Status** | SHIPPED |
+
+**Description** Tracing context must propagate across async boundaries with correct parent-child relationships.
+
+**Traceability**
+- Crate: `pheno-tracing`
+- tests/unit/pheno-tracing/test_trace_context_creation.rs
+- tests/unit/pheno-tracing/test_trace_context_clone.rs
+
+---
+
+### FR-OBS-004 — Optional span event recording
+
+| Field | Value |
+|-------|-------|
+| **Status** | SHIPPED |
+
+**Description** System must support optional span event recording (open, close, new_message).
+
+**Traceability**
+- Crate: `pheno-tracing`
+- tests/unit/pheno-tracing/test_config_span_events.rs
+
+---
+
+### FR-OBS-005 — Thread ID and name in trace spans
+
+| Field | Value |
+|-------|-------|
+| **Status** | SHIPPED |
+
+**Description** System must support thread ID and thread name inclusion in trace spans.
+
+**Traceability**
+- Crate: `pheno-tracing`
+- tests/unit/pheno-tracing/test_config_thread_info.rs
+
+---
+
+### FR-OBS-006 — Graceful double-init failure
+
+| Field | Value |
+|-------|-------|
+| **Status** | SHIPPED |
+
+**Description** Tracing initialization must fail gracefully when subscriber already initialized.
+
+**Traceability**
+- Crate: `pheno-tracing`
+- tests/unit/pheno-tracing/test_double_init_error.rs
+
+---
+
+### FR-OBS-007 — Trace level string-to-enum mapping
+
+| Field | Value |
+|-------|-------|
+| **Status** | SHIPPED |
+
+**Description** Trace level strings must map correctly to tracing Level enum.
+
+**Traceability**
+- Crate: `pheno-tracing`
+- tests/unit/pheno-tracing/test_level_as_str_all_levels.rs
+
+---
+
+### FR-OBS-008 — TraceKey Display and Debug serialization
+
+| Field | Value |
+|-------|-------|
+| **Status** | SHIPPED |
+
+**Description** TraceKey must implement Display and Debug for serialization.
+
+**Traceability**
+- Crate: `pheno-tracing`
+- tests/unit/pheno-tracing/test_trace_key_display.rs
+
+---
+
+## 2. Logging
+
+### FR-OBS-009 — Structured logging with correlation IDs
+
+| Field | Value |
+|-------|-------|
+| **Status** | SHIPPED |
+
+**Description** System must support structured logging with correlation IDs.
+
+**Traceability**
+- Crate: `helix-logging`
+- tests/unit/helix-logging/test_logger_config_defaults.rs
+
+---
+
+### FR-OBS-010 — Auto-generated correlation IDs
+
+| Field | Value |
+|-------|-------|
+| **Status** | SHIPPED |
+
+**Description** System must generate unique correlation IDs when none provided.
+
+**Traceability**
+- Crate: `helix-logging`
+- tests/unit/helix-logging/test_log_context_autogen_id.rs
+
+---
+
+### FR-OBS-011 — Preserve provided correlation IDs
+
+| Field | Value |
+|-------|-------|
+| **Status** | SHIPPED |
+
+**Description** System must preserve provided correlation IDs in logging context.
+
+**Traceability**
+- Crate: `helix-logging`
+- tests/unit/helix-logging/test_log_context_with_provided_id.rs
+
+---
+
+### FR-OBS-012 — All standard log levels supported
+
+| Field | Value |
+|-------|-------|
+| **Status** | SHIPPED |
+
+**Description** Logger must support all standard log levels (Trace, Debug, Info, Warn, Error).
+
+**Traceability**
+- Crate: `helix-logging`
+- tests/unit/helix-logging/test_logger_level_filter.rs
+
+---
+
+### FR-OBS-013 — Timestamps in log output
+
+| Field | Value |
+|-------|-------|
+| **Status** | SHIPPED |
+
+**Description** Logger must include timestamps in output.
+
+**Traceability**
+- Crate: `helix-logging`
+- tests/unit/helix-logging/test_logger_include_timestamps.rs
+
+---
+
+### FR-OBS-014 — File and line location in logs
+
+| Field | Value |
+|-------|-------|
+| **Status** | SHIPPED |
+
+**Description** Logger must include file and line location information.
+
+**Traceability**
+- Crate: `helix-logging`
+- tests/unit/helix-logging/test_logger_include_location.rs
+
+---
+
+### FR-OBS-015 — JSON logging macro serialization
+
+| Field | Value |
+|-------|-------|
+| **Status** | SHIPPED |
+
+**Description** JSON logging macro must serialize structured data correctly.
+
+**Traceability**
+- Crate: `helix-logging`
+- tests/unit/helix-logging/test_log_json_serialization.rs
+
+---
+
+## 3. Rate Limiting
+
+### FR-OBS-016 — Token bucket starts at full capacity
+
+| Field | Value |
+|-------|-------|
+| **Status** | SHIPPED |
+
+**Description** Token bucket must start with full capacity.
+
+**Traceability**
+- Crate: `tracely-sentinel`
+- tests/unit/tracely-sentinel/test_token_bucket_initial_capacity.rs
+
+---
+
+### FR-OBS-017 — Token bucket refuses acquisition when exhausted
+
+| Field | Value |
+|-------|-------|
+| **Status** | SHIPPED |
+
+**Description** Token bucket must refuse acquisition when exhausted.
+
+**Traceability**
+- Crate: `tracely-sentinel`
+- tests/unit/tracely-sentinel/test_token_bucket_exhaustion.rs
+
+---
+
+### FR-OBS-018 — Token bucket refills at configured rate
+
+| Field | Value |
+|-------|-------|
+| **Status** | SHIPPED |
+
+**Description** Token bucket must refill at configured rate.
+
+**Traceability**
+- Crate: `tracely-sentinel`
+- tests/unit/tracely-sentinel/test_token_bucket_refill_rate.rs
+
+---
+
+### FR-OBS-019 — Token bucket capacity ceiling during refill
+
+| Field | Value |
+|-------|-------|
+| **Status** | SHIPPED |
+
+**Description** Token bucket must not exceed capacity during refill.
+
+**Traceability**
+- Crate: `tracely-sentinel`
+- tests/unit/tracely-sentinel/test_token_bucket_capacity_ceiling.rs
+
+---
+
+### FR-OBS-020 — Leaky bucket enforces queue capacity
+
+| Field | Value |
+|-------|-------|
+| **Status** | SHIPPED |
+
+**Description** Leaky bucket must enforce queue capacity.
+
+**Traceability**
+- Crate: `tracely-sentinel`
+- tests/unit/tracely-sentinel/test_leaky_bucket_capacity_limit.rs
+
+---
+
+### FR-OBS-021 — Leaky bucket pending request tracking
+
+| Field | Value |
+|-------|-------|
+| **Status** | SHIPPED |
+
+**Description** Leaky bucket must track pending requests accurately.
+
+**Traceability**
+- Crate: `tracely-sentinel`
+- tests/unit/tracely-sentinel/test_leaky_bucket_pending_count.rs
+
+---
+
+### FR-OBS-022 — Leaky bucket leak rate
+
+| Field | Value |
+|-------|-------|
+| **Status** | SHIPPED |
+
+**Description** Leaky bucket must leak at configured rate.
+
+**Traceability**
+- Crate: `tracely-sentinel`
+- tests/unit/tracely-sentinel/test_leaky_bucket_leak_rate.rs
+
+---
+
+## 4. Circuit Breaker
+
+### FR-OBS-023 — Circuit breaker starts Closed
+
+| Field | Value |
+|-------|-------|
+| **Status** | SHIPPED |
+
+**Description** Circuit breaker must start in Closed state.
+
+**Traceability**
+- Crate: `tracely-sentinel`
+- tests/unit/tracely-sentinel/test_circuit_breaker_initial_state.rs
+
+---
+
+### FR-OBS-024 — Circuit breaker failure count tracking
+
+| Field | Value |
+|-------|-------|
+| **Status** | SHIPPED |
+
+**Description** Circuit breaker must track failure count.
+
+**Traceability**
+- Crate: `tracely-sentinel`
+- tests/unit/tracely-sentinel/test_circuit_breaker_failure_tracking.rs
+
+---
+
+### FR-OBS-025 — Transition to Open on threshold exceeded
+
+| Field | Value |
+|-------|-------|
+| **Status** | SHIPPED |
+
+**Description** Circuit breaker must transition to Open when threshold exceeded.
+
+**Traceability**
+- Crate: `tracely-sentinel`
+- tests/unit/tracely-sentinel/test_circuit_breaker_open_transition.rs
+
+---
+
+### FR-OBS-026 — Open state blocks requests
+
+| Field | Value |
+|-------|-------|
+| **Status** | SHIPPED |
+
+**Description** Circuit breaker must block requests in Open state.
+
+**Traceability**
+- Crate: `tracely-sentinel`
+- tests/unit/tracely-sentinel/test_circuit_breaker_open_blocks_requests.rs
+
+---
+
+### FR-OBS-027 — Half-Open state after timeout
+
+| Field | Value |
+|-------|-------|
+| **Status** | SHIPPED |
+
+**Description** Circuit breaker must enter Half-Open state after timeout.
+
+**Traceability**
+- Crate: `tracely-sentinel`
+- tests/unit/tracely-sentinel/test_circuit_breaker_half_open_transition.rs
+
+---
+
+### FR-OBS-028 — Close on success in Half-Open
+
+| Field | Value |
+|-------|-------|
+| **Status** | SHIPPED |
+
+**Description** Circuit breaker must close on successful request in Half-Open state.
+
+**Traceability**
+- Crate: `tracely-sentinel`
+- tests/unit/tracely-sentinel/test_circuit_breaker_half_open_success.rs
+
+---
+
+### FR-OBS-029 — Reset failure count on success
+
+| Field | Value |
+|-------|-------|
+| **Status** | SHIPPED |
+
+**Description** Circuit breaker must reset failure count on success.
+
+**Traceability**
+- Crate: `tracely-sentinel`
+- tests/unit/tracely-sentinel/test_circuit_breaker_failure_reset.rs
+
+---
+
+### FR-OBS-030 — Config validates thresholds
+
+| Field | Value |
+|-------|-------|
+| **Status** | SHIPPED |
+
+**Description** Circuit breaker configuration must validate thresholds.
+
+**Traceability**
+- Crate: `tracely-sentinel`
+- tests/unit/tracely-sentinel/test_circuit_breaker_config_validation.rs
+
+---
+
+## 5. Bulkhead
+
+### FR-OBS-031 — Bulkhead enforces partition count limits
+
+| Field | Value |
+|-------|-------|
+| **Status** | SHIPPED |
+
+**Description** Bulkhead must enforce partition count limits.
+
+**Traceability**
+- Crate: `tracely-sentinel`
+- tests/unit/tracely-sentinel/test_bulkhead_partition_limit.rs
+
+---
+
+### FR-OBS-032 — Bulkhead creates guards for successful acquisitions
+
+| Field | Value |
+|-------|-------|
+| **Status** | SHIPPED |
+
+**Description** Bulkhead must create guards for successful acquisitions.
+
+**Traceability**
+- Crate: `tracely-sentinel`
+- tests/unit/tracely-sentinel/test_bulkhead_guard_creation.rs
+
+---
+
+### FR-OBS-033 — Bulkhead releases partition on guard drop
+
+| Field | Value |
+|-------|-------|
+| **Status** | SHIPPED |
+
+**Description** Bulkhead must release partition on guard drop.
+
+**Traceability**
+- Crate: `tracely-sentinel`
+- tests/unit/tracely-sentinel/test_bulkhead_guard_release.rs
+
+---
+
+### FR-OBS-034 — Bulkhead prevents over-allocation across partitions
+
+| Field | Value |
+|-------|-------|
+| **Status** | SHIPPED |
+
+**Description** Bulkhead must prevent over-allocation across partitions.
+
+**Traceability**
+- Crate: `tracely-sentinel`
+- tests/unit/tracely-sentinel/test_bulkhead_multi_partition_isolation.rs
+
+---
+
+### FR-OBS-035 — Bulkhead config validates partition counts
+
+| Field | Value |
+|-------|-------|
+| **Status** | SHIPPED |
+
+**Description** Bulkhead configuration must validate partition counts.
+
+**Traceability**
+- Crate: `tracely-sentinel`
+- tests/unit/tracely-sentinel/test_bulkhead_config_validation.rs
+
+---
+
+### FR-OBS-036 — Bulkhead supports concurrent partition access
+
+| Field | Value |
+|-------|-------|
+| **Status** | SHIPPED |
+
+**Description** Bulkhead must support concurrent partition access.
+
+**Traceability**
+- Crate: `tracely-sentinel`
+- tests/unit/tracely-sentinel/test_bulkhead_concurrent_access.rs
+
+---
+
+### FR-OBS-037 — Bulkhead exhausted error on capacity exceeded
+
+| Field | Value |
+|-------|-------|
+| **Status** | SHIPPED |
+
+**Description** Bulkhead must return exhausted error when capacity exceeded.
+
+**Traceability**
+- Crate: `tracely-sentinel`
+- tests/unit/tracely-sentinel/test_bulkhead_exhausted_error.rs
+
+---
+
+## 6. Configuration
+
+### FR-OBS-038 — Rate limiter config validates capacity > 0
+
+| Field | Value |
+|-------|-------|
+| **Status** | SHIPPED |
+
+**Description** Rate limiter config must validate capacity > 0.
+
+**Traceability**
+- Crate: `tracely-sentinel`
+- tests/unit/tracely-sentinel/test_rate_limiter_config_validation.rs
+
+---
+
+### FR-OBS-039 — Circuit breaker config validates failure threshold
+
+| Field | Value |
+|-------|-------|
+| **Status** | SHIPPED |
+
+**Description** Circuit breaker config must validate failure threshold.
+
+**Traceability**
+- Crate: `tracely-sentinel`
+- tests/unit/tracely-sentinel/test_circuit_breaker_config_defaults.rs
+
+---
+
+### FR-OBS-040 — Bulkhead config validates partition count
+
+| Field | Value |
+|-------|-------|
+| **Status** | SHIPPED |
+
+**Description** Bulkhead config must validate partition count.
+
+**Traceability**
+- Crate: `tracely-sentinel`
+- tests/unit/tracely-sentinel/test_bulkhead_config_defaults.rs
+
+---
+
+### FR-OBS-041 — Sentinel config allows policy composition
+
+| Field | Value |
+|-------|-------|
+| **Status** | SHIPPED |
+
+**Description** Sentinel config must allow composition of all policies.
+
+**Traceability**
+- Crate: `tracely-sentinel`
+- tests/unit/tracely-sentinel/test_sentinel_config_composition.rs
+
+---
+
+### FR-OBS-042 — Config provides sensible defaults
+
+| Field | Value |
+|-------|-------|
+| **Status** | SHIPPED |
+
+**Description** Config must provide sensible defaults for all parameters.
+
+**Traceability**
+- Crate: `tracely-sentinel`
+- tests/unit/tracely-sentinel/test_config_all_defaults.rs
+
+---
+
+### FR-OBS-043 — Config serializable to/from TOML
+
+| Field | Value |
+|-------|-------|
+| **Status** | SHIPPED |
+
+**Description** Config must be serializable to/from TOML.
+
+**Traceability**
+- Crate: `tracely-sentinel`
+- tests/unit/tracely-sentinel/test_config_serialization.rs
+
+---
+
+## 7. Validation
+
+### FR-OBS-044 — Validation rejects invalid log levels
+
+| Field | Value |
+|-------|-------|
+| **Status** | SHIPPED |
+
+**Description** Validation must reject invalid log levels.
+
+**Traceability**
+- Crate: `tracely-sentinel`
+- tests/unit/tracely-sentinel/test_validate_invalid_level.rs
+
+---
+
+### FR-OBS-045 — Validation accepts valid log levels
+
+| Field | Value |
+|-------|-------|
+| **Status** | SHIPPED |
+
+**Description** Validation must accept valid log levels.
+
+**Traceability**
+- Crate: `tracely-sentinel`
+- tests/unit/tracely-sentinel/test_validate_log_levels.rs
+
+---
+
+### FR-OBS-046 — Validation checks capacity constraints
+
+| Field | Value |
+|-------|-------|
+| **Status** | SHIPPED |
+
+**Description** Validation must check capacity constraints.
+
+**Traceability**
+- Crate: `tracely-sentinel`
+- tests/unit/tracely-sentinel/test_validate_capacity.rs
+
+---
+
+### FR-OBS-047 — Validation checks timeout constraints
+
+| Field | Value |
+|-------|-------|
+| **Status** | SHIPPED |
+
+**Description** Validation must check timeout constraints.
+
+**Traceability**
+- Crate: `tracely-sentinel`
+- tests/unit/tracely-sentinel/test_validate_timeout.rs
+
+---
+
+### FR-OBS-048 — Validation provides descriptive error messages
+
+| Field | Value |
+|-------|-------|
+| **Status** | SHIPPED |
+
+**Description** Validation must provide descriptive error messages.
+
+**Traceability**
+- Crate: `tracely-sentinel`
+- tests/unit/tracely-sentinel/test_validate_error_messages.rs
+
+---
+
+### FR-OBS-049 — Validation supports batch multi-field config checks
+
+| Field | Value |
+|-------|-------|
+| **Status** | SHIPPED |
+
+**Description** Validation must support batch checks for multi-field config.
+
+**Traceability**
+- Crate: `tracely-sentinel`
+- tests/unit/tracely-sentinel/test_validate_batch.rs


### PR DESCRIPTION
## **User description**
## Summary
- Copy `phenomcp-frnfr.md` and `phenoobservability-frnfr.md` from their source repos into `docs/requirements/`
- Extend `seed_requirements.rs` (CLI) to include PhenoMCP + PhenoObservability initiatives
- Add standalone `seed_requirements` binary to `agileplus-sqlite` crate (bypasses unrelated broken CLI deps)
- Re-run seed: 6 epics, 138 stories; all SHIPPED FRs mapped to Done status

## Verification
- `sqlite3 agileplus.db "select count(*) from epics"` → **6**
- `sqlite3 agileplus.db "select count(*) from stories"` → **138**
- `GET http://localhost:4000/api/dashboard/epics-stories.json` → `"epic_count":6`
- `:5176` dashboard now shows 6 Epics

## Test plan
- [x] `cargo test -p agileplus-sqlite` → 79 passed, 0 failed
- [x] `cargo check -p agileplus-sqlite -p agileplus-domain` → clean
- [x] Seed idempotency verified (re-run produces same counts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and seed/CLI tooling only; upserts are idempotent and do not change runtime auth or production paths beyond refreshed local DB content.
> 
> **Overview**
> Extends **seed-requirements** from four to **six** initiatives by adding **PhenoMCP** and **PhenoObservability** FR/NFR markdown under `docs/requirements/`, wired into the CLI via new `include_str!` catalogs and `Initiative` entries (same idempotent upsert path as before).
> 
> Adds a **standalone** `agileplus-sqlite` **`seed_requirements`** binary (migrations + seed, minimal `--db` parsing, per-initiative Done/Todo summary) and an **`anyhow`** dependency on that crate so seeding can run without the full CLI. Expect **6 epics / ~138 stories** in SQLite and on the dashboard after re-seed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65b36b2e8581937af3d552bb34d201edc3230171. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
Add PhenoMCP and PhenoObservability to requirement seeding, with a standalone SQLite seeder

### What Changed
- The requirement seeding flow now includes two additional catalogs, so six initiatives are loaded instead of four
- A standalone `seed_requirements` command is now available in the SQLite crate, letting users seed the database without relying on the main CLI
- The standalone seeder also sets up the database before loading requirements and prints a per-initiative summary after seeding
- The new PhenoMCP and PhenoObservability requirement catalogs are added to the requirements docs bundle

### Impact
`✅ Six initiatives available in the seeded database`
`✅ Easier local seeding when the main CLI cannot run`
`✅ Clearer seeding results with per-initiative status output`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
