### PR TITLE
feat(plane): FR-AGP-018 Plane.so adapter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,7 +203,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tokio",
@@ -222,7 +222,7 @@ dependencies = [
  "config",
  "envsubst",
  "regex",
- "reqwest",
+ "reqwest 0.12.28",
  "rusqlite",
  "serde",
  "serde_json",
@@ -313,6 +313,29 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "agileplus-plane"
+version = "0.1.0"
+dependencies = [
+ "agileplus-domain",
+ "anyhow",
+ "async-trait",
+ "axum 0.8.9",
+ "chrono",
+ "hex",
+ "hmac",
+ "reqwest 0.13.4",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "wiremock",
 ]
 
 [[package]]
@@ -529,6 +552,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-nats"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -644,6 +677,28 @@ name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
 
 [[package]]
 name = "axum"
@@ -937,6 +992,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chacha20"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1009,6 +1070,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "197fd99cb113a8d5d9b6376f3aa817f32c1078f2343b714fff7d2ca44fdf67d5"
 dependencies = [
  "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1323,6 +1393,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1380,6 +1468,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1666,6 +1755,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "fsevent-sys"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1779,8 +1874,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1790,9 +1887,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2865,6 +2964,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "hostname"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3335,6 +3455,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3515,6 +3684,12 @@ name = "log"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchers"
@@ -3829,6 +4004,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3913,7 +4098,7 @@ dependencies = [
  "bytes",
  "http",
  "opentelemetry",
- "reqwest",
+ "reqwest 0.12.28",
 ]
 
 [[package]]
@@ -3930,7 +4115,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest",
+ "reqwest 0.12.28",
  "thiserror 1.0.69",
  "tokio",
  "tonic 0.12.3",
@@ -4318,6 +4503,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2 0.6.4",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.6.4",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4345,8 +4586,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -4371,12 +4622,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -4550,6 +4820,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower 0.5.3",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "reserve-port"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4624,6 +4934,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4651,6 +4967,7 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -4699,8 +5016,36 @@ version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs 0.8.3",
+ "rustls-platform-verifier-android",
+ "rustls-webpki 0.103.13",
+ "security-framework 3.7.0",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -4719,6 +5064,7 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -5017,6 +5363,22 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
@@ -6157,6 +6519,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6577,6 +6948,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64 0.22.1",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "crates/agileplus-api",
     "crates/agileplus-grpc",
     "crates/agileplus-github",
+    "crates/agileplus-plane",
     "crates/agileplus-nats",
     "crates/agileplus-p2p",
     "crates/agileplus-telemetry",

--- a/crates/agileplus-domain/src/ports/mod.rs
+++ b/crates/agileplus-domain/src/ports/mod.rs
@@ -4,6 +4,7 @@ pub mod agent;
 pub mod epic;
 pub mod events;
 pub mod observability;
+pub mod plane_sync;
 pub mod storage;
 pub mod story;
 pub mod vcs;
@@ -12,6 +13,10 @@ pub use agent::AgentPort;
 pub use epic::EpicRepository;
 pub use events::{DomainEvent, DomainEventPublisher};
 pub use observability::ObservabilityPort;
+pub use plane_sync::{
+    PlaneIssue, PlaneProject, PlaneSyncPort, plane_state_to_story_status,
+    story_status_to_plane_state,
+};
 pub use story::StoryRepository;
 
 // ReviewPort — a no-op port for code-review integrations (WP09, not yet implemented).
@@ -27,7 +32,7 @@ use async_trait::async_trait;
 use crate::domain::{
     audit::AuditEntry,
     backlog::{BacklogFilters, BacklogItem, BacklogPriority, BacklogStatus},
-    cycle::{Cycle, CycleFeature, CycleWithFeatures, CycleState},
+    cycle::{Cycle, CycleFeature, CycleState, CycleWithFeatures},
     epic::{Epic, EpicStatus},
     feature::Feature,
     governance::{Evidence, GovernanceContract, PolicyRule},
@@ -52,7 +57,10 @@ pub trait StoragePort: Send + Sync {
     async fn get_feature_by_slug(&self, slug: &str) -> Result<Option<Feature>, DomainError>;
     async fn get_feature_by_id(&self, id: i64) -> Result<Option<Feature>, DomainError>;
     async fn update_feature_state(&self, id: i64, state: FeatureState) -> Result<(), DomainError>;
-    async fn list_features_by_state(&self, state: FeatureState) -> Result<Vec<Feature>, DomainError>;
+    async fn list_features_by_state(
+        &self,
+        state: FeatureState,
+    ) -> Result<Vec<Feature>, DomainError>;
     async fn list_all_features(&self) -> Result<Vec<Feature>, DomainError>;
 
     // --- Work Packages ---
@@ -67,7 +75,10 @@ pub trait StoragePort: Send + Sync {
     // --- Audit ---
     async fn append_audit_entry(&self, entry: &AuditEntry) -> Result<i64, DomainError>;
     async fn get_audit_trail(&self, feature_id: i64) -> Result<Vec<AuditEntry>, DomainError>;
-    async fn get_latest_audit_entry(&self, feature_id: i64) -> Result<Option<AuditEntry>, DomainError>;
+    async fn get_latest_audit_entry(
+        &self,
+        feature_id: i64,
+    ) -> Result<Option<AuditEntry>, DomainError>;
 
     // --- Evidence ---
     async fn create_evidence(&self, ev: &Evidence) -> Result<i64, DomainError>;
@@ -79,21 +90,43 @@ pub trait StoragePort: Send + Sync {
     async fn list_active_policies(&self) -> Result<Vec<PolicyRule>, DomainError>;
     async fn record_metric(&self, metric: &Metric) -> Result<i64, DomainError>;
     async fn get_metrics_by_feature(&self, feature_id: i64) -> Result<Vec<Metric>, DomainError>;
-    async fn create_governance_contract(&self, contract: &GovernanceContract) -> Result<i64, DomainError>;
-    async fn get_governance_contract(&self, feature_id: i64, version: i32) -> Result<Option<GovernanceContract>, DomainError>;
-    async fn get_latest_governance_contract(&self, feature_id: i64) -> Result<Option<GovernanceContract>, DomainError>;
+    async fn create_governance_contract(
+        &self,
+        contract: &GovernanceContract,
+    ) -> Result<i64, DomainError>;
+    async fn get_governance_contract(
+        &self,
+        feature_id: i64,
+        version: i32,
+    ) -> Result<Option<GovernanceContract>, DomainError>;
+    async fn get_latest_governance_contract(
+        &self,
+        feature_id: i64,
+    ) -> Result<Option<GovernanceContract>, DomainError>;
 
     // --- Modules ---
     async fn create_module(&self, module: &Module) -> Result<i64, DomainError>;
     async fn get_module(&self, id: i64) -> Result<Option<Module>, DomainError>;
     async fn get_module_by_slug(&self, slug: &str) -> Result<Option<Module>, DomainError>;
-    async fn update_module(&self, id: i64, friendly_name: &str, description: Option<&str>) -> Result<(), DomainError>;
+    async fn update_module(
+        &self,
+        id: i64,
+        friendly_name: &str,
+        description: Option<&str>,
+    ) -> Result<(), DomainError>;
     async fn delete_module(&self, id: i64) -> Result<(), DomainError>;
     async fn list_root_modules(&self) -> Result<Vec<Module>, DomainError>;
     async fn list_child_modules(&self, parent_id: i64) -> Result<Vec<Module>, DomainError>;
-    async fn get_module_with_features(&self, id: i64) -> Result<Option<ModuleWithFeatures>, DomainError>;
+    async fn get_module_with_features(
+        &self,
+        id: i64,
+    ) -> Result<Option<ModuleWithFeatures>, DomainError>;
     async fn tag_feature_to_module(&self, tag: &ModuleFeatureTag) -> Result<(), DomainError>;
-    async fn untag_feature_from_module(&self, module_id: i64, feature_id: i64) -> Result<(), DomainError>;
+    async fn untag_feature_from_module(
+        &self,
+        module_id: i64,
+        feature_id: i64,
+    ) -> Result<(), DomainError>;
 
     // --- Cycles ---
     async fn create_cycle(&self, cycle: &Cycle) -> Result<i64, DomainError>;
@@ -102,15 +135,34 @@ pub trait StoragePort: Send + Sync {
     async fn list_cycles_by_state(&self, state: CycleState) -> Result<Vec<Cycle>, DomainError>;
     async fn list_cycles_by_module(&self, module_id: i64) -> Result<Vec<Cycle>, DomainError>;
     async fn list_all_cycles(&self) -> Result<Vec<Cycle>, DomainError>;
-    async fn get_cycle_with_features(&self, id: i64) -> Result<Option<CycleWithFeatures>, DomainError>;
+    async fn get_cycle_with_features(
+        &self,
+        id: i64,
+    ) -> Result<Option<CycleWithFeatures>, DomainError>;
     async fn add_feature_to_cycle(&self, entry: &CycleFeature) -> Result<(), DomainError>;
-    async fn remove_feature_from_cycle(&self, cycle_id: i64, feature_id: i64) -> Result<(), DomainError>;
+    async fn remove_feature_from_cycle(
+        &self,
+        cycle_id: i64,
+        feature_id: i64,
+    ) -> Result<(), DomainError>;
 
     // --- Sync Mappings ---
-    async fn get_sync_mapping(&self, entity_type: &str, entity_id: i64) -> Result<Option<SyncMapping>, DomainError>;
+    async fn get_sync_mapping(
+        &self,
+        entity_type: &str,
+        entity_id: i64,
+    ) -> Result<Option<SyncMapping>, DomainError>;
     async fn upsert_sync_mapping(&self, mapping: &SyncMapping) -> Result<(), DomainError>;
-    async fn get_sync_mapping_by_plane_id(&self, entity_type: &str, plane_issue_id: &str) -> Result<Option<SyncMapping>, DomainError>;
-    async fn delete_sync_mapping(&self, entity_type: &str, entity_id: i64) -> Result<(), DomainError>;
+    async fn get_sync_mapping_by_plane_id(
+        &self,
+        entity_type: &str,
+        plane_issue_id: &str,
+    ) -> Result<Option<SyncMapping>, DomainError>;
+    async fn delete_sync_mapping(
+        &self,
+        entity_type: &str,
+        entity_id: i64,
+    ) -> Result<(), DomainError>;
 
     // --- Projects ---
     async fn create_project(&self, project: &Project) -> Result<i64, DomainError>;
@@ -197,7 +249,10 @@ pub trait ContentStoragePort: Send + Sync {
     async fn get_feature_by_id(&self, id: i64) -> Result<Option<Feature>, DomainError>;
     async fn update_feature_state(&self, id: i64, state: FeatureState) -> Result<(), DomainError>;
     async fn update_feature(&self, feature: &Feature) -> Result<(), DomainError>;
-    async fn list_features_by_state(&self, state: FeatureState) -> Result<Vec<Feature>, DomainError>;
+    async fn list_features_by_state(
+        &self,
+        state: FeatureState,
+    ) -> Result<Vec<Feature>, DomainError>;
     async fn list_all_features(&self) -> Result<Vec<Feature>, DomainError>;
     // Work packages
     async fn create_work_package(&self, wp: &WorkPackage) -> Result<i64, DomainError>;
@@ -211,26 +266,71 @@ pub trait ContentStoragePort: Send + Sync {
     // Backlog
     async fn create_backlog_item(&self, item: &BacklogItem) -> Result<i64, DomainError>;
     async fn get_backlog_item(&self, id: i64) -> Result<Option<BacklogItem>, DomainError>;
-    async fn list_backlog_items(&self, filters: &BacklogFilters) -> Result<Vec<BacklogItem>, DomainError>;
-    async fn update_backlog_status(&self, id: i64, status: BacklogStatus) -> Result<(), DomainError>;
-    async fn update_backlog_priority(&self, id: i64, priority: BacklogPriority) -> Result<(), DomainError>;
+    async fn list_backlog_items(
+        &self,
+        filters: &BacklogFilters,
+    ) -> Result<Vec<BacklogItem>, DomainError>;
+    async fn update_backlog_status(
+        &self,
+        id: i64,
+        status: BacklogStatus,
+    ) -> Result<(), DomainError>;
+    async fn update_backlog_priority(
+        &self,
+        id: i64,
+        priority: BacklogPriority,
+    ) -> Result<(), DomainError>;
     async fn pop_next_backlog_item(&self) -> Result<Option<BacklogItem>, DomainError>;
 }
 
 /// VCS port — git operations needed by the domain.
 #[async_trait]
 pub trait VcsPort: Send + Sync {
-    async fn create_worktree(&self, feature_slug: &str, wp_id: &str) -> Result<PathBuf, DomainError>;
+    async fn create_worktree(
+        &self,
+        feature_slug: &str,
+        wp_id: &str,
+    ) -> Result<PathBuf, DomainError>;
     async fn list_worktrees(&self) -> Result<Vec<WorktreeInfo>, DomainError>;
     async fn cleanup_worktree(&self, worktree_path: &Path) -> Result<(), DomainError>;
     async fn create_branch(&self, branch_name: &str, base: &str) -> Result<(), DomainError>;
-    async fn list_branches(&self, pattern: Option<&str>, remote: bool) -> Result<Vec<BranchInfo>, DomainError>;
-    async fn delete_branch(&self, branch_name: &str, force: bool, remote: Option<&str>) -> Result<(), DomainError>;
+    async fn list_branches(
+        &self,
+        pattern: Option<&str>,
+        remote: bool,
+    ) -> Result<Vec<BranchInfo>, DomainError>;
+    async fn delete_branch(
+        &self,
+        branch_name: &str,
+        force: bool,
+        remote: Option<&str>,
+    ) -> Result<(), DomainError>;
     async fn checkout_branch(&self, branch_name: &str) -> Result<(), DomainError>;
-    async fn merge_to_target(&self, source: &str, target: &str) -> Result<MergeResult, DomainError>;
-    async fn detect_conflicts(&self, source: &str, target: &str) -> Result<Vec<ConflictInfo>, DomainError>;
-    async fn read_artifact(&self, feature_slug: &str, relative_path: &str) -> Result<String, DomainError>;
-    async fn write_artifact(&self, feature_slug: &str, relative_path: &str, content: &str) -> Result<(), DomainError>;
-    async fn artifact_exists(&self, feature_slug: &str, relative_path: &str) -> Result<bool, DomainError>;
-    async fn scan_feature_artifacts(&self, feature_slug: &str) -> Result<FeatureArtifacts, DomainError>;
+    async fn merge_to_target(&self, source: &str, target: &str)
+    -> Result<MergeResult, DomainError>;
+    async fn detect_conflicts(
+        &self,
+        source: &str,
+        target: &str,
+    ) -> Result<Vec<ConflictInfo>, DomainError>;
+    async fn read_artifact(
+        &self,
+        feature_slug: &str,
+        relative_path: &str,
+    ) -> Result<String, DomainError>;
+    async fn write_artifact(
+        &self,
+        feature_slug: &str,
+        relative_path: &str,
+        content: &str,
+    ) -> Result<(), DomainError>;
+    async fn artifact_exists(
+        &self,
+        feature_slug: &str,
+        relative_path: &str,
+    ) -> Result<bool, DomainError>;
+    async fn scan_feature_artifacts(
+        &self,
+        feature_slug: &str,
+    ) -> Result<FeatureArtifacts, DomainError>;
 }

--- a/crates/agileplus-domain/src/ports/plane_sync.rs
+++ b/crates/agileplus-domain/src/ports/plane_sync.rs
@@ -1,0 +1,86 @@
+//! Plane.so sync port.
+
+use async_trait::async_trait;
+
+use crate::domain::story::{Story, StoryStatus};
+use crate::error::DomainError;
+
+/// Minimal Plane project representation used by the sync adapter.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct PlaneProject {
+    pub id: String,
+    pub name: String,
+    pub identifier: String,
+}
+
+/// Minimal Plane issue representation used by the sync adapter.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct PlaneIssue {
+    pub id: String,
+    pub name: String,
+    pub state: Option<String>,
+    pub priority: Option<i32>,
+    pub sequence_id: Option<i64>,
+}
+
+impl PlaneIssue {
+    pub fn new(
+        id: impl Into<String>,
+        name: impl Into<String>,
+        state: Option<String>,
+        priority: Option<i32>,
+        sequence_id: Option<i64>,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            name: name.into(),
+            state,
+            priority,
+            sequence_id,
+        }
+    }
+}
+
+/// Hexagonal port for Plane.so synchronization.
+#[async_trait]
+pub trait PlaneSyncPort: Send + Sync {
+    async fn list_projects(&self) -> Result<Vec<PlaneProject>, DomainError>;
+
+    async fn sync_story_to_plane(
+        &self,
+        project_identifier: &str,
+        story: &Story,
+    ) -> Result<PlaneIssue, DomainError>;
+
+    async fn sync_from_plane(
+        &self,
+        project_id: i64,
+        epic_id: i64,
+        issue: &PlaneIssue,
+    ) -> Result<Story, DomainError>;
+}
+
+pub fn story_status_to_plane_state(status: StoryStatus) -> &'static str {
+    match status {
+        StoryStatus::Todo => "todo",
+        StoryStatus::InProgress => "in_progress",
+        StoryStatus::Review => "review",
+        StoryStatus::Done => "done",
+        StoryStatus::Blocked => "blocked",
+        StoryStatus::Cancelled => "cancelled",
+    }
+}
+
+pub fn plane_state_to_story_status(state: &str) -> Result<StoryStatus, DomainError> {
+    match state {
+        "todo" => Ok(StoryStatus::Todo),
+        "in_progress" => Ok(StoryStatus::InProgress),
+        "review" => Ok(StoryStatus::Review),
+        "done" => Ok(StoryStatus::Done),
+        "blocked" => Ok(StoryStatus::Blocked),
+        "cancelled" => Ok(StoryStatus::Cancelled),
+        other => Err(DomainError::Validation(format!(
+            "unknown Plane story state: {other}"
+        ))),
+    }
+}

--- a/crates/agileplus-plane/src/lib.rs
+++ b/crates/agileplus-plane/src/lib.rs
@@ -11,13 +11,14 @@ pub mod content_hash;
 pub mod inbound;
 pub mod labels;
 pub mod outbound;
+mod plane_sync;
 pub mod runtime;
 pub mod state_mapper;
 pub mod sync;
 pub mod sync_queue;
 pub mod webhook;
 
-pub use client::PlaneClient;
+pub use agileplus_domain::ports::{PlaneIssue, PlaneProject, PlaneSyncPort};
 pub use client::{
     PlaneCreateCycleRequest, PlaneCreateModuleRequest, PlaneCycleResponse, PlaneModuleResponse,
 };
@@ -28,6 +29,7 @@ pub use outbound::{
     OutboundSync, push_cycle, push_cycle_delete, push_feature_cycle_assignment,
     push_feature_module_assignment, push_module, push_module_delete,
 };
+pub use plane_sync::PlaneClient;
 pub use runtime::*;
 pub use state_mapper::{PlaneStateMapper, PlaneStateMapperConfig};
 pub use sync::{PlaneSyncAdapter, SyncState};

--- a/crates/agileplus-plane/src/plane_sync.rs
+++ b/crates/agileplus-plane/src/plane_sync.rs
@@ -1,0 +1,463 @@
+use std::env;
+
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use serde::Serialize;
+
+use agileplus_domain::domain::story::{Story, StoryStatus};
+use agileplus_domain::error::DomainError;
+use agileplus_domain::ports::{
+    PlaneIssue, PlaneProject, PlaneSyncPort, plane_state_to_story_status,
+    story_status_to_plane_state,
+};
+
+#[derive(Debug, Clone)]
+pub struct PlaneClient {
+    base_url: String,
+    workspace: String,
+    token: String,
+    http: reqwest::Client,
+}
+
+#[derive(Debug, Serialize)]
+struct StoryIssueRequest {
+    name: String,
+    state: Option<String>,
+    priority: Option<i32>,
+}
+
+impl PlaneClient {
+    pub fn new(base_url: String, workspace: String, token: String) -> Self {
+        Self {
+            base_url: base_url.trim_end_matches('/').to_string(),
+            workspace,
+            token,
+            http: reqwest::Client::new(),
+        }
+    }
+
+    pub fn from_env() -> Result<Self> {
+        let base_url = env::var("PLANE_BASE_URL").context("PLANE_BASE_URL is not set")?;
+        let workspace = env::var("PLANE_WORKSPACE").context("PLANE_WORKSPACE is not set")?;
+        let token = env::var("PLANE_TOKEN").context("PLANE_TOKEN is not set")?;
+        Ok(Self::new(base_url, workspace, token))
+    }
+
+    fn endpoint(&self, path: &str) -> String {
+        format!("{}/{}", self.base_url, path.trim_start_matches('/'))
+    }
+
+    fn projects_url(&self) -> String {
+        self.endpoint(&format!("api/v1/workspaces/{}/projects/", self.workspace))
+    }
+
+    fn issues_url(&self, project_identifier: &str) -> String {
+        self.endpoint(&format!(
+            "api/v1/workspaces/{}/projects/{}/work-items/",
+            self.workspace, project_identifier
+        ))
+    }
+
+    async fn get_json<T: serde::de::DeserializeOwned>(&self, url: String) -> Result<T> {
+        let response = self
+            .http
+            .get(url)
+            .bearer_auth(&self.token)
+            .send()
+            .await
+            .context("sending GET request to Plane")?;
+        Self::read_json(response).await
+    }
+
+    async fn post_json<T: serde::de::DeserializeOwned, B: Serialize + ?Sized>(
+        &self,
+        url: String,
+        body: &B,
+    ) -> Result<T> {
+        let response = self
+            .http
+            .post(url)
+            .bearer_auth(&self.token)
+            .json(body)
+            .send()
+            .await
+            .context("sending POST request to Plane")?;
+        Self::read_json(response).await
+    }
+
+    async fn read_json<T: serde::de::DeserializeOwned>(response: reqwest::Response) -> Result<T> {
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            anyhow::bail!("Plane API error {status}: {body}");
+        }
+
+        response.json::<T>().await.context("decoding Plane JSON")
+    }
+
+    fn map_story_points_to_priority(
+        points: Option<u32>,
+    ) -> std::result::Result<Option<i32>, DomainError> {
+        points
+            .map(|value| {
+                i32::try_from(value).map_err(|_| {
+                    DomainError::Validation("story points exceed Plane priority range".to_string())
+                })
+            })
+            .transpose()
+    }
+
+    fn map_priority_to_story_points(
+        priority: Option<i32>,
+    ) -> std::result::Result<Option<u32>, DomainError> {
+        priority
+            .map(|value| {
+                u32::try_from(value).map_err(|_| {
+                    DomainError::Validation(
+                        "Plane priority cannot be converted to story points".to_string(),
+                    )
+                })
+            })
+            .transpose()
+    }
+
+    fn map_story_to_issue(
+        &self,
+        story: &Story,
+    ) -> std::result::Result<StoryIssueRequest, DomainError> {
+        Ok(StoryIssueRequest {
+            name: story.title.clone(),
+            state: Some(story_status_to_plane_state(story.status).to_string()),
+            priority: Self::map_story_points_to_priority(story.points)?,
+        })
+    }
+
+    fn map_issue_to_story(
+        &self,
+        project_id: i64,
+        epic_id: i64,
+        issue: &PlaneIssue,
+    ) -> std::result::Result<Story, DomainError> {
+        let mut story = Story::new(
+            epic_id,
+            project_id,
+            &issue.name,
+            Self::map_priority_to_story_points(issue.priority)?,
+        )?;
+        if let Some(sequence_id) = issue.sequence_id {
+            story.id = sequence_id;
+        }
+        story.status = match issue.state.as_deref() {
+            Some(state) => plane_state_to_story_status(state)?,
+            None => StoryStatus::Todo,
+        };
+        Ok(story)
+    }
+
+    pub async fn list_projects(&self) -> Result<Vec<PlaneProject>> {
+        self.get_json(self.projects_url()).await
+    }
+
+    pub async fn sync_story_to_plane(
+        &self,
+        project_identifier: &str,
+        story: &Story,
+    ) -> Result<PlaneIssue> {
+        let body = self
+            .map_story_to_issue(story)
+            .map_err(|err| anyhow::anyhow!(err.to_string()))?;
+        self.post_json(self.issues_url(project_identifier), &body)
+            .await
+    }
+
+    pub async fn sync_from_plane(
+        &self,
+        project_id: i64,
+        epic_id: i64,
+        issue: &PlaneIssue,
+    ) -> Result<Story> {
+        self.map_issue_to_story(project_id, epic_id, issue)
+            .map_err(|err| anyhow::anyhow!(err.to_string()))
+    }
+}
+
+#[async_trait]
+impl PlaneSyncPort for PlaneClient {
+    async fn list_projects(&self) -> Result<Vec<PlaneProject>, DomainError> {
+        self.get_json(self.projects_url())
+            .await
+            .map_err(|err| DomainError::Storage(err.to_string()))
+    }
+
+    async fn sync_story_to_plane(
+        &self,
+        project_identifier: &str,
+        story: &Story,
+    ) -> Result<PlaneIssue, DomainError> {
+        let body = self.map_story_to_issue(story)?;
+        self.post_json(self.issues_url(project_identifier), &body)
+            .await
+            .map_err(|err| DomainError::Storage(err.to_string()))
+    }
+
+    async fn sync_from_plane(
+        &self,
+        project_id: i64,
+        epic_id: i64,
+        issue: &PlaneIssue,
+    ) -> Result<Story, DomainError> {
+        self.map_issue_to_story(project_id, epic_id, issue)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{body_partial_json, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn client(server: &MockServer) -> PlaneClient {
+        PlaneClient::new(server.uri(), "workspace".into(), "token".into())
+    }
+
+    fn sample_story() -> Story {
+        Story::new(9, 42, "Story title", Some(5)).unwrap()
+    }
+
+    #[test]
+    fn new_trims_base_url() {
+        let client = PlaneClient::new(
+            "https://plane.example.com/".into(),
+            "ws".into(),
+            "tok".into(),
+        );
+        assert_eq!(client.base_url, "https://plane.example.com");
+    }
+
+    #[test]
+    fn plane_state_round_trip_helpers_work() {
+        assert_eq!(
+            story_status_to_plane_state(Story::new(1, 1, "x", None).unwrap().status),
+            "todo"
+        );
+        assert!(matches!(
+            plane_state_to_story_status("done"),
+            Ok(agileplus_domain::domain::story::StoryStatus::Done)
+        ));
+    }
+
+    #[test]
+    fn rejects_unknown_plane_state() {
+        let err = plane_state_to_story_status("mystery").unwrap_err();
+        assert!(matches!(err, DomainError::Validation(_)));
+    }
+
+    #[test]
+    fn rejects_priority_overflow_from_story_points() {
+        let story = Story::new(1, 1, "big", Some(u32::MAX)).unwrap();
+        let err = PlaneClient::new("http://localhost".into(), "ws".into(), "tok".into())
+            .map_story_to_issue(&story)
+            .unwrap_err();
+        assert!(matches!(err, DomainError::Validation(_)));
+    }
+
+    #[test]
+    fn rejects_negative_plane_priority_on_pull() {
+        let err = PlaneClient::new("http://localhost".into(), "ws".into(), "tok".into())
+            .map_issue_to_story(
+                1,
+                2,
+                &PlaneIssue::new("1", "x", Some("todo".into()), Some(-1), Some(99)),
+            )
+            .unwrap_err();
+        assert!(matches!(err, DomainError::Validation(_)));
+    }
+
+    #[tokio::test]
+    async fn from_env_reads_configuration() {
+        let old_base = env::var("PLANE_BASE_URL").ok();
+        let old_workspace = env::var("PLANE_WORKSPACE").ok();
+        let old_token = env::var("PLANE_TOKEN").ok();
+
+        unsafe {
+            env::set_var("PLANE_BASE_URL", "https://plane.example.com/");
+            env::set_var("PLANE_WORKSPACE", "team");
+            env::set_var("PLANE_TOKEN", "secret");
+        }
+
+        let client = PlaneClient::from_env().unwrap();
+        assert_eq!(client.base_url, "https://plane.example.com");
+        assert_eq!(client.workspace, "team");
+        assert_eq!(client.token, "secret");
+
+        match old_base {
+            Some(value) => unsafe { env::set_var("PLANE_BASE_URL", value) },
+            None => unsafe { env::remove_var("PLANE_BASE_URL") },
+        }
+        match old_workspace {
+            Some(value) => unsafe { env::set_var("PLANE_WORKSPACE", value) },
+            None => unsafe { env::remove_var("PLANE_WORKSPACE") },
+        }
+        match old_token {
+            Some(value) => unsafe { env::set_var("PLANE_TOKEN", value) },
+            None => unsafe { env::remove_var("PLANE_TOKEN") },
+        }
+    }
+
+    #[tokio::test]
+    async fn list_projects_uses_workspace_endpoint() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/workspaces/workspace/projects/"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(vec![
+                PlaneProject {
+                    id: "1".into(),
+                    name: "Alpha".into(),
+                    identifier: "alpha".into(),
+                },
+                PlaneProject {
+                    id: "2".into(),
+                    name: "Beta".into(),
+                    identifier: "beta".into(),
+                },
+            ]))
+            .mount(&server)
+            .await;
+
+        let result = client(&server).list_projects().await.unwrap();
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].identifier, "alpha");
+    }
+
+    #[tokio::test]
+    async fn list_projects_propagates_http_errors() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/workspaces/workspace/projects/"))
+            .respond_with(ResponseTemplate::new(500).set_body_string("boom"))
+            .mount(&server)
+            .await;
+
+        let err = client(&server).list_projects().await.unwrap_err();
+        assert!(err.to_string().contains("500"));
+    }
+
+    #[tokio::test]
+    async fn sync_story_to_plane_posts_mapped_payload() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/api/v1/workspaces/workspace/projects/proj-1/work-items/",
+            ))
+            .and(body_partial_json(serde_json::json!({
+                "name": "Story title",
+                "state": "todo",
+                "priority": 5
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "issue-1",
+                "name": "Story title",
+                "state": "todo",
+                "priority": 5,
+                "sequence_id": 9001
+            })))
+            .mount(&server)
+            .await;
+
+        let issue = client(&server)
+            .sync_story_to_plane("proj-1", &sample_story())
+            .await
+            .unwrap();
+        assert_eq!(issue.id, "issue-1");
+        assert_eq!(issue.sequence_id, Some(9001));
+    }
+
+    #[tokio::test]
+    async fn sync_story_to_plane_rejects_points_overflow() {
+        let server = MockServer::start().await;
+        let mut story = sample_story();
+        story.points = Some(u32::MAX);
+
+        let err = client(&server)
+            .sync_story_to_plane("proj-1", &story)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("story points"));
+    }
+
+    #[tokio::test]
+    async fn sync_story_to_plane_propagates_http_errors() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/api/v1/workspaces/workspace/projects/proj-1/work-items/",
+            ))
+            .respond_with(ResponseTemplate::new(500).set_body_string("nope"))
+            .mount(&server)
+            .await;
+
+        let err = client(&server)
+            .sync_story_to_plane("proj-1", &sample_story())
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("500"));
+    }
+
+    #[tokio::test]
+    async fn sync_from_plane_maps_state_and_priority() {
+        let story = PlaneClient::new(
+            "http://localhost".into(),
+            "workspace".into(),
+            "token".into(),
+        )
+        .sync_from_plane(
+            42,
+            9,
+            &PlaneIssue::new(
+                "issue-1",
+                "Remote story",
+                Some("review".into()),
+                Some(3),
+                Some(77),
+            ),
+        )
+        .await
+        .unwrap();
+        assert_eq!(story.project_id, 42);
+        assert_eq!(story.epic_id, 9);
+        assert_eq!(story.id, 77);
+        assert_eq!(story.points, Some(3));
+        assert_eq!(
+            story.status,
+            agileplus_domain::domain::story::StoryStatus::Review
+        );
+    }
+
+    #[tokio::test]
+    async fn sync_from_plane_defaults_missing_state_to_todo() {
+        let story = PlaneClient::new(
+            "http://localhost".into(),
+            "workspace".into(),
+            "token".into(),
+        )
+        .sync_from_plane(
+            1,
+            2,
+            &PlaneIssue::new("issue-1", "Remote story", None, Some(1), None),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            story.status,
+            agileplus_domain::domain::story::StoryStatus::Todo
+        );
+        assert_eq!(story.id, 0);
+    }
+
+    #[test]
+    fn issue_serializes_cleanly() {
+        let issue = PlaneIssue::new("1", "Title", Some("todo".into()), Some(2), Some(11));
+        let json = serde_json::to_string(&issue).unwrap();
+        assert!(json.contains("\"sequence_id\":11"));
+    }
+}

--- a/crates/agileplus-sync/src/orchestrator.rs
+++ b/crates/agileplus-sync/src/orchestrator.rs
@@ -358,9 +358,8 @@ mod tests {
     fn make_test_orchestrator() -> SyncOrchestrator {
         let plane = Arc::new(PlaneClient::new(
             "https://plane.example.com".to_string(),
-            "test-key".to_string(),
             "workspace".to_string(),
-            "project".to_string(),
+            "test-key".to_string(),
         ));
         let sqlite = Arc::new(InMemoryEventStore::new()) as Arc<dyn EventStore>;
         let mapper = PlaneStateMapper::new();


### PR DESCRIPTION
## **User description**
Hexagonal PlaneSyncPort + reqwest client

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New external sync path and a breaking change to the public PlaneClient constructor/export may affect callers still using the older rate-limited client module; story/points mapping errors could reject bad Plane payloads at runtime.
> 
> **Overview**
> Introduces a **hexagonal `PlaneSyncPort`** in `agileplus-domain` with `PlaneProject` / `PlaneIssue` DTOs and bidirectional **story status ↔ Plane state** mapping helpers, and wires the crate into the workspace.
> 
> The **`agileplus-plane`** crate gains a dedicated **`plane_sync` HTTP client** (`reqwest` 0.13) that implements the port: list workspace projects, push local `Story` values to Plane work-items, and pull issues back into domain stories (including points/priority validation). Configuration is via `PLANE_BASE_URL`, `PLANE_WORKSPACE`, and `PLANE_TOKEN`. **`agileplus-plane` now re-exports the port types from domain** and exposes this client as the public **`PlaneClient`** (replacing the previous crate-root export). **`SyncOrchestrator` tests** are updated to the new `PlaneClient::new(base_url, workspace, token)` signature.
> 
> Coverage includes **wiremock** integration tests for list/push paths and mapping edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cd46592d6226a2a1226d9b87a65394057713078. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Add Plane sync support for projects and stories**

### What Changed
- The app can now list Plane projects, send local stories to Plane, and read Plane issues back into stories.
- Story status now maps to Plane issue state in both directions, with default handling for missing states and validation for unknown states or out-of-range points.
- Plane settings can be loaded from environment variables, and the Plane client now uses the workspace plus token when building API requests.
- The Plane client export moved to the new sync adapter, and existing sync code was updated to use the new constructor order.

### Impact
`✅ Plane project syncing`
`✅ Fewer story mapping errors`
`✅ Clearer Plane sync failures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
