### PR TITLE
docs: rich-media stub boxes pass

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -146,3 +146,11 @@ Use this document for cross-repo boundaries. Use each repo README for local arch
 | hwLedger | [hwLedger/README.md](hwLedger/README.md) |
 | PolicyStack | [PolicyStack/README.md](PolicyStack/README.md) |
 | phenoAI | [phenoAI/README.md](phenoAI/README.md) |
+
+---
+
+## Rich Media Stubs
+
+<!-- RICH-MEDIA-STUB type="annotated-screenshot" subject="AgilePlus hexagonal architecture — Rust workspace + MCP server diagram" journey="" status="TODO" -->
+> **[RICH MEDIA PLACEHOLDER]** *Annotated component diagram of AgilePlus crates and the MCP server adapter.*
+<!-- END-RICH-MEDIA-STUB -->

--- a/README.md
+++ b/README.md
@@ -205,3 +205,19 @@ This is a curated index of the most active/major repos in this checkout.
 - Some directories are placeholders/landing/utility trees and may not represent standalone canonical products.
 - This README is intentionally a shelf-level index; source-of-truth setup for each project stays in that project's own `README.md`.
 - This index does not remove information from previous versions; it reorganizes it for polyrepo orientation and easier navigation.
+
+---
+
+## Rich Media Stubs
+
+<!-- RICH-MEDIA-STUB type="annotated-screenshot" subject="AgilePlus quickstart — agileplus status after first epic created" journey="" status="TODO" -->
+> **[RICH MEDIA PLACEHOLDER]** *Annotated screenshot of `agileplus status` terminal output after bootstrapping the first epic.*
+<!-- END-RICH-MEDIA-STUB -->
+
+<!-- RICH-MEDIA-STUB type="recording-gif" subject="Epic/Story lifecycle — create epic, break into stories, assign" journey="" status="TODO" -->
+> **[RICH MEDIA PLACEHOLDER]** *GIF of creating an epic, decomposing it into stories, and assigning them.*
+<!-- END-RICH-MEDIA-STUB -->
+
+<!-- RICH-MEDIA-STUB type="recording-mp4" subject="Dashboard walkthrough — AgilePlus web dashboard all panels" journey="" status="TODO" -->
+> **[RICH MEDIA PLACEHOLDER]** *Video walkthrough of the AgilePlus dashboard: backlog, kanban, burndown, release gates.*
+<!-- END-RICH-MEDIA-STUB -->

--- a/RICH_MEDIA.md
+++ b/RICH_MEDIA.md
@@ -1,0 +1,58 @@
+# Rich Media Convention — Phenotype Org
+
+> **Canonical location:** `KooshaPari/phenotype-registry` → `RICH_MEDIA.md`
+> Copied to each participating repo as a docs-only reference.
+
+## Stub Marker Format
+
+Insert stubs using this **exact** HTML-comment pair so fill-agents can grep them:
+
+```html
+<!-- RICH-MEDIA-STUB type="annotated-screenshot|recording-mp4|recording-gif" subject="<what>" journey="<flow>" status="TODO" -->
+> **[RICH MEDIA PLACEHOLDER]** *<short human description of what will go here>*
+<!-- END-RICH-MEDIA-STUB -->
+```
+
+### Attribute reference
+
+| attribute | values | notes |
+|-----------|--------|-------|
+| `type` | `annotated-screenshot` \| `recording-mp4` \| `recording-gif` | pick the most appropriate |
+| `subject` | free text | what the media shows (e.g. `"VRAM plan slider UI"`) |
+| `journey` | phenotype-journeys manifest name or `""` | e.g. `"first-plan"`, `"fleet-register"` |
+| `status` | `TODO` \| `CAPTURED` \| `PUBLISHED` | fill-agent updates to `CAPTURED`/`PUBLISHED` |
+
+## Grep Targets
+
+```bash
+# all stubs
+grep -r "RICH-MEDIA-STUB" docs/
+
+# by journey
+grep -r 'journey="first-plan"' docs/
+
+# outstanding TODOs
+grep -r 'status="TODO"' docs/
+```
+
+## Expected Placement Areas (5 categories)
+
+1. **quickstart / getting-started** — `annotated-screenshot` of first-run output or install step
+2. **feature walkthroughs** — `recording-gif` per major feature
+3. **dashboard / UI pages** — `annotated-screenshot` of each major panel or view
+4. **E2E / journey flows** — `recording-mp4` tied to phenotype-journeys journey name
+5. **architecture diagrams** — `annotated-screenshot` of component map or data-flow
+
+## Journey Linkage
+
+Where a `docs/journeys/manifests/` directory exists, the `journey=` attribute **MUST** match the manifest slug exactly.
+
+Known hwLedger journeys (13): `first-plan`, `fleet-register`, `traceability-report`, `vram-reconcile`, `inference-run`, `fleet-probe`, `cost-model`, `audit-log`, `fleet-dispatch`, `model-ingest`, `telemetry-sync`, `kv-cache-plan`, `spot-price-scan`.
+
+## Fill-Agent Instructions
+
+1. Search for `status="TODO"` stubs.
+2. Capture the screenshot/recording described in `subject=`.
+3. Upload asset to `docs/assets/rich-media/<repo>/<slug>.<ext>`.
+4. Replace the placeholder callout with a real `<img>` or `<video>` tag.
+5. Change `status="TODO"` → `status="PUBLISHED"`.

--- a/docs/requirements/agileplus-frnfr.md
+++ b/docs/requirements/agileplus-frnfr.md
@@ -412,3 +412,11 @@ AgilePlus is a hexagonal-architecture Rust workspace providing an agile project 
 | #611 | Dashboard live wiring — epics_stories_json endpoint + React kanban + seed_db binary | FR-AGP-014 |
 | #295, #464 | Plane.so PlaneClient + resources (work_items, modules, cycles, labels) + state_mapper + sync outbound | FR-AGP-018 |
 | #326, #336 | agileplus-graph crate — GraphStore trait + InMemoryGraphStore + UUID-based API | FR-AGP-019 |
+
+---
+
+## Rich Media Stubs
+
+<!-- RICH-MEDIA-STUB type="annotated-screenshot" subject="FR/NFR requirements panel — AgilePlus spec-driven view" journey="" status="TODO" -->
+> **[RICH MEDIA PLACEHOLDER]** *Annotated screenshot of the requirements panel showing FR/NFR linked to epics.*
+<!-- END-RICH-MEDIA-STUB -->


### PR DESCRIPTION
## **User description**
Additive docs-only PR. Inserts RICH_MEDIA.md + 5 stubs: quickstart, epic/story lifecycle, dashboard panels, FR/NFR requirements view, architecture diagram. Status=TODO for fill-agent.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only additive placeholders; no runtime, API, or config changes.
> 
> **Overview**
> Introduces **`RICH_MEDIA.md`** as the org-wide convention for grep-friendly HTML-comment stubs (`type`, `subject`, `journey`, `status`) and fill-agent steps to replace placeholders with assets under `docs/assets/rich-media/`.
> 
> Adds **five `status="TODO"` stubs** (no real media yet): one architecture diagram stub in **`ARCHITECTURE.md`**, three in **`README.md`** (quickstart terminal output, epic/story lifecycle GIF, dashboard walkthrough MP4), and one FR/NFR requirements view stub in **`docs/requirements/agileplus-frnfr.md`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abce42560605e34208264ff1b336eeebec363122. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Add rich media stub guidance and placeholder media slots for AgilePlus docs**

### What Changed
- Added a shared guide for marking rich media placeholders so they can be found and replaced consistently later
- Added TODO placeholders for a quickstart screenshot, epic/story lifecycle GIF, dashboard walkthrough video, requirements panel screenshot, and architecture diagram screenshot
- Documented how these placeholders should be named, found, and updated when the real media is added

### Impact
`✅ Clearer docs asset handoff`
`✅ Easier media replacement in release notes and guides`
`✅ Fewer missing screenshot placeholders during documentation updates`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
