### PR TITLE
fix(docs): add VitePress scaffold and fix deploy pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,9 +33,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Link @phenotype/docs from phenodocs
-          mkdir -p docs/node_modules/@phenotype
-          ln -sf /tmp/phenodocs/packages/docs docs/node_modules/@phenotype/docs
+          # Link @phenotype/docs from the cloned phenodocs workspace
+          mkdir -p node_modules/@phenotype
+          ln -sf /tmp/phenodocs/packages/docs node_modules/@phenotype/docs
           # Configure npm for GitHub Packages
           echo "@phenotype:registry=https://npm.pkg.github.com" >> ~/.npmrc
           echo "//npm.pkg.github.com/:_authToken=\${GITHUB_TOKEN}" >> ~/.npmrc
@@ -44,14 +44,16 @@ jobs:
       - name: Build VitePress site
         working-directory: docs
         env:
-          GITHUB_PAGES: true
-          PHENOTYPE_CUSTOM_DOMAIN: "true"
+          GITHUB_PAGES: "true"
+          # No custom domain — site is served at kooshapari.github.io/AgilePlus/
+          # Keep PHENOTYPE_CUSTOM_DOMAIN unset so base stays /AgilePlus/
         run: bun run docs:build
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b
         with:
-          path: docs/docs/.vitepress/dist
+          # srcDir: '.' → VitePress outputs to docs/.vitepress/dist
+          path: docs/.vitepress/dist
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,0 +1,54 @@
+// AgilePlus VitePress config.
+// The deploy workflow runs with `working-directory: docs`, so this config is
+// loaded as docs/.vitepress/config.mts. srcDir: '.' means VitePress treats the
+// docs/ directory itself as the content root — existing docs/requirements/*.md,
+// docs/tooling.md etc. are served directly without moving files.
+//
+// Base-path: served at kooshapari.github.io/AgilePlus/ → base='/AgilePlus/' on
+// GitHub Pages. No custom domain is configured. If a custom domain is added,
+// set PHENOTYPE_CUSTOM_DOMAIN=true in the deploy workflow and add a CNAME file
+// under docs/public/.
+import { createPhenotypeConfig } from '@phenotype/docs/config'
+
+const isPagesBuild =
+  process.env.GITHUB_ACTIONS === 'true' || process.env.GITHUB_PAGES === 'true'
+const repoName = process.env.GITHUB_REPOSITORY?.split('/')[1] ?? 'AgilePlus'
+// Honor custom-domain override: PHENOTYPE_CUSTOM_DOMAIN=true → serve from /
+const customDomain = process.env.PHENOTYPE_CUSTOM_DOMAIN === 'true'
+const docsBase = customDomain ? '/' : isPagesBuild ? `/${repoName}/` : '/'
+
+export default createPhenotypeConfig({
+  title: 'AgilePlus',
+  description: 'Phenotype-org spec-driven development platform',
+  srcDir: '.',
+  base: docsBase,
+  githubOrg: 'KooshaPari',
+  githubRepo: repoName,
+
+  nav: [
+    { text: 'Requirements', link: '/requirements/agileplus-frnfr' },
+    { text: 'Tooling', link: '/tooling' },
+  ],
+
+  sidebar: {
+    '/requirements/': [
+      {
+        text: 'Requirements',
+        items: [
+          { text: 'AgilePlus FR/NFR', link: '/requirements/agileplus-frnfr' },
+          { text: 'AuthVault FR/NFR', link: '/requirements/authvault-frnfr' },
+          { text: 'PhenoMCP FR/NFR', link: '/requirements/phenomcp-frnfr' },
+          {
+            text: 'PhenoObservability FR/NFR',
+            link: '/requirements/phenoobservability-frnfr',
+          },
+          {
+            text: 'Phenotype Voxel FR/NFR',
+            link: '/requirements/phenotype-voxel-frnfr',
+          },
+          { text: 'Tracera FR/NFR', link: '/requirements/tracera-frnfr' },
+        ],
+      },
+    ],
+  },
+})

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1,0 +1,23 @@
+---
+layout: home
+
+hero:
+  name: "AgilePlus"
+  text: "Spec-driven development platform"
+  tagline: Requirement traceability from FR/NFR to code to test to PR
+  actions:
+    - theme: brand
+      text: Requirements
+      link: /requirements/agileplus-frnfr
+    - theme: alt
+      text: Tooling
+      link: /tooling
+
+features:
+  - title: Requirements traceability
+    details: Every feature traces to a FR/NFR in Tracera, wired to Epic/Story in AgilePlus.
+  - title: Multi-project coverage
+    details: FR/NFR specs for AgilePlus, AuthVault, PhenoMCP, PhenoObservability, Voxel, Tracera.
+  - title: Spec-driven delivery
+    details: TDD/BDD/SDD/CDD/DDD methodologies enforced via pre-commit hooks and CI gates.
+---

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,23 @@
+---
+layout: home
+
+hero:
+  name: "AgilePlus"
+  text: "Spec-driven development platform"
+  tagline: Requirement traceability from FR/NFR to code to test to PR
+  actions:
+    - theme: brand
+      text: Requirements
+      link: /requirements/agileplus-frnfr
+    - theme: alt
+      text: Tooling
+      link: /tooling
+
+features:
+  - title: Requirements traceability
+    details: Every feature traces to a FR/NFR in Tracera, wired to Epic/Story in AgilePlus.
+  - title: Multi-project coverage
+    details: FR/NFR specs for AgilePlus, AuthVault, PhenoMCP, PhenoObservability, Voxel, Tracera.
+  - title: Spec-driven delivery
+    details: TDD/BDD/SDD/CDD/DDD methodologies enforced via pre-commit hooks and CI gates.
+---

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "agileplus-docs",
+  "version": "0.1.0",
+  "private": true,
+  "description": "AgilePlus documentation site (VitePress)",
+  "type": "module",
+  "scripts": {
+    "docs:dev": "vitepress dev docs",
+    "docs:build": "vitepress build docs",
+    "docs:preview": "vitepress preview docs"
+  },
+  "dependencies": {
+    "vitepress": "^1.5.0",
+    "vue": "^3.5.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.8.0"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  }
+}


### PR DESCRIPTION
## **User description**
## Summary
- Adds missing `docs/.vitepress/config.mts`, `docs/package.json`, and `docs/index.md` so the VitePress Pages workflow can actually build (was failing with 'cannot find package.json')
- Fixes `deploy.yml` node_modules symlink path (`docs/node_modules/` → `node_modules/` relative to `working-directory: docs`)
- Fixes artifact path (`docs/docs/.vitepress/dist` → `docs/.vitepress/dist`) to match `srcDir: '.'` config
- Removes stale `PHENOTYPE_CUSTOM_DOMAIN=true` — this site has no custom domain and needs the `/AgilePlus/` base prefix preserved
- Base path correctly set to `/AgilePlus/` for `kooshapari.github.io/AgilePlus/`

## Test plan
- [ ] Deploy workflow passes (was failing at 'Install dependencies' step)
- [ ] Built site assets reference `/AgilePlus/assets/...` not `/assets/...`
- [ ] Requirements markdown pages render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only and CI wiring changes with no application auth, data, or runtime behavior impact; main risk is a misconfigured VitePress build path if local scripts disagree with `srcDir`.
> 
> **Overview**
> Adds the missing **VitePress docs package** (`docs/package.json`, `docs/.vitepress/config.mts`, home `docs/index.md`) so CI can install dependencies and build the site instead of failing on a absent manifest.
> 
> **Deploy workflow** (`deploy.yml`) is aligned with `working-directory: docs`: the `@phenotype/docs` symlink now lands in `node_modules/@phenotype` (not a nested `docs/node_modules`), the Pages artifact path is **`docs/.vitepress/dist`** to match `srcDir: '.'`, and **`PHENOTYPE_CUSTOM_DOMAIN` is no longer forced** so the site keeps the **`/AgilePlus/`** base on `kooshapari.github.io/AgilePlus/`.
> 
> The new config wires **nav/sidebar** to existing requirement and tooling markdown and sets **base** from GitHub Pages vs optional custom-domain env.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25cc3d4fd2bd0b0444ee69882b1f416eee331f9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Set up the AgilePlus docs site and fix GitHub Pages deployment**

### What Changed
- Adds the missing VitePress docs home page and site settings so the documentation site can build and show the AgilePlus landing page
- Restores the GitHub Pages deploy flow by fixing where dependencies are linked and where the built site is uploaded from
- Keeps the site base path set for `/AgilePlus/` on GitHub Pages instead of forcing a custom domain path

### Impact
`✅ Docs site can build and deploy again`
`✅ AgilePlus homepage appears on GitHub Pages`
`✅ Fewer broken links and missing assets on the published docs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
