### PR TITLE
fix(deploy): symlink vitepress into phenodocs to fix ERR_MODULE_NOT_FOUND

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,13 +33,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Install consumer dependencies first so node_modules/vitepress exists
+          bun install
           # Link @phenotype/docs from the cloned phenodocs workspace
           mkdir -p node_modules/@phenotype
           ln -sf /tmp/phenodocs/packages/docs node_modules/@phenotype/docs
-          # Configure npm for GitHub Packages
-          echo "@phenotype:registry=https://npm.pkg.github.com" >> ~/.npmrc
-          echo "//npm.pkg.github.com/:_authToken=\${GITHUB_TOKEN}" >> ~/.npmrc
-          bun install
+          # Expose vitepress to phenodocs so its config/index.ts can resolve it
+          mkdir -p /tmp/phenodocs/node_modules
+          ln -sf "$(pwd)/node_modules/vitepress" /tmp/phenodocs/node_modules/vitepress
 
       - name: Build VitePress site
         working-directory: docs

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,9 +5,9 @@
   "description": "AgilePlus documentation site (VitePress)",
   "type": "module",
   "scripts": {
-    "docs:dev": "vitepress dev docs",
-    "docs:build": "vitepress build docs",
-    "docs:preview": "vitepress preview docs"
+    "docs:dev": "vitepress dev .",
+    "docs:build": "vitepress build .",
+    "docs:preview": "vitepress preview ."
   },
   "dependencies": {
     "vitepress": "^1.5.0",


### PR DESCRIPTION
## **User description**
## Summary
- phenodocs/packages/docs/src/config/index.ts imports 'vitepress' but Node resolves from /tmp/phenodocs/ which has no node_modules — causing ERR_MODULE_NOT_FOUND at build time
- Fix: install consumer deps first (so node_modules/vitepress exists), then symlink it into /tmp/phenodocs/node_modules/

## Test plan
- [ ] Deploy workflow build step passes without ERR_MODULE_NOT_FOUND
- [ ] Site deploys to kooshapari.github.io/AgilePlus/

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to dependency install and symlinks in the deploy workflow; no runtime app or auth behavior is affected.
> 
> **Overview**
> Fixes the GitHub Pages **Install dependencies** step so VitePress builds succeed when `@phenotype/docs` is linked from a cloned phenodocs repo.
> 
> **Install order** is changed: `bun install` runs in `docs/` *before* symlinking `@phenotype/docs`, so `node_modules/vitepress` exists locally. A symlink then exposes that package at `/tmp/phenodocs/node_modules/vitepress`, letting phenodocs config that imports `vitepress` resolve the module from the clone’s tree instead of failing with `ERR_MODULE_NOT_FOUND`.
> 
> The workflow **drops GitHub Packages `.npmrc` setup** for `@phenotype`; the docs package is supplied only via the filesystem link to `/tmp/phenodocs/packages/docs`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3439c778966fc00e7b66ddf450928260321254c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Fix the docs deploy workflow so the VitePress build can resolve its dependencies**

### What Changed
- Installs the docs package before linking the shared docs workspace, so the build can find VitePress during deploy
- Exposes the local VitePress package to the cloned `phenodocs` repo so its config can load without failing
- Removes the GitHub Packages npm config step that is no longer needed for this deploy flow

### Impact
`✅ Fewer deploy build failures`
`✅ Clearer docs publishing`
`✅ Less setup needed for GitHub Pages deploys`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
