### PR TITLE
feat: Planify<->AgilePlus REST shim adapter (frontend candidate #1 wiring)

### DIFF
--- a/tools/planify-shim/.gitignore
+++ b/tools/planify-shim/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+package-lock.json
+*.log

--- a/tools/planify-shim/README.md
+++ b/tools/planify-shim/README.md
@@ -1,0 +1,98 @@
+# planify-shim
+
+A thin REST adapter that exposes **Plane's HTTP API shape** on top of the
+**AgilePlus Axum backend**, so the **Planify** frontend (`apps/web`, a Plane
+fork) can render a populated board against real AgilePlus data — without any
+changes to AgilePlus or to Planify's frontend code.
+
+This makes Planify viable as **frontend candidate #1** for AgilePlus.
+
+## Why a shim
+
+| Planify (`apps/web`) expects | AgilePlus provides |
+| --- | --- |
+| Plane REST at `VITE_API_BASE_URL` (default `:8000`) | Rust Axum API on `:4000` |
+| `/api/workspaces/`, `/api/.../projects/`, `/api/.../issues/`, CSRF+session cookie auth | `/api/v1/features`, `/api/v1/features/:slug/work-packages`, `X-API-Key`/Bearer auth |
+| Plane object model (workspace / project / issue / state) | AgilePlus model (feature / work-package / state-machine) |
+
+The shim sits on `:8000`, speaks Plane's dialect to the browser, and translates
+to AgilePlus's REST + auth on the backend.
+
+## Mapping
+
+| Plane concept | AgilePlus source |
+| --- | --- |
+| Workspace (single, slug `agileplus`) | the AgilePlus root |
+| Project | `Feature` (`GET /api/v1/features`) |
+| Project states (board columns) | fixed set derived from `FeatureState` (Created → Planned → Implementing → Validated → Shipped), grouped into Plane groups (backlog/unstarted/started/completed) |
+| Issue | `WorkPackage` (`GET /api/v1/features/:slug/work-packages`) |
+| Issue state group | `WorkPackage.state` snapped onto the nearest column group |
+| `me` user / members / labels | local stubs (read-only review) |
+
+UUIDs required by Plane are derived deterministically (SHA-256 of a namespaced
+key) so the same feature/work-package always maps to the same id.
+
+## Endpoints implemented (read path for a board)
+
+- `GET /auth/get-csrf-token/` — stub CSRF token + cookie
+- `GET /api/instances/` — instance config (setup done, signup off)
+- `GET /api/users/me/` (+ `/profile/`, `/settings/`, `/workspaces/`)
+- `GET /api/workspaces/:slug/` (+ `/members/`)
+- `GET /api/workspaces/:slug/projects/` (+ `/details/`, `/:id/`)
+- `GET /api/workspaces/:slug/projects/:id/project-members/me/`, `/members/`
+- `GET /api/workspaces/:slug/projects/:id/states/`
+- `GET /api/workspaces/:slug/projects/:id/issue-labels/`
+- `GET /api/workspaces/:slug/projects/:id/issues/` → Plane `TIssuesResponse`
+- `GET /shim/health` — shim + AgilePlus reachability check
+
+Auth is a **local-review stub**: a fixed CSRF token and a synthetic "me" user
+are returned so the SPA treats the session as authenticated. The shim itself
+authenticates to AgilePlus with `X-API-Key`. Writes are out of scope.
+Any unmapped read returns `[]` (200) to avoid the SPA's 401 redirect loop.
+
+## Run sequence + ports
+
+```bash
+# 1. AgilePlus API on :4000 (from the AgilePlus repo root)
+AGILEPLUS_API_KEY=dev-api-key cargo run -p agileplus-api      # serves :4000
+
+# 2. The shim on :8000 (this dir)
+npm install
+AGILEPLUS_API_URL=http://localhost:4000 \
+AGILEPLUS_API_KEY=dev-api-key \
+PORT=8000 \
+WEB_ORIGIN=http://localhost:4400 \
+npm start                                                     # serves :8000
+
+# 3. Planify frontend on :4400 (from C:/Users/koosh/Dev/Planify)
+#    apps/web/.env already has VITE_API_BASE_URL="http://localhost:8000"
+pnpm --filter web dev                                         # serves :4400
+```
+
+Open `http://localhost:4400`. The board renders the AgilePlus workspace with
+one project per Feature and one card per Work-Package, laid out across the
+state columns.
+
+## Config (env)
+
+| Var | Default | Meaning |
+| --- | --- | --- |
+| `PORT` | `8000` | shim listen port (must match `VITE_API_BASE_URL`) |
+| `AGILEPLUS_API_URL` | `http://localhost:4000` | AgilePlus Axum base URL |
+| `AGILEPLUS_API_KEY` | `dev-api-key` | key sent as `X-API-Key` to AgilePlus |
+| `WEB_ORIGIN` | `http://localhost:4400` | allowed credentialed CORS origin |
+
+## What renders / what doesn't
+
+**Renders:** workspace, project list, board columns (states), issues/cards
+grouped by state, basic project + issue detail. Verified end-to-end against a
+fixtured AgilePlus (features → projects, work-packages → issues, correct
+Plane state groups).
+
+**Gaps (intentional, read-only candidate review):**
+- Writes (create/update/transition) are not mapped — board is read-only.
+- Labels, cycles, modules, members beyond `me`, comments, attachments return
+  empty stubs.
+- Auth is a stub (no real login/session); not for shared/prod use.
+- One synthetic workspace; AgilePlus modules/projects hierarchy is flattened
+  to Feature=Project.

--- a/tools/planify-shim/package.json
+++ b/tools/planify-shim/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.21.2"
+  }
+}

--- a/tools/planify-shim/src/agileplus-client.js
+++ b/tools/planify-shim/src/agileplus-client.js
@@ -1,0 +1,34 @@
+/**
+ * Thin client for the AgilePlus Axum REST API.
+ *
+ * AgilePlus exposes (auth: `X-API-Key` or `Authorization: Bearer`):
+ *   GET /api/v1/features                       -> [FeatureResponse]
+ *   GET /api/v1/features/:slug                  -> FeatureResponse
+ *   GET /api/v1/features/:slug/work-packages    -> [WorkPackageResponse]
+ *
+ * FeatureResponse:     { id, slug, name, state, target_branch, created_at, updated_at }
+ * WorkPackageResponse: { id, feature_id, title, state, sequence, acceptance_criteria,
+ *                        pr_url, created_at, updated_at }
+ */
+
+const BASE = process.env.AGILEPLUS_API_URL || "http://localhost:4000";
+const API_KEY = process.env.AGILEPLUS_API_KEY || "dev-api-key";
+
+async function call(path) {
+  const res = await fetch(`${BASE}${path}`, {
+    headers: { "X-API-Key": API_KEY, Accept: "application/json" },
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`AgilePlus ${path} -> ${res.status} ${body}`);
+  }
+  return res.json();
+}
+
+export const agileplus = {
+  base: BASE,
+  listFeatures: () => call("/api/v1/features"),
+  getFeature: (slug) => call(`/api/v1/features/${encodeURIComponent(slug)}`),
+  listWorkPackages: (slug) =>
+    call(`/api/v1/features/${encodeURIComponent(slug)}/work-packages`),
+};

--- a/tools/planify-shim/src/map.js
+++ b/tools/planify-shim/src/map.js
@@ -1,0 +1,179 @@
+/**
+ * Maps AgilePlus domain objects onto Plane REST shapes.
+ *
+ *   AgilePlus root          -> single Plane workspace  (slug "agileplus")
+ *   AgilePlus Feature/Epic  -> Plane project
+ *   AgilePlus WorkPackage   -> Plane issue
+ *   Feature/WP state        -> Plane state (board column), grouped by Plane group
+ *
+ * Plane requires UUIDs for ids; we derive stable v5-ish UUIDs from a namespace
+ * + a string key so the same Feature/WP always maps to the same id across calls.
+ */
+import { createHash } from "node:crypto";
+
+export const WORKSPACE_SLUG = "agileplus";
+export const WORKSPACE_ID = uuidFrom("workspace", "agileplus");
+export const USER_ID = uuidFrom("user", "dogfood@agileplus.dev");
+
+/** Deterministic UUID (name-based, formatted as a v4-shaped string) from any key. */
+export function uuidFrom(ns, key) {
+  const h = createHash("sha256").update(`${ns}:${key}`).digest("hex");
+  return [
+    h.slice(0, 8),
+    h.slice(8, 12),
+    `4${h.slice(13, 16)}`,
+    `8${h.slice(17, 20)}`,
+    h.slice(20, 32),
+  ].join("-");
+}
+
+const NOW = new Date().toISOString();
+
+/**
+ * AgilePlus state name -> Plane state group.
+ * Plane groups: backlog | unstarted | started | completed | cancelled
+ */
+const STATE_GROUP = {
+  created: "backlog",
+  specified: "backlog",
+  researched: "unstarted",
+  planned: "unstarted",
+  implementing: "started",
+  validated: "started",
+  shipped: "completed",
+  retrospected: "completed",
+  // work-package states (best-effort; unknown -> unstarted)
+  todo: "unstarted",
+  doing: "started",
+  done: "completed",
+  blocked: "started",
+};
+
+const GROUP_COLOR = {
+  backlog: "#a3a3a3",
+  unstarted: "#3f76ff",
+  started: "#f59e0b",
+  completed: "#16a34a",
+  cancelled: "#ef4444",
+};
+
+export function stateGroup(name) {
+  return STATE_GROUP[String(name || "").toLowerCase()] || "unstarted";
+}
+
+/** Build the canonical, fixed set of board columns (states) for a project. */
+export function statesForProject(projectId) {
+  const order = ["created", "planned", "implementing", "validated", "shipped"];
+  return order.map((name, i) => {
+    const group = stateGroup(name);
+    return {
+      id: uuidFrom("state", `${projectId}:${name}`),
+      name: name.charAt(0).toUpperCase() + name.slice(1),
+      color: GROUP_COLOR[group],
+      group,
+      default: i === 0,
+      sequence: (i + 1) * 1000,
+      project: projectId,
+      workspace: WORKSPACE_ID,
+      description: "",
+      created_at: NOW,
+      updated_at: NOW,
+    };
+  });
+}
+
+/** AgilePlus Feature -> Plane project. */
+export function featureToProject(f) {
+  const id = uuidFrom("project", f.slug);
+  const identifier = (f.slug || `F${f.id}`)
+    .replace(/[^a-zA-Z0-9]/g, "")
+    .slice(0, 5)
+    .toUpperCase() || `F${f.id}`;
+  return {
+    id,
+    name: f.name || f.slug,
+    identifier,
+    description: `AgilePlus feature '${f.slug}' (state: ${f.state}, branch: ${f.target_branch})`,
+    network: 2,
+    workspace: WORKSPACE_ID,
+    cover_image: null,
+    icon_prop: null,
+    emoji: null,
+    logo_props: {},
+    archived_at: null,
+    is_member: true,
+    member_role: 20,
+    total_members: 1,
+    total_cycles: 0,
+    total_modules: 0,
+    project_lead: USER_ID,
+    default_assignee: USER_ID,
+    cycle_view: true,
+    module_view: true,
+    issue_views_view: true,
+    page_view: true,
+    inbox_view: false,
+    guest_view_all_features: false,
+    created_at: f.created_at || NOW,
+    updated_at: f.updated_at || NOW,
+    created_by: USER_ID,
+    updated_by: USER_ID,
+    sort_order: f.id ?? 0,
+    estimate: null,
+    _agileplus_slug: f.slug,
+  };
+}
+
+/** AgilePlus WorkPackage -> Plane issue. */
+export function wpToIssue(wp, project) {
+  const id = uuidFrom("issue", `${project.id}:${wp.id}`);
+  const group = stateGroup(wp.state);
+  const stateId = uuidFrom("state", `${project.id}:${nearestColumn(wp.state)}`);
+  return {
+    id,
+    name: wp.title || `WP-${wp.id}`,
+    description_html: `<p>${escapeHtml(wp.acceptance_criteria || "")}</p>`,
+    description_stripped: wp.acceptance_criteria || "",
+    priority: "none",
+    start_date: null,
+    target_date: null,
+    sequence_id: wp.sequence ?? wp.id ?? 0,
+    sort_order: (wp.sequence ?? wp.id ?? 0) * 1000,
+    state_id: stateId,
+    state__group: group,
+    project_id: project.id,
+    workspace_id: WORKSPACE_ID,
+    parent_id: null,
+    cycle_id: null,
+    module_ids: [],
+    label_ids: [],
+    assignee_ids: [],
+    estimate_point: null,
+    sub_issues_count: 0,
+    attachment_count: 0,
+    link_count: wp.pr_url ? 1 : 0,
+    is_draft: false,
+    archived_at: null,
+    completed_at: group === "completed" ? wp.updated_at || NOW : null,
+    created_at: wp.created_at || NOW,
+    updated_at: wp.updated_at || NOW,
+    created_by: USER_ID,
+    updated_by: USER_ID,
+  };
+}
+
+// Snap any AgilePlus state onto one of the 5 fixed board columns.
+function nearestColumn(name) {
+  const g = stateGroup(name);
+  return (
+    { backlog: "created", unstarted: "planned", started: "implementing", completed: "shipped" }[g] ||
+    "planned"
+  );
+}
+
+function escapeHtml(s) {
+  return String(s)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}

--- a/tools/planify-shim/src/server.js
+++ b/tools/planify-shim/src/server.js
@@ -1,0 +1,271 @@
+/**
+ * planify-shim — exposes a subset of Plane's REST API (the shape the Planify
+ * frontend `apps/web` expects) backed by the AgilePlus Axum API.
+ *
+ * Listens on :8000 (Planify's VITE_API_BASE_URL default). Allows credentialed
+ * CORS from the apps/web dev origin (:4400).
+ *
+ * Auth is a local-review STUB: a fixed CSRF token + a synthetic "me" user are
+ * returned so apps/web treats the session as authenticated. The shim itself
+ * authenticates to AgilePlus with X-API-Key (AGILEPLUS_API_KEY).
+ *
+ * READ endpoints implemented (enough to render a populated board):
+ *   GET  /auth/get-csrf-token/
+ *   GET  /api/instances/
+ *   GET  /api/users/me/  (+ /settings/ /profile/ /workspaces/)
+ *   GET  /api/workspaces/:slug/
+ *   GET  /api/workspaces/:slug/members/
+ *   GET  /api/workspaces/:slug/projects/  (+ /details/)
+ *   GET  /api/workspaces/:slug/projects/:projectId/
+ *   GET  /api/workspaces/:slug/projects/:projectId/project-members/me/
+ *   GET  /api/workspaces/:slug/projects/:projectId/members/
+ *   GET  /api/workspaces/:slug/projects/:projectId/states/
+ *   GET  /api/workspaces/:slug/projects/:projectId/issue-labels/
+ *   GET  /api/workspaces/:slug/projects/:projectId/issues/  (grouped TIssuesResponse)
+ */
+import cors from "cors";
+import express from "express";
+import { agileplus } from "./agileplus-client.js";
+import {
+  USER_ID,
+  WORKSPACE_ID,
+  WORKSPACE_SLUG,
+  featureToProject,
+  statesForProject,
+  wpToIssue,
+} from "./map.js";
+
+const PORT = Number(process.env.PORT || 8000);
+const WEB_ORIGIN = process.env.WEB_ORIGIN || "http://localhost:4400";
+const CSRF = "planify-shim-csrf-token";
+
+const app = express();
+app.use(express.json());
+app.use(
+  cors({
+    origin: [WEB_ORIGIN, "http://127.0.0.1:4400"],
+    credentials: true,
+    exposedHeaders: ["set-cookie"],
+  }),
+);
+
+const log = (req, _res, next) => {
+  console.log(`${req.method} ${req.originalUrl}`);
+  next();
+};
+app.use(log);
+
+const NOW = new Date().toISOString();
+
+// ---- find an AgilePlus feature by the project UUID we synthesised ----
+async function featuresIndex() {
+  const features = await agileplus.listFeatures();
+  const projects = features.map(featureToProject);
+  const byId = new Map(projects.map((p) => [p.id, p]));
+  return { features, projects, byId };
+}
+
+// ───────────────────────────── Auth / instance ─────────────────────────────
+
+app.get("/auth/get-csrf-token/", (_req, res) => {
+  res.cookie("csrftoken", CSRF, { sameSite: "lax" });
+  res.json({ csrf_token: CSRF });
+});
+
+app.get("/api/instances/", (_req, res) => {
+  res.json({
+    instance: {
+      id: "agileplus-instance",
+      instance_name: "AgilePlus (via planify-shim)",
+      is_setup_done: true,
+      is_activated: true,
+      is_signup_screen_visible: false,
+      is_telemetry_enabled: false,
+      product: "plane-ce",
+      version: "shim-0.1.0",
+      workspaces_exist: true,
+    },
+    config: { is_smtp_configured: false, github_app_name: "", magic_login: false, email_password_login: true },
+  });
+});
+
+const ME = {
+  id: USER_ID,
+  username: "dogfood",
+  email: "dogfood@agileplus.dev",
+  first_name: "AgilePlus",
+  last_name: "Dogfood",
+  display_name: "AgilePlus Dogfood",
+  avatar: "",
+  is_active: true,
+  is_onboarded: true,
+  is_email_verified: true,
+  is_tour_completed: true,
+  onboarding_step: { profile_complete: true, workspace_create: true, workspace_invite: true, workspace_join: true },
+  last_workspace_id: WORKSPACE_ID,
+  theme: {},
+  created_at: NOW,
+  updated_at: NOW,
+};
+
+app.get("/api/users/me/", (_req, res) => res.json(ME));
+app.get("/api/users/me/profile/", (_req, res) =>
+  res.json({
+    id: USER_ID,
+    user: USER_ID,
+    role: "Engineering",
+    last_workspace_id: WORKSPACE_ID,
+    theme: {},
+    onboarding_step: ME.onboarding_step,
+    is_onboarded: true,
+    is_tour_completed: true,
+    use_case: "Engineering",
+  }),
+);
+app.get("/api/users/me/settings/", (_req, res) =>
+  res.json({
+    id: USER_ID,
+    workspace: { last_workspace_id: WORKSPACE_ID, last_workspace_slug: WORKSPACE_SLUG, fallback_workspace_id: WORKSPACE_ID, fallback_workspace_slug: WORKSPACE_SLUG, invites: 0 },
+  }),
+);
+
+const workspaceObj = () => ({
+  id: WORKSPACE_ID,
+  name: "AgilePlus",
+  slug: WORKSPACE_SLUG,
+  owner: USER_ID,
+  logo: "",
+  logo_url: null,
+  total_members: 1,
+  total_issues: 0,
+  role: 20,
+  organization_size: "1-10",
+  created_at: NOW,
+  updated_at: NOW,
+});
+
+app.get("/api/users/me/workspaces/", (_req, res) => res.json([workspaceObj()]));
+app.get("/api/workspaces/:slug/", (_req, res) => res.json(workspaceObj()));
+
+const memberMe = {
+  id: USER_ID,
+  member: ME,
+  role: 20,
+  is_active: true,
+  workspace: WORKSPACE_ID,
+  created_at: NOW,
+  updated_at: NOW,
+};
+app.get("/api/workspaces/:slug/members/", (_req, res) => res.json([memberMe]));
+app.get("/api/users/me/workspaces/:slug/", (_req, res) => res.json(workspaceObj()));
+
+// ───────────────────────────── Projects ─────────────────────────────
+
+async function projectsHandler(_req, res) {
+  try {
+    const { projects } = await featuresIndex();
+    res.json(projects);
+  } catch (e) {
+    res.status(502).json({ error: String(e.message || e) });
+  }
+}
+app.get("/api/workspaces/:slug/projects/", projectsHandler);
+app.get("/api/workspaces/:slug/projects/details/", projectsHandler);
+
+app.get("/api/workspaces/:slug/projects/:projectId/", async (req, res) => {
+  try {
+    const { byId } = await featuresIndex();
+    const p = byId.get(req.params.projectId);
+    if (!p) return res.status(404).json({ error: "project not found" });
+    res.json(p);
+  } catch (e) {
+    res.status(502).json({ error: String(e.message || e) });
+  }
+});
+
+const projectMemberMe = (projectId) => ({
+  id: USER_ID,
+  member: ME,
+  role: 20,
+  is_active: true,
+  project: projectId,
+  workspace: WORKSPACE_ID,
+  created_at: NOW,
+  updated_at: NOW,
+});
+app.get("/api/workspaces/:slug/projects/:projectId/project-members/me/", (req, res) =>
+  res.json(projectMemberMe(req.params.projectId)),
+);
+app.get("/api/workspaces/:slug/projects/:projectId/members/", (req, res) =>
+  res.json([projectMemberMe(req.params.projectId)]),
+);
+
+// States (board columns), labels.
+app.get("/api/workspaces/:slug/projects/:projectId/states/", (req, res) =>
+  res.json(statesForProject(req.params.projectId)),
+);
+app.get("/api/workspaces/:slug/states/", async (_req, res) => {
+  try {
+    const { projects } = await featuresIndex();
+    res.json(projects.flatMap((p) => statesForProject(p.id)));
+  } catch (e) {
+    res.status(502).json({ error: String(e.message || e) });
+  }
+});
+app.get("/api/workspaces/:slug/projects/:projectId/issue-labels/", (_req, res) => res.json([]));
+app.get("/api/workspaces/:slug/labels/", (_req, res) => res.json([]));
+
+// ───────────────────────────── Issues ─────────────────────────────
+//
+// Plane's TIssuesResponse (ungrouped) is:
+//   { grouped_by, sub_grouped_by, total_count, count, total_pages, extra_stats,
+//     results: TIssue[] }
+
+async function issuesHandler(req, res) {
+  try {
+    const { byId } = await featuresIndex();
+    const project = byId.get(req.params.projectId);
+    if (!project) return res.status(404).json({ error: "project not found" });
+    const wps = await agileplus.listWorkPackages(project._agileplus_slug);
+    const results = wps.map((wp) => wpToIssue(wp, project));
+    res.json({
+      grouped_by: null,
+      sub_grouped_by: null,
+      total_count: results.length,
+      count: results.length,
+      total_pages: 1,
+      next_page_results: false,
+      prev_page_results: false,
+      extra_stats: null,
+      results,
+    });
+  } catch (e) {
+    res.status(502).json({ error: String(e.message || e) });
+  }
+}
+app.get("/api/workspaces/:slug/projects/:projectId/issues/", issuesHandler);
+app.get("/api/workspaces/:slug/projects/:projectId/v2/issues/", issuesHandler);
+app.get("/api/workspaces/:slug/projects/:projectId/issues-detail/", issuesHandler);
+
+// Health for quick sanity check.
+app.get("/shim/health", async (_req, res) => {
+  try {
+    const f = await agileplus.listFeatures();
+    res.json({ ok: true, agileplus: agileplus.base, features: f.length });
+  } catch (e) {
+    res.status(502).json({ ok: false, error: String(e.message || e) });
+  }
+});
+
+// Default: empty-but-valid 200 so unimplemented reads don't 401-redirect-loop
+// the frontend. (Writes are out of scope for read-only candidate review.)
+app.use((req, res) => {
+  console.warn(`UNMAPPED ${req.method} ${req.originalUrl} -> []`);
+  res.json([]);
+});
+
+app.listen(PORT, () => {
+  console.log(`planify-shim listening on http://localhost:${PORT}`);
+  console.log(`  -> AgilePlus backend: ${agileplus.base}`);
+  console.log(`  -> CORS origin:       ${WEB_ORIGIN}`);
+});


### PR DESCRIPTION
## **User description**
## Summary
Adds **`tools/planify-shim`** — a thin Node/Express adapter that lets the **Planify** frontend (`apps/web`, a Plane fork on `:4400`) render real **AgilePlus** data, wiring up frontend **candidate #1**.

Planify expects Plane's REST API on `:8000` (workspaces/projects/issues, CSRF+session). AgilePlus is a Rust Axum API on `:4000` (features/work-packages, `X-API-Key`). The shim bridges the two with **zero changes** to AgilePlus or to Planify's frontend.

## Mapping
| Plane | AgilePlus |
| --- | --- |
| workspace (`agileplus`) | root |
| project | `Feature` (`/api/v1/features`) |
| issue | `WorkPackage` (`/api/v1/features/:slug/work-packages`) |
| board columns | `FeatureState` -> Plane state groups (backlog/unstarted/started/completed) |

Deterministic SHA-256-derived UUIDs keep ids stable across calls. Auth is a local-review stub (CSRF + synthetic `me`); the shim authenticates to AgilePlus with `X-API-Key`.

## Endpoints (read path)
`/auth/get-csrf-token/`, `/api/instances/`, `/api/users/me/*`, `/api/workspaces/:slug/*`, `.../projects/*`, `.../states/`, `.../issue-labels/`, `.../issues/` (-> Plane `TIssuesResponse`), `/shim/health`. Unmapped reads return `[]` to avoid the SPA 401 loop.

## Run sequence
1. `AGILEPLUS_API_KEY=dev-api-key cargo run -p agileplus-api` -> `:4000`
2. `npm install && AGILEPLUS_API_URL=http://localhost:4000 PORT=8000 npm start` (in `tools/planify-shim`) -> `:8000`
3. `pnpm --filter web dev` in Planify -> `:4400` (`.env` already targets `:8000`)

## Verification
End-to-end against a fixtured AgilePlus: 2 features -> 2 projects, 3 work-packages -> 3 issues, correct state groups; auth/csrf/me return valid JSON. `/shim/health` reports `{ok:true, features:N}`.

## Gaps (intentional)
Read-only (no write mapping); labels/cycles/modules/comments stubbed empty; stub auth; Feature=Project flattening.

DO NOT MERGE — review wiring for candidate #1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Isolated dev tooling under `tools/` with stub auth and read-only GETs; no production AgilePlus or Planify code paths are modified.
> 
> **Overview**
> Adds **`tools/planify-shim`**, a new Node/Express service that speaks Plane’s REST shape on **:8000** while proxying read data from the AgilePlus Axum API on **:4000** with **`X-API-Key`**, so the Planify frontend can load a board without changes to either codebase.
> 
> **Mapping and behavior:** A single stub workspace (`agileplus`) is exposed; each AgilePlus **Feature** becomes a Plane **project** and each **WorkPackage** an **issue**, with SHA-256–derived UUIDs for stable IDs. Board **states** are a fixed five-column set (Created → Shipped) with AgilePlus states snapped into Plane groups (backlog/unstarted/started/completed). **`map.js`** holds the transforms; **`agileplus-client.js`** wraps `GET /api/v1/features` and work-package listing.
> 
> **HTTP surface:** Read-only GET handlers cover CSRF/instance, synthetic **`me`** / workspace / members, projects, states, empty labels, and **`TIssuesResponse`**-shaped issues (including v2/issues and issues-detail aliases). Stub CSRF cookie + credentialed CORS toward **`WEB_ORIGIN`** (:4400). Unmapped routes return **`[]`** with 200 to avoid SPA redirect loops; **`/shim/health`** checks AgilePlus reachability. Writes and real auth are explicitly out of scope (local dogfood only).
> 
> **Docs:** README documents port sequence, env vars, and intentional gaps (read-only, stub auth, flattened Feature=Project model).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acf18723ce4c3674cd5f6c1d3a562ccc5185ce39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Let the Planify frontend render real AgilePlus boards through a local REST shim**

### What Changed
- Added a local adapter that makes the Planify frontend talk to AgilePlus data using Plane-style workspace, project, state, and issue responses
- Planify can now show an authenticated-looking session, a single workspace, projects for AgilePlus features, and cards for work packages on the board
- Board columns and card states are mapped from AgilePlus states into Plane's fixed board groups so the board opens with usable lanes and populated items
- Updated the project docs and rich-media placeholders to include the new dashboard screenshots, capture status, and journey notes

### Impact
`✅ Planify can open against AgilePlus data`
`✅ Board columns and cards load with stable IDs`
`✅ Fewer empty or blocked frontend screens`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
