### PR TITLE
feat(desktop): native Electrobun shell (HMR) for AgilePlus

### DIFF
--- a/crates/agileplus-dashboard/desktop-electrobun/.env.example
+++ b/crates/agileplus-dashboard/desktop-electrobun/.env.example
@@ -1,0 +1,10 @@
+# Override renderer URL (default: http://localhost:5173)
+RENDERER_URL=http://localhost:5173
+
+# Path to process-compose.yml for one-click service boot
+# Leave unset to skip service boot
+SERVICES_COMPOSE_FILE=
+
+# Optional window size overrides
+# WINDOW_WIDTH=1400
+# WINDOW_HEIGHT=900

--- a/crates/agileplus-dashboard/desktop-electrobun/.gitignore
+++ b/crates/agileplus-dashboard/desktop-electrobun/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+build/
+dist/
+.env
+*.log

--- a/crates/agileplus-dashboard/desktop-electrobun/bun.lock
+++ b/crates/agileplus-dashboard/desktop-electrobun/bun.lock
@@ -1,0 +1,117 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@phenotype/desktop-shell",
+      "dependencies": {
+        "electrobun": "^1.18.1",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "typescript": "^5.7.0",
+      },
+    },
+  },
+  "packages": {
+    "@babylonjs/core": ["@babylonjs/core@7.54.3", "", {}, "sha512-P5ncXVd8GEUJLhwloP9V0oVwQYIrvZztguVeLlvd5Rx+9aQnenKjpV8auJ6SRsUlAmNZU4pFTKzwF6o2EUfhAw=="],
+
+    "@malept/cross-spawn-promise": ["@malept/cross-spawn-promise@1.1.1", "", { "dependencies": { "cross-spawn": "^7.0.1" } }, "sha512-RTBGWL5FWQcg9orDOCcp4LvItNzUPcyEU9bwaeJX0rJ1IQxzucC48Y0/sQLp/g6t99IQgAlGIaesJS+gTn7tVQ=="],
+
+    "@tootallnate/quickjs-emscripten": ["@tootallnate/quickjs-emscripten@0.23.0", "", {}, "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="],
+
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/node": ["@types/node@25.9.1", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg=="],
+
+    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
+    "ast-types": ["ast-types@0.13.4", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w=="],
+
+    "basic-ftp": ["basic-ftp@5.3.1", "", {}, "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "cross-spawn-windows-exe": ["cross-spawn-windows-exe@1.2.0", "", { "dependencies": { "@malept/cross-spawn-promise": "^1.1.0", "is-wsl": "^2.2.0", "which": "^2.0.2" } }, "sha512-mkLtJJcYbDCxEG7Js6eUnUNndWjyUZwJ3H7bErmmtOYU/Zb99DyUkpamuIZE0b3bhmJyZ7D90uS6f+CGxRRjOw=="],
+
+    "data-uri-to-buffer": ["data-uri-to-buffer@6.0.2", "", {}, "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "degenerator": ["degenerator@5.0.1", "", { "dependencies": { "ast-types": "^0.13.4", "escodegen": "^2.1.0", "esprima": "^4.0.1" } }, "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ=="],
+
+    "electrobun": ["electrobun@1.18.1", "", { "dependencies": { "@babylonjs/core": "^7.45.0", "@types/bun": "^1.3.8", "png-to-ico": "^2.1.8", "proxy-agent": "^6.5.0", "rcedit": "^4.0.1", "three": "^0.165.0" }, "bin": { "electrobun": "bin/electrobun.cjs" } }, "sha512-tgZ+WKGskn/1/Y5i1mpVCCkgRa1O31Tz7MIArBTK44GfPzT43uOq9c/HvxdQGrLeZV8ZvjK1lQrwqSXCgh6tvA=="],
+
+    "escodegen": ["escodegen@2.1.0", "", { "dependencies": { "esprima": "^4.0.1", "estraverse": "^5.2.0", "esutils": "^2.0.2" }, "optionalDependencies": { "source-map": "~0.6.1" }, "bin": { "esgenerate": "bin/esgenerate.js", "escodegen": "bin/escodegen.js" } }, "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w=="],
+
+    "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
+
+    "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
+
+    "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
+
+    "get-uri": ["get-uri@6.0.5", "", { "dependencies": { "basic-ftp": "^5.0.2", "data-uri-to-buffer": "^6.0.2", "debug": "^4.3.4" } }, "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg=="],
+
+    "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
+
+    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
+    "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
+
+    "is-docker": ["is-docker@2.2.1", "", { "bin": { "is-docker": "cli.js" } }, "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="],
+
+    "is-wsl": ["is-wsl@2.2.0", "", { "dependencies": { "is-docker": "^2.0.0" } }, "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
+
+    "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "netmask": ["netmask@2.1.1", "", {}, "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA=="],
+
+    "pac-proxy-agent": ["pac-proxy-agent@7.2.0", "", { "dependencies": { "@tootallnate/quickjs-emscripten": "^0.23.0", "agent-base": "^7.1.2", "debug": "^4.3.4", "get-uri": "^6.0.1", "http-proxy-agent": "^7.0.0", "https-proxy-agent": "^7.0.6", "pac-resolver": "^7.0.1", "socks-proxy-agent": "^8.0.5" } }, "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA=="],
+
+    "pac-resolver": ["pac-resolver@7.0.1", "", { "dependencies": { "degenerator": "^5.0.0", "netmask": "^2.0.2" } }, "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "png-to-ico": ["png-to-ico@2.1.8", "", { "dependencies": { "@types/node": "^17.0.36", "minimist": "^1.2.6", "pngjs": "^6.0.0" }, "bin": { "png-to-ico": "bin/cli.js" } }, "sha512-Nf+IIn/cZ/DIZVdGveJp86NG5uNib1ZXMiDd/8x32HCTeKSvgpyg6D/6tUBn1QO/zybzoMK0/mc3QRgAyXdv9w=="],
+
+    "pngjs": ["pngjs@6.0.0", "", {}, "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg=="],
+
+    "proxy-agent": ["proxy-agent@6.5.0", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "http-proxy-agent": "^7.0.1", "https-proxy-agent": "^7.0.6", "lru-cache": "^7.14.1", "pac-proxy-agent": "^7.1.0", "proxy-from-env": "^1.1.0", "socks-proxy-agent": "^8.0.5" } }, "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A=="],
+
+    "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
+
+    "rcedit": ["rcedit@4.0.1", "", { "dependencies": { "cross-spawn-windows-exe": "^1.1.0" } }, "sha512-bZdaQi34krFWhrDn+O53ccBDw0MkAT2Vhu75SqhtvhQu4OPyFM4RoVheyYiVQYdjhUi6EJMVWQ0tR6bCIYVkUg=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "smart-buffer": ["smart-buffer@4.2.0", "", {}, "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="],
+
+    "socks": ["socks@2.8.9", "", { "dependencies": { "ip-address": "^10.1.1", "smart-buffer": "^4.2.0" } }, "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw=="],
+
+    "socks-proxy-agent": ["socks-proxy-agent@8.0.5", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "socks": "^2.8.3" } }, "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw=="],
+
+    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
+    "three": ["three@0.165.0", "", {}, "sha512-cc96IlVYGydeceu0e5xq70H8/yoVT/tXBxV/W8A/U6uOq7DXc4/s1Mkmnu6SqoYGhSRWWYFOhVwvq6V0VtbplA=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "png-to-ico/@types/node": ["@types/node@17.0.45", "", {}, "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw=="],
+  }
+}

--- a/crates/agileplus-dashboard/desktop-electrobun/electrobun.config.ts
+++ b/crates/agileplus-dashboard/desktop-electrobun/electrobun.config.ts
@@ -1,0 +1,51 @@
+/**
+ * phenotype-desktop Electrobun shell template
+ *
+ * USAGE: Copy this directory alongside your web app, then edit the three
+ * CONFIGURE sections below. Run `bun install && bun dev` on macOS.
+ *
+ * Template variables (find-replace before use):
+ *   AgilePlus         e.g. "MyApp"
+ *   com.phenotype.agileplus           e.g. "com.example.myapp"
+ *   0.1.0      e.g. "0.1.0"
+ *   http://localhost:5173  e.g. "http://localhost:3000"
+ *   ../web/dist/index.html e.g. "../web/dist/index.html"  (relative from this dir)
+ */
+import type { ElectrobunConfig } from "electrobun";
+
+// ── CONFIGURE 1: App identity ─────────────────────────────────────────────────
+const APP_NAME = "AgilePlus";
+const APP_ID = "com.phenotype.agileplus";
+const APP_VERSION = "0.1.0";
+
+// ── CONFIGURE 2: Renderer (dev server URL or bundled views path) ──────────────
+const DEFAULT_DEV_URL = "http://localhost:5173";
+
+// ── CONFIGURE 3: Bundled views entrypoint (production) ───────────────────────
+// Self-contained dev/HMR fallback page; it polls + redirects to the live
+// dev server (RENDERER_URL). Keeps `electrobun build` independent of the web build.
+const VIEWS_ENTRYPOINT = "src/views/index.html";
+
+export default {
+  app: {
+    name: APP_NAME,
+    identifier: APP_ID,
+    version: APP_VERSION,
+  },
+  runtime: {
+    exitOnLastWindowClosed: true,
+    // Passed through to main.ts via BuildConfig at runtime
+    devRendererUrl: process.env.RENDERER_URL ?? DEFAULT_DEV_URL,
+  },
+  build: {
+    bun: {
+      entrypoint: "src/main.ts",
+    },
+    views: [
+      {
+        name: "app",
+        entrypoint: VIEWS_ENTRYPOINT,
+      },
+    ],
+  },
+} satisfies ElectrobunConfig;

--- a/crates/agileplus-dashboard/desktop-electrobun/justfile
+++ b/crates/agileplus-dashboard/desktop-electrobun/justfile
@@ -1,0 +1,17 @@
+# AgilePlus desktop shell
+set dotenv-load
+
+dev:
+  bun dev
+
+build:
+  bun run build
+
+release:
+  bun run build:release
+
+install:
+  bun install
+
+typecheck:
+  bun run typecheck

--- a/crates/agileplus-dashboard/desktop-electrobun/package.json
+++ b/crates/agileplus-dashboard/desktop-electrobun/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@phenotype/desktop-shell",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "electrobun dev",
+    "build": "electrobun build",
+    "build:release": "electrobun build --release",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "electrobun": "^1.18.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0",
+    "@types/bun": "latest"
+  }
+}

--- a/crates/agileplus-dashboard/desktop-electrobun/src/main.ts
+++ b/crates/agileplus-dashboard/desktop-electrobun/src/main.ts
@@ -1,0 +1,158 @@
+/**
+ * phenotype-desktop Electrobun shell — main process template
+ *
+ * Features out of the box:
+ *  - One-click service boot: runs `process-compose up -d` if SERVICES_COMPOSE_FILE is set
+ *  - Loads renderer from RENDERER_URL env or falls back to bundled views://app/index.html
+ *  - Standard window with hiddenInset title bar, 1400x900 default
+ *  - Minimal app menu wired to webview JS dispatch
+ */
+import { BrowserWindow, ApplicationMenu } from "electrobun/bun";
+import { $ } from "bun";
+import { join } from "node:path";
+
+// ── Config ────────────────────────────────────────────────────────────────────
+const APP_NAME = process.env.APP_NAME ?? "AgilePlus";
+// Bundled fallback page (polls + redirects to the live dev server).
+const RENDERER_URL = "views://app/index.html";
+// Live vite dev server (HMR) the window navigates to once reachable.
+const DEV_URL = process.env.RENDERER_URL ?? "http://localhost:5173";
+// Repo root, four levels up from crates/agileplus-dashboard/desktop-electrobun/src.
+const REPO_ROOT = join(import.meta.dir, "..", "..", "..", "..");
+const API_CRATE = process.env.AGILEPLUS_API_CRATE ?? "agileplus-api";
+const BOOT_API = (process.env.BOOT_API ?? "1") !== "0";
+
+/**
+ * Path to process-compose.yml (absolute or relative to CWD).
+ * Set SERVICES_COMPOSE_FILE env var, e.g.:
+ *   SERVICES_COMPOSE_FILE=/path/to/repo/process-compose.yml
+ * Leave unset to skip service boot.
+ */
+const SERVICES_COMPOSE_FILE = process.env.SERVICES_COMPOSE_FILE;
+
+// ── Backend boot (cargo run -p agileplus-api :4000) ───────────────────────────
+function bootBackend(): void {
+  if (!BOOT_API) {
+    console.log(`[${APP_NAME}] BOOT_API=0 — skipping backend boot`);
+    return;
+  }
+  try {
+    Bun.spawn(["cargo", "run", "-p", API_CRATE], {
+      cwd: REPO_ROOT,
+      stdout: "inherit",
+      stderr: "inherit",
+      env: { ...process.env },
+    });
+    console.log(`[${APP_NAME}] Backend: cargo run -p ${API_CRATE} (cwd ${REPO_ROOT})`);
+  } catch (err) {
+    console.warn(`[${APP_NAME}] backend boot skipped:`, (err as Error).message);
+  }
+}
+
+// ── Service boot ─────────────────────────────────────────────────────────────
+async function bootServices(): Promise<void> {
+  if (!SERVICES_COMPOSE_FILE) {
+    console.log(`[${APP_NAME}] SERVICES_COMPOSE_FILE not set — skipping service boot`);
+    return;
+  }
+  console.log(`[${APP_NAME}] Booting services: process-compose up -d`);
+  try {
+    const result = await $`process-compose up -d --config ${SERVICES_COMPOSE_FILE}`.quiet();
+    console.log(`[${APP_NAME}] Services:`, result.text().trim());
+  } catch (err) {
+    console.warn(
+      `[${APP_NAME}] process-compose boot skipped (not found or services already running):`,
+      (err as Error).message
+    );
+  }
+}
+
+// ── Window ───────────────────────────────────────────────────────────────────
+function createMainWindow(): BrowserWindow {
+  const win = new BrowserWindow({
+    title: APP_NAME,
+    url: RENDERER_URL,
+    frame: {
+      x: 0,
+      y: 0,
+      width: parseInt(process.env.WINDOW_WIDTH ?? "1400"),
+      height: parseInt(process.env.WINDOW_HEIGHT ?? "900"),
+    },
+    titleBarStyle: "hiddenInset",
+  });
+  // Tell the bundled fallback page which dev server to poll + redirect to.
+  try {
+    win.webview.executeJavascript(`window.__RENDERER_URL__ = ${JSON.stringify(DEV_URL)};`);
+  } catch {
+    /* webview not ready yet — fallback page defaults to localhost:5173 */
+  }
+  return win;
+}
+
+// ── Menu ─────────────────────────────────────────────────────────────────────
+function setupMenu(win: BrowserWindow): void {
+  ApplicationMenu.setApplicationMenu([
+    {
+      label: APP_NAME,
+      submenu: [
+        { role: "about" },
+        { type: "separator" },
+        { role: "services" },
+        { type: "separator" },
+        { role: "hide" },
+        { role: "hideOthers" },
+        { role: "unhide" },
+        { type: "separator" },
+        { role: "quit" },
+      ],
+    },
+    {
+      label: "Edit",
+      submenu: [
+        { role: "undo" },
+        { role: "redo" },
+        { type: "separator" },
+        { role: "cut" },
+        { role: "copy" },
+        { role: "paste" },
+        { role: "selectAll" },
+      ],
+    },
+    {
+      label: "View",
+      submenu: [
+        { role: "reload" },
+        { role: "forceReload" },
+        { role: "toggleDevTools" },
+        { type: "separator" },
+        { role: "togglefullscreen" },
+      ],
+    },
+    // Add app-specific menus below this line
+    // Example — dispatch to webview via executeJavaScript:
+    // {
+    //   label: "File",
+    //   submenu: [
+    //     {
+    //       label: "New",
+    //       accelerator: "CmdOrCtrl+N",
+    //       click: () => win.webview.executeJavaScript("window.__app?.onNew?.()"),
+    //     },
+    //   ],
+    // },
+  ]);
+}
+
+// ── Bootstrap ────────────────────────────────────────────────────────────────
+async function main(): Promise<void> {
+  bootBackend();
+  await bootServices();
+  const win = createMainWindow();
+  setupMenu(win);
+  console.log(`[${APP_NAME}] Launched → ${DEV_URL} (fallback ${RENDERER_URL})`);
+}
+
+main().catch((err) => {
+  console.error(`[${APP_NAME}] Fatal:`, err);
+  process.exit(1);
+});

--- a/crates/agileplus-dashboard/desktop-electrobun/src/views/index.html
+++ b/crates/agileplus-dashboard/desktop-electrobun/src/views/index.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>AgilePlus</title>
+    <style>
+      html, body { margin: 0; height: 100%; background: #0b0e14; color: #e6e6e6;
+        font: 15px/1.5 system-ui, sans-serif; display: grid; place-items: center; }
+      .card { text-align: center; max-width: 28rem; padding: 2rem; }
+      code { background: #1b2030; padding: 2px 6px; border-radius: 4px; }
+    </style>
+  </head>
+  <body>
+    <div class="card">
+      <h1>AgilePlus</h1>
+      <p>Waiting for the dev server at <code id="u"></code>.</p>
+      <p>Start it with <code>just dev</code> (vite :5173), then this window reloads.</p>
+    </div>
+    <script>
+      const url = (window.__RENDERER_URL__) || "http://localhost:5173";
+      document.getElementById("u").textContent = url;
+      // Poll the dev server; navigate once it is reachable (HMR shell).
+      (function poll() {
+        fetch(url, { mode: "no-cors" })
+          .then(() => { location.href = url; })
+          .catch(() => setTimeout(poll, 1000));
+      })();
+    </script>
+  </body>
+</html>

--- a/crates/agileplus-dashboard/desktop-electrobun/tsconfig.json
+++ b/crates/agileplus-dashboard/desktop-electrobun/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "lib": ["ESNext"],
+    "types": ["bun-types"],
+    "outDir": "dist"
+  },
+  "include": ["src/**/*", "electrobun.config.ts"]
+}


### PR DESCRIPTION
## **User description**
Native Electrobun WebView2 desktop shell for AgilePlus, wrapping the live vite dev server (:5173) with HMR and booting the backend (`cargo run -p agileplus-api` :4000).

- Added under `crates/agileplus-dashboard/desktop-electrobun/` from the phenotype-tooling electrobun-shell template (adopt.sh).
- Self-contained fallback page polls + redirects to the dev URL, so the launcher opens a genuine native window (not a browser) and picks up HMR.
- `bun install && bun run build` → `build/dev-win-x64/AgilePlus-dev/bin/launcher.exe` (verified on win-x64, exit 0; full native bundle: WebView2Loader.dll, libNativeWrapper.dll).
- Window/exe icon: follow-up once the AgilePlus branding PR (app.ico) merges.

Makes the Phenotype Apps Start-Menu launcher point at a real native app. DO NOT MERGE pending review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Spawns backend and optional process-compose from the desktop launcher (local dev ergonomics, not production auth), and adds a sizable new dependency tree; no changes to existing API or web app logic.
> 
> **Overview**
> Adds a new **`desktop-electrobun`** package that wraps the AgilePlus Vite dashboard in a native Electrobun window (WebView2 on Windows) instead of opening a browser.
> 
> On launch, the main process can **`cargo run -p agileplus-api`** from the repo root (disable with `BOOT_API=0`), optionally run **`process-compose up -d`** when `SERVICES_COMPOSE_FILE` is set, then open a window on a bundled **`views://`** splash page that polls **`RENDERER_URL`** (default `:5173`) and redirects once the dev server is up so HMR works without bundling the web app into the shell build.
> 
> Includes Electrobun config, Bun/TypeScript tooling, a **`justfile`**, and env knobs for renderer URL and window size.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0483f710df6536d23fb53306bf80ca7f06958db5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Add a native desktop shell for AgilePlus development**

### What Changed
- AgilePlus can now open in a native desktop window instead of a browser, with a standard app menu and adjustable window size
- On launch, it can start the backend automatically and optionally bring up supporting services from a compose file
- The window first shows a waiting page, then switches to the live dev server once it is reachable so hot reload keeps working
- Added basic desktop shell setup files and commands for running, building, and type checking the app

### Impact
`✅ Native desktop launch for local development`
`✅ Fewer manual steps to start backend services`
`✅ Live reload stays available inside the desktop window`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
