### PR TITLE
docs: register Tracera platform R&D FRs/NFRs (cross-repo traceability)

### DIFF
--- a/docs/requirements/tracera-frnfr.md
+++ b/docs/requirements/tracera-frnfr.md
@@ -203,6 +203,141 @@
 
 ---
 
+### FR-TRC-011 — Requirement Miner: Extract Candidate Requirements from Source Artifacts
+
+**Title:** Heuristic requirement miner with confidence scoring and embedding hook
+
+**Description:** The system shall provide a `requirement_miner` service that, given source text and/or file paths, extracts candidate Requirement statements by detecting (a) requirement-language modal verbs (`shall`/`must` → 0.90, `should`/`will` → 0.70, `may`/`can` → 0.50), (b) explicit FR/NFR/REQ/SYS/SRS identifier tags (→ 0.95), and (c) TODO/SPEC/FIXME/`@requirement` code-comment markers (→ 0.60). Candidates are emitted as `CandidateRequirement` records carrying `id`, `text`, `confidence`, `source_ref`, and `tags`. The service is a pure function (no DB access); an embedding hook (`_embedding_hook`) is stubbed for future RAG integration. The API shall expose a read-only POST endpoint: `POST /api/v1/mine/requirements`.
+
+**Acceptance Criteria:**
+- `mine_text(text)` returns `CandidateRequirement` list sorted descending by confidence.
+- `mine_files(paths)` reads real files and merges results; missing files are silently skipped.
+- Requirement-language sentence extracted as candidate; non-requirement prose not flagged.
+- FR/NFR-pattern detected at confidence 0.95; tags populated in `CandidateRequirement.tags`.
+- Confidence ordering: explicit tag (0.95) > `shall`/`must` (0.90) > `should`/`will` (0.70) > `may`/`can` (0.50) > marker (0.60).
+- Empty input returns empty list.
+- `MinerConfig.deduplicate` de-duplicates by normalised text when True.
+- `MinerConfig.min_confidence` filters candidates below threshold.
+- `POST /api/v1/mine/requirements` accepts `{text, paths, min_confidence, include_markers, deduplicate}` and returns `{total, candidates[]}`.
+- 26 unit tests pass with no live DB or graph required.
+
+**Traceability:**
+- Branch: `feat/requirement-miner`
+- Source: `src/tracertm/services/requirement_miner.py`, `src/tracertm/api/routers/mine.py`
+- Tests: `tests/unit/services/test_requirement_miner.py` (26 tests)
+- Closes: FR-TRC-011
+
+---
+
+### FR-TRC-012 — Automated Duplicate / Conflict Detection via TraceLink Miner
+
+**Title:** Detect near-duplicate requirements and mutually-exclusive TraceLinks
+
+**Description:** The system shall provide a `dup_conflict_detector` service that, given an in-memory collection of `Artifact`/`Requirement` objects and `TraceLink` objects, identifies (a) near-duplicate requirements using token-Jaccard similarity (stdlib `difflib`-compatible, no external NLP dependency) above a configurable threshold (default 0.75), and (b) conflicting TraceLinks where the same ordered (source, target) artifact pair carries mutually-exclusive link types (e.g. `CONFLICTS_WITH` co-existing with `SATISFIES`, `VERIFIES`, `IMPLEMENTS`, `DERIVES_FROM`, or `REFINES`). Both detectors are pure functions over in-memory collections (no live DB access required). The API shall expose two read-only POST endpoints: `POST /api/v1/quality/duplicates` and `POST /api/v1/quality/conflicts`.
+
+**Acceptance Criteria:**
+- `detect_duplicate_requirements(artifacts, threshold)` returns `DuplicateFinding` list sorted descending by similarity.
+- `detect_conflicting_links(links)` returns `ConflictFinding` list for all (source, target) pairs with cooperative + `CONFLICTS_WITH` link types.
+- Threshold outside `(0.0, 1.0]` raises `ValueError`.
+- `POST /api/v1/quality/duplicates` and `POST /api/v1/quality/conflicts` accept JSON bodies and return findings with confidence.
+- 22 unit tests pass with no live DB or graph required.
+
+**Traceability:**
+- Branch: `feat/dup-conflict-detector`
+- Source: `src/tracertm/services/dup_conflict_detector.py`, `src/tracertm/api/routers/dup_conflict.py`
+- Tests: `src/tracertm/services/test_dup_conflict_detector.py` (22 tests)
+- Closes: FR-TRC-012
+
+---
+
+### FR-TRC-018 — Canonical Typed-Graph Schema Contract
+
+**Title:** Single canonical node/edge-kind schema contract; GraphPort is the sole graph writer
+
+**Description:** The platform shall define one canonical typed-graph schema (node kinds: Requirement, Spec, ADR, Code, Test, PR, Commit, Release, Repo, Team, Portfolio, OKR, Roadmap, Evidence, Journey, Keyframe; edges: TRACES_TO, VERIFIES, IMPACTS, DEPENDS_ON, DUPLICATES, IMPLEMENTS, COVERS, EVIDENCES, BELONGS_TO, RELEASES) and route all Neo4j writes through a single `GraphPort`. No service may write Neo4j directly. Epic: EPIC-TRC-A-SPINE.
+
+**Acceptance Criteria:**
+- Node/edge kinds are enumerated in one shared contract (HexaKit canonical ports + Python mirror).
+- All existing trace/impact services write via `GraphPort`.
+- Schema drift is impossible: writes outside the contract are rejected.
+
+**Traceability:**
+- Epic: EPIC-TRC-PLATFORM / EPIC-TRC-A-SPINE
+- Blueprint: `docs/TRACERA_PLATFORM_RND.md` §3.3
+- Status: PLANNED (Phase 0)
+
+---
+
+### FR-TRC-019 — Pluggable Agreement Scorer Port
+
+**Title:** ScorerPort with Jaccard / SentenceTransformer / SigLIP / VLM strategies
+
+**Description:** The platform shall expose a `ScorerPort` strategy interface for requirement↔artifact agreement scoring, with interchangeable implementations: lexical (Jaccard), text-embedding (SentenceTransformer), visual-embedding (SigLIP), and blind-vs-intent VLM. Pillars A and C consume the same port.
+
+**Acceptance Criteria:**
+- Scoring strategy is selectable at call site without changing callers.
+- Each scorer returns a normalized confidence in [0.0, 1.0] + rationale.
+
+**Traceability:**
+- Epic: EPIC-TRC-A-SPINE
+- Blueprint: `docs/TRACERA_PLATFORM_RND.md` §3.2
+- Status: PLANNED (Phase 1)
+
+---
+
+### FR-TRC-020 — Blind-vs-Intent Visual Verification
+
+**Title:** VLM proof that running code matches the requirement, with keyframe evidence
+
+**Description:** The Evidence & Verification engine shall capture journey keyframes/recordings (via phenotype-journeys behind `EvidenceRunnerPort`), store them in MinIO as `Evidence`/`Keyframe` graph nodes, and produce a blind-vs-intent VLM verdict asserting whether the running code satisfies the requirement. Verdicts attach to the graph via `VERIFIES` edges.
+
+**Acceptance Criteria:**
+- Evidence artifacts are content-addressed in MinIO and linked from graph nodes.
+- A verdict (pass/fail + rationale + confidence) is recorded per requirement under test.
+- phenotype-journeys is wrapped, not re-implemented.
+
+**Traceability:**
+- Epic: EPIC-TRC-C-VERIFY
+- Blueprint: `docs/TRACERA_PLATFORM_RND.md` §4 (Phase 2)
+- Status: PLANNED (Phase 2)
+
+---
+
+### FR-TRC-021 — Program Management via AgilePlus PmEnginePort
+
+**Title:** Portfolios / OKRs / roadmaps / releases as first-class graph nodes via AgilePlus
+
+**Description:** Pillar B shall promote `agileplus_adapter` into a `PmEnginePort` backed by AgilePlus (Rust), projecting portfolios, OKRs, roadmaps, and releases as canonical graph nodes with a PG-backed compliance/audit trail. AgilePlus is wrapped as the PM engine, not duplicated.
+
+**Acceptance Criteria:**
+- Portfolio/OKR/Roadmap/Release exist as graph node kinds with TraceLinks to requirements.
+- AgilePlus is consumed via a contract port (gRPC/HTTP), not re-implemented in Python.
+
+**Traceability:**
+- Epic: EPIC-TRC-B-PM
+- Blueprint: `docs/TRACERA_PLATFORM_RND.md` §4 (Phase 3)
+- Status: PLANNED (Phase 3)
+
+---
+
+### FR-TRC-022 — Multi-Repo Org Intelligence via RegistryPort
+
+**Title:** Org-wide repo/ecosystem graph + dependency/dup rationalization view
+
+**Description:** Pillar D shall wrap phenotype-registry (ECOSYSTEM_MAP / RATIONALIZATION_PLAN) behind a `RegistryPort`, ingesting the org repo graph and surfacing cross-repo dependency and duplication rationalization as a Tracera SPA view.
+
+**Acceptance Criteria:**
+- Repo / Team nodes and DEPENDS_ON / DUPLICATES edges populate the org graph.
+- Rationalization findings render in the SPA org-map workspace.
+- phenotype-registry is wrapped, not re-implemented.
+
+**Traceability:**
+- Epic: EPIC-TRC-D-ORG
+- Blueprint: `docs/TRACERA_PLATFORM_RND.md` §4 (Phase 4)
+- Status: PLANNED (Phase 4)
+
+---
+
 ## Non-Functional Requirements
 
 ### NFR-TRC-001 — Spatial Index Query Performance
@@ -295,15 +430,18 @@
 
 | ID | Title | Status | Notes |
 |----|-------|--------|-------|
-| FR-TRC-011 | RAG-layer traceability query (LLM-assisted link suggestion) | PLANNED | Referenced in `trace_link.py` docstring as "later PRs"; miner posterior = `confidence` field |
-| FR-TRC-012 | Automated duplicate / conflict detection via TraceLink miner | PLANNED | `DUPLICATES` and `CONFLICTS_WITH` link types defined but no miner service wired |
-| FR-TRC-013 | Bulk TraceLink ingestion from external sources (Jira, GitHub Issues) | PLANNED | `github_import_service.py`, `jira_import_service.py` exist but TraceLink confidence mapping TBD |
-| FR-TRC-014 | Traceability coverage matrix export (CSV/JSON/PDF) | PLANNED | `traceability_matrix_service.py` and `frontend/apps/web/e2e/traceability-matrix.spec.ts` exist; FR/NFR ingestion path not wired |
-| FR-TRC-015 | Graph-level impact blast-radius scoring (risk-weighted path analysis) | PLANNED | `impact_analysis_service.py`, `critical_path_service.py` exist; no confidence-weighted scoring yet |
-| FR-TRC-016 | AgilePlus integration — push Requirements / TraceLinks to AgilePlus project | PLANNED | Dog-food use case; AgilePlus at `C:/Users/koosh/Dev/AgilePlus`; API contract TBD |
-| FR-TRC-017 | Requirement quality scoring (completeness, ambiguity detection) | PARTIAL | `requirement_quality_service.py` and `requirement_quality_repository.py` exist; needs FR spec |
+| FR-TRC-011 | RAG-layer traceability query / requirement miner | SHIPPED | Heuristic miner (modal verbs, FR/NFR tags, spec markers) + confidence scoring; `requirement_miner.py`; endpoint POST /api/v1/mine/requirements; PR: feat/requirement-miner |
+| FR-TRC-012 | Automated duplicate / conflict detection via TraceLink miner | SHIPPED | Token-Jaccard duplicate detector + structural conflict detector; `dup_conflict_detector.py`; endpoints POST /api/v1/quality/duplicates + /conflicts; PR: feat/dup-conflict-detector |
+| FR-TRC-013 | Bulk TraceLink ingestion from external sources (Jira, GitHub Issues) | SHIPPED | Branch `feat/trc013-bulk-tracelink-ingestion`; sources: `src/tracertm/services/github_import_service.py`, `src/tracertm/services/jira_import_service.py`, `src/tracertm/api/routers/ingest.py`; validated with 28 unit tests; `uv run python -c "import tracertm"` |
+| FR-TRC-014 | Traceability coverage matrix export (CSV/JSON/PDF) | SHIPPED | Pure-function `coverage_matrix_service.py`; rows=requirements, cols=impl/test + ArtifactKind buckets; endpoint GET /api/v1/coverage/matrix?format=csv\|json; CSV RFC 4180 + pipe-separated multi-artifact cells; PDF deferred (heavy dep); 25 unit tests; PR: feat/coverage-matrix-export |
+| FR-TRC-015 | Graph-level impact blast-radius scoring (risk-weighted path analysis) | SHIPPED | Pure-function `blast_radius_service.py`; BFS over Requirement/Artifact/TraceLink graph with per-ArtifactKind risk weights + link-confidence multipliers; score 0–100 with LOW/MEDIUM/HIGH/CRITICAL tiers; endpoint `GET /api/v1/impact/blast-radius/{artifact_id}`; 20 unit tests; PR: feat/trc015-blast-radius-scoring |
+| FR-TRC-016 | AgilePlus integration — push Requirements / TraceLinks to AgilePlus project | SHIPPED | branch `feat/trc016-agileplus-push`; `tests/unit/services/test_agileplus_adapter.py` (17 tests); `src/tracertm/adapters/agileplus_adapter.py`; endpoint `POST /api/v1/integrations/agileplus/push`; `.env.example` AgilePlus config |
+| FR-TRC-017 | Traceability coverage / health scoring over Requirement-Artifact-TraceLink graph | SHIPPED | Pure-function `traceability_score_service.py`; metrics: impl_coverage, test_coverage, orphan_req_pct, orphan_art_pct, avg_confidence, composite 0-100; endpoint GET /api/v1/quality/score; 19 unit tests; PR: feat/quality-scoring |
 | NFR-TRC-008 | Link confidence index selectivity target ≥ 90% for miner-generated links | PLANNED | Baseline TBD once miner ships |
 | NFR-TRC-009 | Neo4j projection sync latency < 500 ms p99 for single-link writes | PLANNED | No SLA defined yet |
+| NFR-TRC-010 | All graph writes go through exactly one contract; no service writes Neo4j directly | PLANNED | Blueprint §3.2; EPIC-TRC-A-SPINE |
+| NFR-TRC-011 | Wrap-over-handroll: Authvault/AgilePlus/phenotype-journeys/phenotype-registry/HexaKit consumed via ports, never re-implemented | PLANNED | Blueprint §2 |
+| NFR-TRC-012 | Self-hosting: every shipped capability traces Requirement→Code→Test→PR in Tracera's own graph | PLANNED | Blueprint §7 |
 
 ---
 
@@ -321,4 +459,10 @@
 | FR-TRC-008 | #466 | `test_auth_config_db.py` |
 | FR-TRC-009 | #469 | alembic `063` |
 | FR-TRC-010 | #470 | `test_project_lifecycle.py` |
+| FR-TRC-011 | feat/requirement-miner | `test_requirement_miner.py` (26 tests) |
+| FR-TRC-012 | feat/dup-conflict-detector | `test_dup_conflict_detector.py` (22 tests) |
+| FR-TRC-014 | feat/coverage-matrix-export | `test_coverage_matrix_service.py` (25 tests) |
+| FR-TRC-015 | feat/trc015-blast-radius-scoring | `test_blast_radius_scoring.py` (20 tests) |
+| FR-TRC-016 | feat/trc016-agileplus-push | `test_agileplus_adapter.py` (17 tests) |
+| FR-TRC-017 | feat/quality-scoring | `test_traceability_score_service.py` (19 tests) |
 | NFR-TRC-001..007 | #458–#470 | (see individual evidences above) |


### PR DESCRIPTION
## **User description**
Companion to **Tracera PR #493** (Tracera platform R&D blueprint).

Mirrors Tracera's FR/NFR catalog (`docs/requirements/tracera-frnfr.md`) so the cross-repo `seed_requirements.py` ingests the new 4-pillar superset requirements + epics into the shared traceability graph:

- `FR-TRC-018` canonical typed-graph schema contract (GraphPort sole writer)
- `FR-TRC-019` pluggable ScorerPort (Jaccard / SentenceTransformer / SigLIP / VLM)
- `FR-TRC-020` blind-vs-intent visual verification (phenotype-journeys)
- `FR-TRC-021` AgilePlus PmEnginePort (portfolios/OKRs/roadmaps/releases)
- `FR-TRC-022` org intelligence via RegistryPort (phenotype-registry)
- `NFR-TRC-010..012` (single graph contract, wrap>handroll, self-hosting)
- Epics: EPIC-TRC-PLATFORM / A-SPINE / C-VERIFY / B-PM / D-ORG

Docs only. DO NOT MERGE before Tracera #493.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only catalog sync with no application or infrastructure behavior changes.
> 
> **Overview**
> Updates **`docs/requirements/tracera-frnfr.md`** so the embedded Tracera catalog (consumed by **`seed-requirements`**) matches the expanded platform blueprint and recent shipped work.
> 
> **New full requirement entries:** **FR-TRC-011** (requirement miner) and **FR-TRC-012** (duplicate/conflict detection) are documented with acceptance criteria and traceability. **FR-TRC-018–022** add **PLANNED** forward items (canonical **GraphPort** schema, **ScorerPort**, visual verification, **AgilePlus** **PmEnginePort**, **RegistryPort** org intelligence) with epic/blueprint links.
> 
> **Gap analysis & traceability tables:** **FR-TRC-011–017** move from **PLANNED** to **SHIPPED** with branch/endpoint/test notes; **NFR-TRC-010–012** are added as **PLANNED** platform NFRs. The **Requirement → PR** summary table gains rows for **011**, **012**, and **014–017**.
> 
> Docs-only; no runtime code changes in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d04d2229f67602e0c3007197b88e78df2b9b77d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Register new Tracera platform requirements and planned quality checks**

### What Changed
- Added new requirement entries for mining candidate requirements and detecting duplicate or conflicting trace links, including their expected behavior and API endpoints.
- Added planned platform requirements for the shared graph schema, scoring strategies, visual verification, program management, and org-wide repository intelligence.
- Updated the requirements status tables to mark shipped items and record the new requirement-to-test traceability entries.

### Impact
`✅ Clearer Tracera requirements catalog`
`✅ Easier cross-repo traceability`
`✅ Better visibility into shipped and planned platform work`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
