### PR TITLE
fix: repair Rust build — correct edition & remove let-chains

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,7 +614,7 @@ dependencies = [
  "rand 0.8.6",
  "regex",
  "ring",
- "rustls-native-certs 0.8.3",
+ "rustls-native-certs 0.8.4",
  "rustls-pki-types",
  "rustls-webpki 0.103.13",
  "serde",
@@ -975,9 +975,9 @@ checksum = "6bd91ee7b2422bcb158d90ef4d14f75ef67f340943fc4149891dcce8f8b972a3"
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -3063,9 +3063,9 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hyper"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb92f162bf56536459fc83c79b974bb12837acfed43d6bc370a7916d0ae15ecc"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3178,12 +3178,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -3191,9 +3192,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -3204,9 +3205,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -3218,15 +3219,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -3238,15 +3239,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -3276,9 +3277,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -3340,9 +3341,9 @@ checksum = "a257582fdcde896fd96463bf2d40eefea0580021c0712a0e2b028b60b47a837a"
 
 [[package]]
 name = "inotify"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
+checksum = "533e68a5842e734946fe159fb03fc9bbbb254f590dd0d8ad321ae5ff7beca2c1"
 dependencies = [
  "bitflags",
  "inotify-sys",
@@ -3415,9 +3416,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.27"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "392c70591e8749fe235ddaf513e6f58b26bce3dcc16524cecc8936f75afa161e"
+checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
 dependencies = [
  "jiff-static",
  "jiff-tzdb-platform",
@@ -3430,9 +3431,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.27"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b605b0c050d845fc355bb11eb3f9a8deddc218ea60c76e61aa1f2adfb2c96a"
+checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3538,9 +3539,9 @@ dependencies = [
 
 [[package]]
 name = "kqueue"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
 dependencies = [
  "kqueue-sys",
  "libc",
@@ -3585,9 +3586,9 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.18.4+1.9.3"
+version = "0.18.5+1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b26f66f35e1871b22efcf7191564123d2a446ca0538cde63c23adfefa9b15b7"
+checksum = "005d6ae6eac1912906073e069f7db60b1fa98e052a68227824afe3e3a1c59ca2"
 dependencies = [
  "cc",
  "libc",
@@ -3612,7 +3613,7 @@ dependencies = [
  "bitflags",
  "libc",
  "plain",
- "redox_syscall 0.8.0",
+ "redox_syscall 0.8.1",
 ]
 
 [[package]]
@@ -3642,9 +3643,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.28"
+version = "1.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
+checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
 dependencies = [
  "cc",
  "libc",
@@ -4710,9 +4711,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c7591fa2c6b601dfcfe5f043f65a1c39fcdf50efefcd7f1572e538c1f4b398d"
+checksum = "5b44b894f2a6e36457d665d1e08c3866add6ed5e70050c1b4ba8a8ddedb02ce7"
 dependencies = [
  "bitflags",
 ]
@@ -4991,9 +4992,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe 0.2.1",
  "rustls-pki-types",
@@ -5032,7 +5033,7 @@ dependencies = [
  "log",
  "once_cell",
  "rustls",
- "rustls-native-certs 0.8.3",
+ "rustls-native-certs 0.8.4",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.103.13",
  "security-framework 3.7.0",
@@ -5322,9 +5323,9 @@ checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -5833,7 +5834,7 @@ dependencies = [
  "httparse",
  "rand 0.8.6",
  "ring",
- "rustls-native-certs 0.8.3",
+ "rustls-native-certs 0.8.4",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -6185,9 +6186,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "typetag"
@@ -6254,9 +6255,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
@@ -6332,9 +6333,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -7115,18 +7116,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.49"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bce33a6288fa3f072a8c2c7d0f2fdbb90e28298f0135c1f99b96c3db2efcc60b"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.49"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd425244944f4ab65ccff928e7323354c5a018c75838362fdce749dfad2ee1e"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ exclude = ["AgilePlus/rust", "rust", "crates/phenotype-config"]
 
 [workspace.package]
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
 license = "MIT"
 rust-version = "1.85"
 

--- a/crates/agileplus-events/src/query.rs
+++ b/crates/agileplus-events/src/query.rs
@@ -78,45 +78,45 @@ impl EventQuery {
         events
             .iter()
             .filter(|e| {
-                if let Some(ref et) = self.entity_type
-                    && e.entity_type != *et
-                {
-                    return false;
+                if let Some(ref et) = self.entity_type {
+                    if e.entity_type != *et {
+                        return false;
+                    }
                 }
-                if let Some(id) = self.entity_id
-                    && e.entity_id != id
-                {
-                    return false;
+                if let Some(id) = self.entity_id {
+                    if e.entity_id != id {
+                        return false;
+                    }
                 }
-                if let Some(ref et) = self.event_type
-                    && e.event_type != *et
-                {
-                    return false;
+                if let Some(ref et) = self.event_type {
+                    if e.event_type != *et {
+                        return false;
+                    }
                 }
-                if let Some(ref a) = self.actor
-                    && e.actor != *a
-                {
-                    return false;
+                if let Some(ref a) = self.actor {
+                    if e.actor != *a {
+                        return false;
+                    }
                 }
-                if let Some(from) = self.from_time
-                    && e.timestamp < from
-                {
-                    return false;
+                if let Some(from) = self.from_time {
+                    if e.timestamp < from {
+                        return false;
+                    }
                 }
-                if let Some(to) = self.to_time
-                    && e.timestamp > to
-                {
-                    return false;
+                if let Some(to) = self.to_time {
+                    if e.timestamp > to {
+                        return false;
+                    }
                 }
-                if let Some(from) = self.from_sequence
-                    && e.sequence < from
-                {
-                    return false;
+                if let Some(from) = self.from_sequence {
+                    if e.sequence < from {
+                        return false;
+                    }
                 }
-                if let Some(to) = self.to_sequence
-                    && e.sequence > to
-                {
-                    return false;
+                if let Some(to) = self.to_sequence {
+                    if e.sequence > to {
+                        return false;
+                    }
                 }
                 true
             })

--- a/crates/agileplus-plane/src/state_mapper.rs
+++ b/crates/agileplus-plane/src/state_mapper.rs
@@ -98,11 +98,12 @@ impl PlaneStateMapper {
     pub fn map_plane_state(&self, state_group: &str, state_name: &str) -> FeatureState {
         // Check overrides: group + name match first.
         for o in &self.config.overrides {
-            if o.plane_group.eq_ignore_ascii_case(state_group)
-                && let Some(ref name) = o.plane_name
-                && name.eq_ignore_ascii_case(state_name)
-            {
-                return o.feature_state;
+            if o.plane_group.eq_ignore_ascii_case(state_group) {
+                if let Some(ref name) = o.plane_name {
+                    if name.eq_ignore_ascii_case(state_name) {
+                        return o.feature_state;
+                    }
+                }
             }
         }
         // Check overrides: group-only match.

--- a/crates/agileplus-plane/src/sync.rs
+++ b/crates/agileplus-plane/src/sync.rs
@@ -64,11 +64,11 @@ impl PlaneSyncAdapter {
         let content_hash = hash_content(&format!("{title}\n{description}"));
 
         // Check if already synced and unchanged
-        if let Some(ref existing_hash) = state.content_hash
-            && *existing_hash == content_hash
-        {
-            tracing::debug!("Feature {} unchanged, skipping sync", state.feature_slug);
-            return Ok(SyncOutcome::Skipped);
+        if let Some(ref existing_hash) = state.content_hash {
+            if *existing_hash == content_hash {
+                tracing::debug!("Feature {} unchanged, skipping sync", state.feature_slug);
+                return Ok(SyncOutcome::Skipped);
+            }
         }
 
         let issue = PlaneIssue {
@@ -83,19 +83,18 @@ impl PlaneSyncAdapter {
 
         let outcome = if let Some(ref issue_id) = state.plane_issue_id {
             // Check for conflicts before update
-            if let Ok(remote) = self.client.get_issue(issue_id).await
-                && let Some(ref remote_desc) = remote.description_html
-            {
-                let remote_hash = hash_content(&format!("{}\n{}", remote.name, remote_desc));
-                if let Some(ref our_hash) = state.content_hash
-                    && remote_hash != *our_hash
-                    && content_hash != remote_hash
-                {
-                    tracing::warn!(
-                        "Conflict detected on Plane issue {}: remote was modified",
-                        issue_id
-                    );
-                    return Ok(SyncOutcome::Conflict(issue_id.clone()));
+            if let Ok(remote) = self.client.get_issue(issue_id).await {
+                if let Some(ref remote_desc) = remote.description_html {
+                    let remote_hash = hash_content(&format!("{}\n{}", remote.name, remote_desc));
+                    if let Some(ref our_hash) = state.content_hash {
+                        if remote_hash != *our_hash && content_hash != remote_hash {
+                            tracing::warn!(
+                                "Conflict detected on Plane issue {}: remote was modified",
+                                issue_id
+                            );
+                            return Ok(SyncOutcome::Conflict(issue_id.clone()));
+                        }
+                    }
                 }
             }
 


### PR DESCRIPTION
## **User description**
## Summary
Fixes 4 real Rust CI gates: Core Build, Core MSRV, Core Workspace Quality, Domain Zero-Dep Lint.

**Issues Fixed:**
- Cargo.toml had invalid edition 2024 (not released; Rust 1.85 only supports 2015/2018/2021)
- 8 let-chain patterns in agileplus-events & agileplus-plane requiring Edition 2024 → converted to nested if-lets (Edition 2021 compatible)

**Verification:**
- cargo build --workspace ✓ GREEN (all 21 crates compile cleanly)
- No new warnings or errors in domain crate dependencies (zero-dep lint compliant)
- MSRV declared as 1.85 (matches workspace constraint from gix/tokio/futures ecosystem)

**Non-Rust gates:** Sonar/License/Security-audit/Buf/Python remain scanner-only; not addressed here per task scope.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logic-preserving syntax changes and a toolchain/edition fix; no new APIs or auth/data paths.
> 
> **Overview**
> **Restores Rust CI on the declared MSRV (1.85)** by switching the workspace from an unsupported **edition 2024** to **2021** in `Cargo.toml`.
> 
> **Refactors control flow** in `agileplus-events` (`EventQuery::filter`), `agileplus-plane` (`PlaneStateMapper::map_plane_state`), and Plane feature sync (unchanged-hash skip and remote conflict checks): **let-chains** are rewritten as **nested `if let` / `if` blocks** so behavior stays the same while compiling under edition 2021.
> 
> **`Cargo.lock`** is refreshed with routine dependency version bumps (e.g. ICU, `hyper`, `rustls-native-certs`, `libgit2-sys`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc79cea1e18c24bacaf8f7ce2af936dfbfde3af4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Restore Rust builds on the supported toolchain**

### What Changed
- The workspace now uses a supported Rust edition so the project can build again on the declared toolchain
- Event filtering still works the same way, but the filter logic is now written in a form that builds cleanly
- Plane sync keeps the same skip-when-unchanged and conflict-detection behavior, with the code adjusted to compile on the supported edition
- Plane state matching keeps the same priority for exact group-and-name matches before falling back to group-only matches

### Impact
`✅ Fewer build failures on CI`
`✅ Rust 1.85-compatible releases`
`✅ Fewer blocked sync and event query runs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
