### PR TITLE
chore: add workspace cargo config for day-1 loadability

### DIFF
--- a/crates/agileplus-cli/src/main.rs
+++ b/crates/agileplus-cli/src/main.rs
@@ -24,7 +24,8 @@ use sync_cmd::SyncArgs;
 #[command(
     name = "agileplus",
     about = "AgilePlus project management CLI",
-    version
+    version,
+    arg_required_else_help = true
 )]
 struct Cli {
     #[command(subcommand)]


### PR DESCRIPTION
## Summary
- add .cargo/config.toml with local workspace target dir and incremental build enabled
- created as a small, reversible stabilization increment for day-1 loadability