### PR TITLE
hygiene(AgilePlus): preserve canonical ahead commits

### DIFF
--- a/.github/workflows/ai-testing.yml
+++ b/.github/workflows/ai-testing.yml
@@ -16,6 +16,10 @@ on:
   schedule:
     - cron: '0 3 * * *'  # Weekly test run
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   bdd-tests:
     name: BDD Feature Tests

--- a/.github/workflows/self-merge-gate.yml
+++ b/.github/workflows/self-merge-gate.yml
@@ -14,4 +14,4 @@ permissions:
 
 jobs:
   gate:
-    uses: KooshaPari/phenoShared/.github/workflows/self-merge-gate.yml@main
+    uses: KooshaPari/phenoShared/.github/workflows/self-merge-gate.yml@438e2e71e448c9f1f47f184d3ca4acbb28928677  # main

--- a/.github/workflows/tag-automation.yml
+++ b/.github/workflows/tag-automation.yml
@@ -14,6 +14,6 @@ on:
 
 jobs:
   tag:
-    uses: KooshaPari/phenoShared/.github/workflows/tag-automation.yml@main
+    uses: KooshaPari/phenoShared/.github/workflows/tag-automation.yml@438e2e71e448c9f1f47f184d3ca4acbb28928677  # main
     permissions:
       contents: write

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -1,13 +1,26 @@
 ﻿name: TruffleHog Secrets Scan
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+
 on:
   push:
-    branches: [main]
+    branches: [main, "chore/**", "feat/**", "fix/**"]
   pull_request:
+    branches: [main, "chore/**", "feat/**", "fix/**"]
+  workflow_dispatch:
 permissions:
   contents: read
+  actions: read
+
 jobs:
   trufflehog:
-    uses: KooshaPari/phenotype-tooling/.github/workflows/reusable/trufflehog.yml@main
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: trufflesecurity/trufflehog@3fc0c2aa6648d54242e4af6fbfde0701796e4fb0  # v3.92.0 — SHA-pinned (matches sast-quick.yml)
+        with:
+          extra_args: --only-verified

--- a/docs/operations/journey-traceability.md
+++ b/docs/operations/journey-traceability.md
@@ -1,0 +1,83 @@
+# Journey Traceability
+
+Implements the phenotype-infra journey-traceability standard for AgilePlus as the spec-driven project management system of record.
+
+## Traceability Model
+
+Every user-facing or agent-facing flow should be traceable across:
+
+1. **FR/NFR** — requirement ID and user story from `docs/requirements/agileplus-frnfr.md`.
+2. **Spec** — acceptance criteria, invariant, and non-regression constraint.
+3. **Docs** — operator/user documentation and rich media placeholders.
+4. **Code** — domain crate, application use case, adapter, API, CLI, dashboard, or sync surface implementing the flow.
+5. **Tests/Gates** — unit, integration, BDD, lint, coverage, and journey verification acting as autograders.
+6. **Evidence** — journey manifest, recording/keyframes, and evaluation verdict.
+
+## User-Facing and Agent-Facing Flows
+
+| Flow | Requirement | Implementation surface | Autograder gates | Evidence status |
+| --- | --- | --- | --- | --- |
+| Create and validate a rich project backlog | FR-AGP-001, NFR-AGP-005 | `agileplus-domain`, `agileplus-application`, CLI/API project commands | domain invariant tests, use-case tests, BDD journey, eval verdict | Stubbed |
+| Import a manifest into AgilePlus entities | FR-AGP-012, NFR-AGP-005 | `agileplus-import`, manifest parser, `ImportReport` | fixture import tests, error-report assertions, journey manifest | Stubbed |
+| Sync GitHub issues/PRs into domain objects | FR-AGP-006, NFR-AGP-002 | `agileplus-github`, sync mapping, octocrab adapter | adapter contract tests, mocked GitHub fixtures, sync smoke | Stubbed |
+| Persist and query synced project state | FR-AGP-003, FR-AGP-013, NFR-AGP-005 | `agileplus-sqlite`, repository ports, application use cases | repository tests, migration checks, query smoke, BDD journey | Stubbed |
+| Dashboard shows traceable epics/stories | FR-AGP-014, NFR-AGP-006 | dashboard endpoint, React/Askama UI, seed database | UI smoke, JSON endpoint tests, screenshot journey, accessibility check | Stubbed |
+| Agent triage maps work to intent and priority | FR-AGP-017, NFR-AGP-005 | triage engine, `Intent::Docs`, default priority mapping | rule tests, fixture payloads, eval verdict | Stubbed |
+
+## Rich Media Stubs
+
+<!-- RICH-MEDIA-STUB type="animated-gif" subject="Project backlog creation and invariant validation" journey="create-project-backlog" status="TODO" -->
+![AgilePlus project backlog creation — project, epic, feature, story, invariant validation, and saved state](../assets/rich-media/agileplus/create-project-backlog.gif)
+
+*Expected capture: create a project backlog through the CLI/API/UI path, show invalid-state rejection, then show the valid backlog persisted and queryable.*
+
+<!-- RICH-MEDIA-STUB type="annotated-screenshot" subject="Manifest import report" journey="manifest-import-report" status="TODO" -->
+![AgilePlus manifest import report — imported entities, skipped rows, validation errors, and traceability IDs](../assets/rich-media/agileplus/manifest-import-report.png)
+
+*Expected capture: import a deterministic fixture manifest, annotate success/failure counts, and link imported entities back to FR-AGP-012.*
+
+<!-- RICH-MEDIA-STUB type="journey-eval" subject="GitHub sync evidence verdict" journey="github-sync-evidence" status="TODO" -->
+![AgilePlus GitHub sync evidence — fixture issue, mapped story, sync provenance, and eval verdict](../assets/rich-media/agileplus/github-sync-evidence.png)
+
+*Expected capture: sync GitHub fixture data, prove mapped domain entities match expected state, and attach a pass/fail eval verdict for FR-AGP-006 and NFR-AGP-002.*
+
+<!-- RICH-MEDIA-STUB type="annotated-screenshot" subject="Dashboard traceable epics and stories" journey="dashboard-traceable-work" status="TODO" -->
+![AgilePlus dashboard — epics, stories, FR/NFR links, and backlog status rollup](../assets/rich-media/agileplus/dashboard-traceable-work.png)
+
+*Expected capture: open the seeded dashboard, show epics/stories with FR/NFR IDs, and verify the JSON endpoint agrees with the rendered UI.*
+
+<!-- RICH-MEDIA-STUB type="journey-eval" subject="Agent triage intent and priority verdict" journey="agent-triage-intent-priority" status="TODO" -->
+![AgilePlus triage verdict — raw work item, inferred intent, priority, and rule trace](../assets/rich-media/agileplus/agent-triage-intent-priority.png)
+
+*Expected capture: run the triage engine against fixture work items, show inferred intent/priority, and attach an eval verdict checking expected classifications.*
+
+## Journey Manifests
+
+Journey manifests should live in `docs/journeys/manifests/` and include:
+
+- FR/NFR IDs covered by the journey;
+- CLI command, API route, dashboard route, or agent entrypoint used to reproduce the flow;
+- fixture data required for deterministic replay;
+- expected screenshots/GIFs/keyframes;
+- tests and gates that must pass before the journey is accepted;
+- eval verdict schema and pass/fail criteria.
+
+## Autograder Gates
+
+Minimum gates before marking a journey complete:
+
+- `cargo test --workspace` for domain/application behavior;
+- targeted crate tests for imports, sync, persistence, and triage;
+- dashboard/API smoke for user-visible flows;
+- BDD journey replay for FR/NFR user stories;
+- doc link validation for every referenced rich media asset;
+- journey manifest validation via `phenotype-journey verify` when available;
+- eval verdict linked to the FR/NFR IDs in the manifest.
+
+## Status
+
+- [x] Identify initial FR/NFR-backed flows from `docs/requirements/agileplus-frnfr.md`
+- [x] Stub rich media embeds for expected screenshots/GIFs/evals
+- [ ] Author manifests in `docs/journeys/manifests/`
+- [ ] Record journey captures for each flow
+- [ ] Run `phenotype-journey verify` in CI


### PR DESCRIPTION
## **User description**
Preserves 2 local canonical commits before resetting to clean origin/main.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI configuration and documentation; TruffleHog scope widens to feature/fix branches but uses verified-only scanning with read-only permissions.
> 
> **Overview**
> **CI hardening and supply-chain pinning** across several GitHub Actions workflows, plus a new **journey traceability** operations doc.
> 
> **Workflows:** `ai-testing.yml` now declares explicit **`contents: read`** and **`actions: read`** permissions. **`self-merge-gate`** and **`tag-automation`** stop calling **`phenoShared`** at **`@main`** and pin the reusable workflow to commit **`438e2e71…`**. **`trufflehog.yml`** no longer delegates to **`phenotype-tooling`**; it runs an inline job on **`ubuntu-24.04`**, scans on **`main`** plus **`chore/**`**, **`feat/**`**, and **`fix/**`** (push and PR), adds **`workflow_dispatch`**, sets the same read permissions, checks out with **`fetch-depth: 0`**, and uses the same SHA-pinned **`trufflesecurity/trufflehog`** action as **`sast-quick.yml`** with **`--only-verified`**.
> 
> **Documentation:** Adds **`docs/operations/journey-traceability.md`**, mapping six AgilePlus flows to FR/NFR IDs, implementation surfaces, autograder gates, and stubbed rich-media placeholders, with a checklist for manifests, captures, and future **`phenotype-journey verify`** in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d04dc58e39b5844377ddc1a3702b1704df3a9cb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Add journey traceability guidance and harden CI workflow access**

### What Changed
- Added a new operations guide that maps key AgilePlus user flows to requirements, code areas, tests, and expected evidence
- Added rich media placeholders and acceptance checkpoints for backlog creation, manifest import, GitHub sync, persistence, dashboard tracing, and triage flows
- Locked down GitHub Actions workflows with read-only access where needed, and pinned shared workflow references to a fixed commit
- Expanded secrets scanning to run on feature, fix, and chore branches, with manual runs enabled and verified-only results

### Impact
`✅ Clearer journey ownership for AgilePlus flows`
`✅ Fewer CI surprises from shared workflow changes`
`✅ Earlier secrets checks on active branches`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
