### PR TITLE
chore(specs): add FR stubs for 011-import, 012-telemetry, 013-grpc, 014-github

### DIFF
--- a/specs/011-agileplus-import/FR-IMPORT-001.md
+++ b/specs/011-agileplus-import/FR-IMPORT-001.md
@@ -1,0 +1,34 @@
+# FR-IMPORT-001 — AgilePlus Import Adapter Boundary
+
+> Spec anchor: `specs/011-agileplus-import/`
+> Status: PROPOSED → accepted on `cargo test -p agileplus-import` pass
+> Crate: `agileplus-import`
+
+## Description
+
+The `agileplus-import` adapter ports external PM data (Jira, Linear, Trello,
+CSV) into AgilePlus domain entities. The `Importer` port accepts a source
+manifest, streams entities through the application port layer, and emits
+typed `ImportEvent`s on the events bus. Idempotency is enforced via a
+content-addressed dedupe key derived from source IDs plus schema version.
+
+## Acceptance Criteria
+
+| AC  | Criterion |
+|-----|-----------|
+| AC1 | `Importer` trait exposes `import(manifest) -> Result<ImportSummary>` returning counts, skipped, failed. |
+| AC2 | Imported entities carry dedupe keys `{source, external_id, schema_version}`. |
+| AC3 | Re-running an import with identical source IDs produces zero new rows. |
+| AC4 | Failures are surfaced as `ImportEvent::Failed` and never silently dropped. |
+| AC5 | At least one adapter (CSV) is wired with a passing integration test. |
+| AC6 | `ImportSummary` shape: `{created, updated, skipped, failed, duration_ms}`. |
+| AC7 | No adapter reads from a network or filesystem without going through the port. |
+| AC8 | `import_integration.rs` proves ACs above with at least one assertion per AC. |
+
+## Traceability
+
+- Spec: `specs/011-agileplus-import/`
+- Code: `crates/agileplus-import/src/`
+- BDD: `specs/011-agileplus-import/bdd/`
+- Tests: `crates/agileplus-import/tests/import_integration.rs`
+- Journey: `docs/journeys/import-flow.md`

--- a/specs/011-agileplus-import/bdd/import.feature
+++ b/specs/011-agileplus-import/bdd/import.feature
@@ -1,0 +1,20 @@
+Feature: AgilePlus import adapter
+  As a migration operator
+  I want to import PM data from external sources
+  So that AgilePlus work packages reflect upstream state
+
+  Background:
+    Given an Importer port wired with a CSV adapter
+    And an empty AgilePlus domain store
+
+  Scenario: Idempotent re-import
+    Given a manifest pointing at 10 CSV rows
+    When the importer runs twice
+    Then the second run creates zero new rows
+    And the second run returns skipped == 10
+
+  Scenario: Surface failures as events
+    Given a manifest with one malformed row
+    When the importer runs
+    Then it returns failed == 1
+    And it emits an ImportEvent::Failed for that row

--- a/specs/012-agileplus-telemetry/FR-TELEMETRY-001.md
+++ b/specs/012-agileplus-telemetry/FR-TELEMETRY-001.md
@@ -1,0 +1,34 @@
+# FR-TELEMETRY-001 — AgilePlus Telemetry Port
+
+> Spec anchor: `specs/012-agileplus-telemetry/`
+> Status: PROPOSED → accepted on `cargo test -p agileplus-telemetry` pass
+> Crate: `agileplus-telemetry`
+
+## Description
+
+The `agileplus-telemetry` crate exposes a `TelemetrySink` port for emitting
+spans, metrics, and structured logs without coupling callers to a specific
+backend. The default adapter is OTLP-over-HTTP, with a no-op adapter for
+tests and an in-memory recorder for assertions. Sampling is configurable
+per-signal; PII redaction runs at the port boundary.
+
+## Acceptance Criteria
+
+| AC  | Criterion |
+|-----|-----------|
+| AC1 | `TelemetrySink` trait exposes `span(name, attrs)`, `counter(name, value)`, `log(level, msg)`. |
+| AC2 | No-op adapter compiles and never panics on any input. |
+| AC3 | In-memory recorder exposes `recorded()` for test assertions. |
+| AC4 | OTLP adapter serializes to the documented JSON shape. |
+| AC5 | PII redaction runs before any span/counter/log reaches a sink. |
+| AC6 | Sampling config is per-signal and hot-reloadable from `agileplus-config`. |
+| AC7 | Backpressure on a sink does not block callers for more than 10ms. |
+| AC8 | `telemetry_integration.rs` proves ACs above with at least one assertion per AC. |
+
+## Traceability
+
+- Spec: `specs/012-agileplus-telemetry/`
+- Code: `crates/agileplus-telemetry/src/`
+- BDD: `specs/012-agileplus-telemetry/bdd/`
+- Tests: `crates/agileplus-telemetry/tests/telemetry_integration.rs`
+- Journey: `docs/journeys/telemetry-emission.md`

--- a/specs/012-agileplus-telemetry/bdd/telemetry.feature
+++ b/specs/012-agileplus-telemetry/bdd/telemetry.feature
@@ -1,0 +1,16 @@
+Feature: AgilePlus telemetry port
+  As a platform operator
+  I want a stable TelemetrySink port
+  So that backends can be swapped without caller changes
+
+  Background:
+    Given a TelemetrySink wired with the in-memory recorder
+
+  Scenario: Span emission is observable
+    When a span "agileplus.op" with attrs is emitted
+    Then the recorder contains one span named "agileplus.op"
+
+  Scenario: No-op adapter never panics
+    Given a NoopTelemetrySink
+    When any span, counter, or log is emitted
+    Then the call returns Ok(())

--- a/specs/013-agileplus-grpc/FR-GRPC-001.md
+++ b/specs/013-agileplus-grpc/FR-GRPC-001.md
@@ -1,0 +1,35 @@
+# FR-GRPC-001 — AgilePlus gRPC Service Surface
+
+> Spec anchor: `specs/013-agileplus-grpc/`
+> Status: PROPOSED → accepted on `cargo test -p agileplus-grpc` pass
+> Crate: `agileplus-grpc` (with `agileplus-proto` for schema)
+
+## Description
+
+The `agileplus-grpc` adapter exposes the AgilePlus application port layer
+over a tonic gRPC server, sharing `agileplus-proto` schemas with any
+remote-language client. Health, reflection, and bidirectional streaming
+for events are first-class. Server errors map to canonical gRPC status
+codes; the integration test suite proves request/response parity with
+the HTTP adapter in `agileplus-api`.
+
+## Acceptance Criteria
+
+| AC  | Criterion |
+|-----|-----------|
+| AC1 | gRPC service `AgilePlusService` implements at least one unary and one streaming method. |
+| AC2 | Health check returns SERVING when dependencies are healthy. |
+| AC3 | Reflection is enabled and lists every registered service. |
+| AC4 | Domain errors map to canonical gRPC status codes (NOT_FOUND, INVALID_ARGUMENT, etc.). |
+| AC5 | Proto schemas live in `agileplus-proto` and are generated, never hand-edited. |
+| AC6 | `agileplus-grpc` and `agileplus-api` share request/response shapes for parity. |
+| AC7 | TLS termination is configurable; insecure mode is only available in dev/test. |
+| AC8 | `grpc_integration.rs` proves ACs above with at least one assertion per AC. |
+
+## Traceability
+
+- Spec: `specs/013-agileplus-grpc/`
+- Code: `crates/agileplus-grpc/src/`, `crates/agileplus-proto/src/`
+- BDD: `specs/013-agileplus-grpc/bdd/`
+- Tests: `crates/agileplus-grpc/tests/grpc_integration.rs`
+- Journey: `docs/journeys/grpc-roundtrip.md`

--- a/specs/013-agileplus-grpc/bdd/grpc.feature
+++ b/specs/013-agileplus-grpc/bdd/grpc.feature
@@ -1,0 +1,16 @@
+Feature: AgilePlus gRPC service
+  As a remote client
+  I want a tonic-based gRPC service
+  So that I can call AgilePlus from non-Rust runtimes
+
+  Background:
+    Given a running AgilePlusService over tonic
+
+  Scenario: Health check reports SERVING
+    When the gRPC Health/Check is invoked
+    Then the response status is SERVING
+
+  Scenario: Domain errors map to canonical codes
+    Given a request that triggers NotFound in the domain
+    When the call is made
+    Then the gRPC status code is NOT_FOUND

--- a/specs/014-agileplus-github/FR-GITHUB-001.md
+++ b/specs/014-agileplus-github/FR-GITHUB-001.md
@@ -1,0 +1,35 @@
+# FR-GITHUB-001 — AgilePlus GitHub Integration
+
+> Spec anchor: `specs/014-agileplus-github/`
+> Status: PROPOSED → accepted on `cargo test -p agileplus-github` pass
+> Crate: `agileplus-github`
+
+## Description
+
+The `agileplus-github` adapter synchronizes AgilePlus work packages with
+GitHub issues, pull requests, and project boards. Webhook ingestion is
+idempotent (delivery ID + event type), and outbound writes go through a
+rate-limited GraphQL/REST port. Tokens are loaded from
+`agileplus-config` and never logged; webhook signatures are verified
+against the configured secret.
+
+## Acceptance Criteria
+
+| AC  | Criterion |
+|-----|-----------|
+| AC1 | Webhook handler accepts `issues`, `pull_request`, and `project_card` events. |
+| AC2 | Duplicate webhook deliveries (same delivery ID) are silently dropped after the first. |
+| AC3 | Webhook signature is verified against the configured secret; invalid signatures return 401. |
+| AC4 | Tokens are loaded from `agileplus-config` and never appear in logs or traces. |
+| AC5 | Outbound API calls are rate-limited (token bucket, configurable RPS). |
+| AC6 | At least one sync direction (inbound issue → work package) is wired with a passing test. |
+| AC7 | 5xx responses trigger exponential backoff with jitter, capped at 6 retries. |
+| AC8 | `github_integration.rs` proves ACs above with at least one assertion per AC. |
+
+## Traceability
+
+- Spec: `specs/014-agileplus-github/`
+- Code: `crates/agileplus-github/src/`
+- BDD: `specs/014-agileplus-github/bdd/`
+- Tests: `crates/agileplus-github/tests/github_integration.rs`
+- Journey: `docs/journeys/github-sync.md`

--- a/specs/014-agileplus-github/bdd/github.feature
+++ b/specs/014-agileplus-github/bdd/github.feature
@@ -1,0 +1,18 @@
+Feature: AgilePlus GitHub integration
+  As a repo steward
+  I want AgilePlus to sync with GitHub issues and PRs
+  So that work packages stay aligned with upstream activity
+
+  Background:
+    Given a webhook handler with a configured secret
+    And a GitHub adapter wired with the in-memory recorder
+
+  Scenario: Duplicate webhook delivery is dropped
+    Given a webhook payload with delivery ID "abc-123"
+    When the same delivery is posted twice
+    Then the second delivery is silently dropped
+
+  Scenario: Invalid signature is rejected
+    Given a webhook payload signed with the wrong secret
+    When the handler is invoked
+    Then the response is HTTP 401


### PR DESCRIPTION
## **User description**
## Summary

- Add minimal FR stubs (8-line header format matching `FR-DASHBOARD-HEALTH-001`) for the four adapter specs that had bdd scaffolding but no FR-*.md
- Add matching minimal `bdd/*.feature` placeholders following the `specs/002-agileplus-dashboard/bdd/dashboard-health.feature` style
- No existing content modified (insertions only, +208 lines)

## Files

- `specs/011-agileplus-import/FR-IMPORT-001.md` + `bdd/import.feature`
- `specs/012-agileplus-telemetry/FR-TELEMETRY-001.md` + `bdd/telemetry.feature`
- `specs/013-agileplus-grpc/FR-GRPC-001.md` + `bdd/grpc.feature`
- `specs/014-agileplus-github/FR-GITHUB-001.md` + `bdd/github.feature`

## Test plan

- [x] Each FR follows the 8-line header pattern (title, blank, anchor/status/crate, blank, description, blank, AC table, traceability)
- [x] Each AC table has 8 numbered acceptance criteria
- [x] Each BDD feature has Background + at least 2 Scenarios
- [x] No existing files modified
- [ ] Flesh out full FR bodies in follow-up PRs (these are minimal stubs as requested)

Notes: GitHub Actions CI will fail (per the org billing constraint in `~/.claude/CLAUDE.md`); quality is verified by the stub format matching the existing reference and the lack of edits to existing content.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only additions under `specs/` with no runtime or application code changes.
> 
> **Overview**
> Adds **functional requirement documents and BDD placeholders** for four adapter specs (`011` import, `012` telemetry, `013` gRPC, `014` GitHub) that previously had scaffolding without `FR-*.md` files. Each new FR follows the shared header pattern (anchor, acceptance gate on crate tests, crate name), a short description, **eight numbered acceptance criteria**, and traceability links to code, BDD, integration tests, and journeys.
> 
> Each spec also gets a **`bdd/*.feature`** file with a Background and at least two scenarios (e.g. idempotent import, failure events; telemetry span/no-op; gRPC health and error mapping; GitHub webhook dedupe and signature rejection). **Insertions only**—no existing files changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4715467f7a185752a3e3ada3521383f6649bf312. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Add FR stubs and BDD placeholders for four adapter specs**

### What Changed
- Added functional requirement stubs for the import, telemetry, gRPC, and GitHub specs
- Each new FR now describes the expected adapter behavior, acceptance criteria, and test traceability
- Added matching BDD feature files with basic scenarios for import, telemetry, gRPC, and GitHub flows

### Impact
`✅ Clearer adapter spec coverage`
`✅ Faster spec onboarding`
`✅ Fewer missing-documentation gaps`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
