### PR TITLE
chore(docs): fix broken rich-media stub links + restore doc-links CI

### DIFF
--- a/.github/workflows/doc-links.yml
+++ b/.github/workflows/doc-links.yml
@@ -1,18 +1,81 @@
 name: Doc Links
 on:
   workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - ".github/workflows/doc-links.yml"
+  pull_request:
+    paths:
+      - "docs/**"
+      - ".github/workflows/doc-links.yml"
 
 permissions:
   contents: read
-
-on: [push, pull_request]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 jobs:
   links:
+    name: Check markdown links in docs/
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
-      - run: echo "Doc link check (phenotype-tooling integration)"
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+      - name: Install markdown-link-check
+        run: npm install --silent --no-audit --no-fund --no-progress markdown-link-check@3.13.7
+      - name: Write config
+        env:
+          WORKSPACE: ${{ github.workspace }}
+        run: |
+          cat > /tmp/mlc-config.json <<EOF
+          {
+            "ignorePatterns": [
+              {"pattern": "^http(s)?://localhost"},
+              {"pattern": "^http(s)?://127\\.0\\.0\\.1"},
+              {"pattern": "^http(s)?://0\\.0\\.0\\.0"},
+              {"pattern": "^http(s)?://example\\.com"},
+              {"pattern": "^http(s)?://www\\.iana\\.org"},
+              {"pattern": "^http(s)?://schemas\\."}
+            ],
+            "replacementPatterns": [
+              {"pattern": "^/repos", "replacement": "${WORKSPACE}/.."},
+              {"pattern": "^repos/", "replacement": "${WORKSPACE}/../"}
+            ],
+            "httpHeaders": [
+              {
+                "urls": ["https://github.com/"],
+                "headers": {"User-Agent": "Mozilla/5.0 (doc-link-check)"}
+              }
+            ],
+            "timeout": "20s",
+            "retryOn429": true,
+            "retryCount": 2
+          }
+          EOF
+      - name: Run markdown-link-check on docs/
+        run: |
+          set -euo pipefail
+          shopt -s globstar nullglob
+          failed=0
+          files=(docs/**/*.md)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "No markdown files under docs/ - nothing to check."
+            exit 0
+          fi
+          for f in "${files[@]}"; do
+            echo "::group::$f"
+            if ! npx --no-install markdown-link-check --config /tmp/mlc-config.json "$f"; then
+              failed=1
+            fi
+            echo "::endgroup::"
+          done
+          if [ "$failed" -ne 0 ]; then
+            echo "Doc link check failed for one or more files." >&2
+            exit 1
+          fi

--- a/docs/operations/journey-traceability.md
+++ b/docs/operations/journey-traceability.md
@@ -27,27 +27,27 @@ Every user-facing or agent-facing flow should be traceable across:
 ## Rich Media Stubs
 
 <!-- RICH-MEDIA-STUB type="animated-gif" subject="Project backlog creation and invariant validation" journey="create-project-backlog" status="TODO" -->
-![AgilePlus project backlog creation — project, epic, feature, story, invariant validation, and saved state](../assets/rich-media/agileplus/create-project-backlog.gif)
+> **Stub (TODO):** AgilePlus project backlog creation — project, epic, feature, story, invariant validation, and saved state. *Capture pending; the linked asset `../assets/rich-media/agileplus/create-project-backlog.gif` is intentionally absent and will be recorded when the journey manifest is captured.*
 
 *Expected capture: create a project backlog through the CLI/API/UI path, show invalid-state rejection, then show the valid backlog persisted and queryable.*
 
 <!-- RICH-MEDIA-STUB type="annotated-screenshot" subject="Manifest import report" journey="manifest-import-report" status="TODO" -->
-![AgilePlus manifest import report — imported entities, skipped rows, validation errors, and traceability IDs](../assets/rich-media/agileplus/manifest-import-report.png)
+> **Stub (TODO):** AgilePlus manifest import report — imported entities, skipped rows, validation errors, and traceability IDs. *Capture pending; the linked asset `../assets/rich-media/agileplus/manifest-import-report.png` is intentionally absent and will be recorded when the journey manifest is captured.*
 
 *Expected capture: import a deterministic fixture manifest, annotate success/failure counts, and link imported entities back to FR-AGP-012.*
 
 <!-- RICH-MEDIA-STUB type="journey-eval" subject="GitHub sync evidence verdict" journey="github-sync-evidence" status="TODO" -->
-![AgilePlus GitHub sync evidence — fixture issue, mapped story, sync provenance, and eval verdict](../assets/rich-media/agileplus/github-sync-evidence.png)
+> **Stub (TODO):** AgilePlus GitHub sync evidence — fixture issue, mapped story, sync provenance, and eval verdict. *Capture pending; the linked asset `../assets/rich-media/agileplus/github-sync-evidence.png` is intentionally absent and will be recorded when the journey manifest is captured.*
 
 *Expected capture: sync GitHub fixture data, prove mapped domain entities match expected state, and attach a pass/fail eval verdict for FR-AGP-006 and NFR-AGP-002.*
 
 <!-- RICH-MEDIA-STUB type="annotated-screenshot" subject="Dashboard traceable epics and stories" journey="dashboard-traceable-work" status="TODO" -->
-![AgilePlus dashboard — epics, stories, FR/NFR links, and backlog status rollup](../assets/rich-media/agileplus/dashboard-traceable-work.png)
+> **Stub (TODO):** AgilePlus dashboard — epics, stories, FR/NFR links, and backlog status rollup. *Capture pending; the linked asset `../assets/rich-media/agileplus/dashboard-traceable-work.png` is intentionally absent and will be recorded when the journey manifest is captured.*
 
 *Expected capture: open the seeded dashboard, show epics/stories with FR/NFR IDs, and verify the JSON endpoint agrees with the rendered UI.*
 
 <!-- RICH-MEDIA-STUB type="journey-eval" subject="Agent triage intent and priority verdict" journey="agent-triage-intent-priority" status="TODO" -->
-![AgilePlus triage verdict — raw work item, inferred intent, priority, and rule trace](../assets/rich-media/agileplus/agent-triage-intent-priority.png)
+> **Stub (TODO):** AgilePlus triage verdict — raw work item, inferred intent, priority, and rule trace. *Capture pending; the linked asset `../assets/rich-media/agileplus/agent-triage-intent-priority.png` is intentionally absent and will be recorded when the journey manifest is captured.*
 
 *Expected capture: run the triage engine against fixture work items, show inferred intent/priority, and attach an eval verdict checking expected classifications.*
 


### PR DESCRIPTION
## **User description**
## Summary

- Replace 5 missing rich-media stub image links in `docs/operations/journey-traceability.md` with explicit "Stub (TODO)" blockquotes that preserve the rich-media metadata (subject, journey, type) for future capture agents.
- Restore `.github/workflows/doc-links.yml` to actually run `markdown-link-check` across `docs/` on push, pull_request, and workflow_dispatch — the previous workflow body was a placeholder echo, so the broken-link class of regression was never caught in CI.

## Test plan

- [x] `markdown-link-check` (local, `npx markdown-link-check@3.13.7` against the modified `docs/`) reports 0 broken links for the touched files.
- [x] All 5 stub blockquotes still carry the original `<!-- RICH-MEDIA-STUB type=... subject=... journey=... status="TODO" -->` marker so capture automation can locate the slot.
- [x] The workflow YAML parses, runs only on changes under `docs/` and the workflow file itself, and uses `env: ${{ github.workspace }}` (no `github.event.*` interpolation) so it is not vulnerable to action-injection.

## Notes

- The stub assets (`docs/assets/rich-media/agileplus/{create-project-backlog.gif,manifest-import-report.png,github-sync-evidence.png,dashboard-traceable-work.png,agent-triage-intent-priority.png}`) remain intentionally absent. The blockquotes document the intended capture path so a future `phenotype-journey` run can still recover the slot.
- This PR is intentionally minimal: 2 files, 71 insertions, 8 deletions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and CI-only changes; no application, auth, or data-path code.
> 
> **Overview**
> Fixes **broken doc links** from missing rich-media assets and **turns on real link validation** in CI.
> 
> In `docs/operations/journey-traceability.md`, five `![...](../assets/rich-media/...)` embeds that pointed at files that do not exist are replaced with **Stub (TODO)** blockquotes. Each slot still has its `<!-- RICH-MEDIA-STUB ... -->` marker and notes the intended asset path for future capture.
> 
> The **Doc Links** workflow no longer only echoes a placeholder: it runs **`markdown-link-check@3.13.7`** on all `docs/**/*.md`, with path filters on `docs/**` and the workflow file, a config for ignores/replacements/GitHub User-Agent, and a failing exit if any file has bad links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d7e3d7b290b4fa7be64c9e14c1204ea69c31ba7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
Fix broken rich-media links in the journey traceability docs and restore doc link checks in CI

### What Changed
- Replaced five missing image links in `docs/operations/journey-traceability.md` with clear “Stub (TODO)” notes that keep the capture details and preserve the original metadata
- Restored the doc-links workflow so markdown links under `docs/` are checked on push, pull request, and manual runs instead of showing a placeholder message
- Added a real link-check run that reports broken documentation links during CI

### Impact
`✅ Fewer broken documentation links`
`✅ Earlier warning for missing doc assets`
`✅ More reliable doc-link checks in CI`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
