### PR TITLE
chore(docs): scaffold journey page + bdd templates

### DIFF
--- a/docs/journeys/README.md
+++ b/docs/journeys/README.md
@@ -1,0 +1,195 @@
+# Journeys
+
+User-facing and agent-facing flows for AgilePlus, modelled on the
+hwLedger `add-rich-journey-embeds-to-docs-v10` exemplar
+(`docs/journeys/manifests/README.md` + per-flow pages with rich-media
+stubs). Every flow documented here MUST be traceable across **spec →
+docs → tests → code → stub → eval**; a missing link at any layer fails
+the docs lint (eco-021, eco-022, eco-024).
+
+## Canonical Layout
+
+```
+docs/
+  journeys/
+    README.md                              # this file
+    <journey-id>.md                        # one per documented flow
+    manifests/
+      <journey-id>.journey.yaml            # rich-media manifest (eval contract)
+    assets/
+      stubs/                               # stub placeholders for capture-in-flight media
+        <journey-id>/                      # one dir per journey
+          frame-###.gif|png                # stub placeholders
+  templates/
+    journey-template.md                    # page template (this dir's contract)
+    bdd-feature-template.feature           # BDD template linked from the page template
+```
+
+A journey page is **always** anchored to an FR/NFR row in
+[`FUNCTIONAL_REQUIREMENTS.md`](../../FUNCTIONAL_REQUIREMENTS.md) and to
+a `kitty-spec` slug under [`kitty-specs/`](../../kitty-specs/). The
+journey page is a thin human-readable narrative; the executable
+contract is the `<journey-id>.journey.yaml` manifest (eval) and the
+`<journey-id>.feature` BDD file (acceptance). Rich-media evidence
+(keyframes, recordings) lives under
+`docs/journeys/assets/stubs/<journey-id>/` as git-tracked placeholders
+until `phenotype-journey capture` produces real artifacts.
+
+## Template
+
+Every journey page MUST follow the canonical template at
+[`../templates/journey-template.md`](../templates/journey-template.md).
+The template enforces, in order:
+
+1. **YAML front-matter** with `fr_id`, `spec_slug`, `spec_anchor`,
+   `status`, `captured_at`. This header is the contract that
+   `tooling/trace-validator/` (eco-024) and the eco-021 autograder
+   consume; the validator refuses a journey whose `fr_id` is not
+   registered in `FUNCTIONAL_REQUIREMENTS.md`.
+2. **User story** paragraph, one block, written in the
+   "As a `<role>`, I want `<capability>`, so that `<outcome>`" voice.
+3. **Acceptance criteria** as an ordered list, each item addressable
+   from the BDD scenarios in the companion `.feature` file.
+4. **Steps** with one stub media reference per transition. Stubs use
+   the Phenotype-org `<!-- RICH-MEDIA-STUB ... --> ... <!-- END-RICH-MEDIA-STUB -->`
+   comment pair (see [`../../RICH_MEDIA.md`](../../RICH_MEDIA.md)). Each
+   stub points at a file under
+   `docs/journeys/assets/stubs/<journey-id>/` and is greppable by
+   `journey="<journey-id>"`.
+5. **Traceability table** with explicit columns `AC | Criterion |
+   Test / Evidence`. The `Test / Evidence` cell must point at a real
+   path (test file, BDD scenario, or YAML manifest) — never at
+   `TBD`.
+6. **Eval checklist** enumerating the autograder gates that must pass
+   before the journey can be marked `status: captured` or
+   `status: published`.
+
+## Stub Convention
+
+Until a real capture is recorded, every transition in the **Steps**
+section carries a stub block:
+
+```html
+<!-- RICH-MEDIA-STUB type="recording-gif" subject="<what the media will show>" journey="<journey-id>" status="TODO" -->
+> **[RICH MEDIA PLACEHOLDER]** *<one-line human description of what will go here>*
+<!-- END-RICH-MEDIA-STUB -->
+```
+
+Rules (strict, enforced by `phenotype-journey lint` once wired into
+eco-021):
+
+- `journey` attribute MUST equal the page's `<journey-id>` and match a
+  manifest under `docs/journeys/manifests/`.
+- `type` MUST be one of `annotated-screenshot | recording-mp4 | recording-gif`
+  (Phenotype-org canonical set; see
+  [`../../RICH_MEDIA.md`](../../RICH_MEDIA.md)).
+- The image path referenced in the stub (when present) MUST live under
+  `docs/journeys/assets/stubs/<journey-id>/`.
+- The stub MUST wrap a single line of human-readable description so
+  fill-agents can replace it without diffing the comment fences.
+- `status` MUST be one of `TODO` (un-captured) | `CAPTURED` (raw asset
+  exists) | `PUBLISHED` (asset is embedded in the live docs site).
+
+A `.gitkeep` placeholder lives at
+[`assets/stubs/.gitkeep`](./assets/stubs/.gitkeep) so the stub tree
+exists in fresh checkouts. Per-journey stub directories are created
+on demand when the first stub for a journey is authored.
+
+## Manifest Convention
+
+The companion manifest
+`docs/journeys/manifests/<journey-id>.journey.yaml` is the **eval
+contract** for the journey. It mirrors
+`phenotype_journey_core::Manifest` (hwLedger exemplar) and lists one
+`steps[]` entry per Acceptance Criterion with `must_contain`,
+`must_contain_regex`, `must_not_contain`, and `expected_exit`
+assertions. The manifest is the only artifact `phenotype-journey
+verify` reads; missing manifests fail the eco-021 docs gate.
+
+```yaml
+id: <journey-id>
+intent: <one-line user story>
+keyframe_count: <int>
+passed: false                       # set true after `phenotype-journey verify` accepts
+recording: assets/stubs/<journey-id>/replay.gif
+steps:
+  - index: 1
+    slug: <short-state-name>
+    assertions:
+      must_contain: ["..."]
+      must_not_contain: ["error:"]
+      expected_exit: 0
+      ocr_required: true
+```
+
+## Spec Linkage
+
+Every journey page MUST cross-link three layers:
+
+| Layer | Where it lives | Required link from the page |
+|-------|----------------|-----------------------------|
+| FR/NFR | [`FUNCTIONAL_REQUIREMENTS.md`](../../FUNCTIONAL_REQUIREMENTS.md) | `fr_id` in front-matter; row in Traceability table |
+| Spec | [`kitty-specs/<spec_slug>/spec.md`](../../kitty-specs/) | `spec_slug` + `spec_anchor` in front-matter; "User story" mirrors the spec verbatim |
+| BDD | `specs/<spec_slug>/bdd/<journey-id>.feature` (or a sibling path) | one `Scenario:` per AC; linked from Traceability table |
+
+Spec linkage is verified by `tooling/trace-validator/` (eco-024) on
+every PR. A journey page that points at a missing slug, a missing
+anchor, or an unregistered FR ID fails the gate.
+
+## BDD Template
+
+BDD files for journeys MUST be authored against
+[`../templates/bdd-feature-template.feature`](../templates/bdd-feature-template.feature).
+The template uses the canonical Gherkin shape: one `Feature:`, one
+`Background:`, one `Scenario:` per AC, and `@fr-XXX` tags on every
+scenario so eco-024 can map scenarios back to FR rows. Scenario names
+are stable — renaming a scenario is a breaking change to the BDD
+contract and requires a Traceability table update on the journey
+page.
+
+## Adoption Checklist
+
+When adding a new journey:
+
+- [ ] Register the FR row in
+      [`FUNCTIONAL_REQUIREMENTS.md`](../../FUNCTIONAL_REQUIREMENTS.md)
+      with `status: proposed` and a stub trace.
+- [ ] Copy [`../templates/journey-template.md`](../templates/journey-template.md)
+      to `docs/journeys/<journey-id>.md` and fill the front-matter.
+- [ ] Copy
+      [`../templates/bdd-feature-template.feature`](../templates/bdd-feature-template.feature)
+      to `specs/<spec_slug>/bdd/<journey-id>.feature` and author one
+      `Scenario:` per AC.
+- [ ] Author `docs/journeys/manifests/<journey-id>.journey.yaml` with
+      at least one `must_not_contain: ["error:"]` step and a final
+      `expected_exit: 0` step.
+- [ ] Add a stub block to every transition in **Steps**; create
+      `docs/journeys/assets/stubs/<journey-id>/` if needed.
+- [ ] Cross-link the journey page from the kitty-spec user-story
+      section.
+- [ ] Run `cargo run -p tooling-trace-validator -- --strict` and
+      confirm green.
+
+## Status
+
+- [x] Identify initial FR/NFR-backed flows from
+      `docs/requirements/agileplus-frnfr.md`
+- [x] Author canonical journey page template
+- [x] Author canonical BDD feature template
+- [ ] Author manifests in `docs/journeys/manifests/`
+- [ ] Wire `phenotype-journey lint` into the eco-021 autograder
+- [ ] Run `phenotype-journey verify` in CI
+
+## See also
+
+- [`../../RICH_MEDIA.md`](../../RICH_MEDIA.md) — Phenotype-org
+  rich-media stub convention (authoritative).
+- [`../operations/journey-traceability.md`](../operations/journey-traceability.md) —
+  AgilePlus journey-traceability standard.
+- [`../../FUNCTIONAL_REQUIREMENTS.md`](../../FUNCTIONAL_REQUIREMENTS.md) —
+  canonical FR registry.
+- [`../../kitty-specs/eco-022-rich-journey-embeds/spec.md`](../../kitty-specs/eco-022-rich-journey-embeds/spec.md) —
+  source spec for this directory's contract.
+- hwLedger exemplar:
+  `KooshaPari/hwLedger@codex/add-rich-journey-embeds-to-docs-v10` →
+  `docs/journeys/manifests/README.md`.

--- a/docs/journeys/assets/stubs/.gitkeep
+++ b/docs/journeys/assets/stubs/.gitkeep
@@ -1,0 +1,7 @@
+Keep this directory under version control so stubbed rich-media assets
+have a stable, well-known home. Per-journey subdirectories
+(`<journey-id>/frame-###.{png,gif}`) are created on demand when a
+journey is first authored. Do not commit real captures here — once
+`phenotype-journey capture` produces a real artifact, the stub is
+replaced and the real asset is published to the docs site. See
+[`../README.md`](../README.md) for the full stub convention.

--- a/docs/templates/bdd-feature-template.feature
+++ b/docs/templates/bdd-feature-template.feature
@@ -1,0 +1,57 @@
+# Template: BDD feature for a journey page
+# Owner: docs/journeys/README.md (mirrors hwLedger add-rich-journey-embeds-to-docs-v10)
+# Linked spec: kitty-specs/eco-022-rich-journey-embeds/spec.md
+# Linked journey: docs/journeys/<journey-id>.md
+# Linked FR: <fr_id>
+#
+# Copy this file to `specs/<spec_slug>/bdd/<journey-id>.feature` and
+# rename `Feature:` and `Scenario:` titles. Tag every Scenario with the
+# matching `@fr-XXX` tag so tooling/trace-validator (eco-024) can
+# bind scenarios to FR rows in FUNCTIONAL_REQUIREMENTS.md.
+#
+# Hard rules (enforced by eco-021 docs gate):
+#   - One Feature per journey page.
+#   - One Background per Feature.
+#   - One Scenario per Acceptance Criterion in the journey page.
+#   - Every Scenario has a stable @fr-XXX tag.
+#   - Renaming a Scenario is a breaking change to the BDD contract;
+#     the linked journey page's Traceability table must be updated
+#     in the same PR.
+
+@journey=<journey-id>
+@fr=<FR-XXX-NNN>
+@spec=<kitty-spec-slug>
+Feature: <Human-Readable Title>
+  As a <role>
+  I want <capability>
+  So that <outcome>
+
+  Background:
+    Given <precondition common to all scenarios>
+    And <precondition common to all scenarios>
+
+  @fr=<FR-XXX-NNN> @ac=1
+  Scenario: AC1 — <short criterion name>
+    When <action>
+    And <action>
+    Then <observable outcome>
+    And <observable outcome>
+
+  @fr=<FR-XXX-NNN> @ac=2
+  Scenario: AC2 — <short criterion name>
+    When <action>
+    Then <observable outcome>
+    And <observable outcome>
+
+  @fr=<FR-XXX-NNN> @ac=3
+  Scenario: AC3 — <short criterion name>
+    When <action>
+    And <action>
+    Then <observable outcome>
+    And <observable outcome>
+
+  @fr=<FR-XXX-NNN> @ac=4
+  Scenario: AC4 — <short criterion name>
+    When <action>
+    Then <observable outcome>
+    And <observable outcome>

--- a/docs/templates/journey-template.md
+++ b/docs/templates/journey-template.md
@@ -1,0 +1,112 @@
+<!--
+Template: journey page
+Owner: docs/journeys/README.md (mirrors hwLedger add-rich-journey-embeds-to-docs-v10)
+Linked spec: kitty-specs/eco-022-rich-journey-embeds/spec.md
+Linked FR: <fr_id> (row in FUNCTIONAL_REQUIREMENTS.md)
+Linked BDD: specs/<spec_slug>/bdd/<journey-id>.feature
+
+Copy this file to `docs/journeys/<journey-id>.md`, fill the placeholders
+in angle brackets, and delete the leading `<!--` block. The contract
+enforced by tooling/trace-validator (eco-024) and the eco-021
+autograder is:
+
+  1. Front-matter is mandatory and well-formed.
+  2. `fr_id` is registered in FUNCTIONAL_REQUIREMENTS.md.
+  3. `spec_slug` + `spec_anchor` resolve to a real file + heading.
+  4. The Traceability table maps every AC to a real test/evidence path.
+  5. The Eval checklist enumerates the autograder gates that must
+     pass before `status` may move from `pending-capture` to
+     `captured` or `published`.
+-->
+---
+fr_id: <FR-XXX-NNN>                # registered in FUNCTIONAL_REQUIREMENTS.md
+spec_slug: <kitty-spec-slug>        # e.g. eco-022-rich-journey-embeds
+spec_anchor: "#<heading-anchor>"    # exact heading anchor in the spec
+status: pending-capture             # pending-capture | captured | published | deprecated
+captured_at: null                   # ISO 8601 timestamp once status flips
+---
+
+# Journey: <Human-Readable Title>
+
+> **Status: `<status>`** — `<fr_id>`. See
+> `kitty-specs/<spec_slug>/spec.md` (anchor `spec_anchor`) for the
+> source of truth and
+> `specs/<spec_slug>/bdd/<journey-id>.feature` for the executable
+> acceptance scenarios. The rich-media manifest lives at
+> [`docs/journeys/manifests/<journey-id>.journey.yaml`](../journeys/manifests/<journey-id>.journey.yaml).
+
+## User story
+
+As a **<role>**, I want <capability>, so that <outcome>. This block
+MUST mirror the spec's user story verbatim. If the spec and the
+journey page disagree, the spec wins and the journey is treated as
+out-of-date by the trace validator.
+
+## Acceptance criteria
+
+1. **AC1** — <one-sentence criterion, addressable from a BDD Scenario>.
+2. **AC2** — <one-sentence criterion>.
+3. **AC3** — <one-sentence criterion>.
+
+(Add or remove ACs to match the FR. Each AC MUST be reachable from a
+BDD scenario in the linked `.feature` file and from a row in the
+Traceability table below.)
+
+## Steps
+
+1. <First transition — e.g. "Run `agileplus <subcommand>`">
+   <!-- RICH-MEDIA-STUB type="recording-gif" subject="<short description of what the GIF will show>" journey="<journey-id>" status="TODO" -->
+   > **[RICH MEDIA PLACEHOLDER]** *<one-line human description of what will go here>*
+   <!-- END-RICH-MEDIA-STUB -->
+2. <Second transition — e.g. "Open `http://localhost:<port>/health`">
+   <!-- RICH-MEDIA-STUB type="annotated-screenshot" subject="<short description>" journey="<journey-id>" status="TODO" -->
+   > **[RICH MEDIA PLACEHOLDER]** *<one-line human description of what will go here>*
+   <!-- END-RICH-MEDIA-STUB -->
+3. <Third transition — e.g. "Confirm `healthy: true` and numeric latency">
+   <!-- RICH-MEDIA-STUB type="recording-gif" subject="<short description>" journey="<journey-id>" status="TODO" -->
+   > **[RICH MEDIA PLACEHOLDER]** *<one-line human description of what will go here>*
+   <!-- END-RICH-MEDIA-STUB -->
+4. <Fourth transition — e.g. "Hit the JSON endpoint and compare payload">
+   <!-- RICH-MEDIA-STUB type="annotated-screenshot" subject="<short description>" journey="<journey-id>" status="TODO" -->
+   > **[RICH MEDIA PLACEHOLDER]** *<one-line human description of what will go here>*
+   <!-- END-RICH-MEDIA-STUB -->
+
+## Traceability
+
+| AC | Criterion | Test / Evidence |
+|----|-----------|-----------------|
+| AC1 | <criterion verbatim> | `crates/<crate>/tests/<file>.rs::<test_name>` |
+| AC2 | <criterion verbatim> | `specs/<spec_slug>/bdd/<journey-id>.feature::<scenario_name>` |
+| AC3 | <criterion verbatim> | `docs/journeys/manifests/<journey-id>.journey.yaml` |
+| AC4 | <criterion verbatim> | (repeat per AC) |
+
+> **Rule:** every `Test / Evidence` cell MUST point at a real path
+> that exists in the working tree at PR time. `TBD`, `TBA`, or empty
+> cells fail the eco-021 docs gate.
+
+## Eval checklist
+
+- [ ] `cargo test -p <crate>` (or workspace) exits 0.
+- [ ] All ACs above have at least one passing test in the linked
+      `*.rs` file or BDD scenario.
+- [ ] BDD scenarios in
+      `specs/<spec_slug>/bdd/<journey-id>.feature` are one-to-one
+      with the ACs.
+- [ ] `docs/journeys/manifests/<journey-id>.journey.yaml` passes
+      `phenotype-journey verify` (every `must_contain` /
+      `must_not_contain` / `expected_exit` assertion holds).
+- [ ] All stub blocks in **Steps** have a non-empty human-readable
+      description and a `journey` attribute equal to `<journey-id>`.
+- [ ] No existing spec under `kitty-specs/` or
+      `docs/requirements/agileplus-frnfr.md` is regressed.
+- [ ] `tooling/trace-validator` reports green for `<fr_id>`.
+
+## See also
+
+- [`../journeys/README.md`](../journeys/README.md) — journeys index
+  and stub convention.
+- [`../../RICH_MEDIA.md`](../../RICH_MEDIA.md) — Phenotype-org
+  rich-media stub markers.
+- `kitty-specs/<spec_slug>/spec.md` — source spec.
+- `docs/journeys/manifests/<journey-id>.journey.yaml` — eval
+  contract.


### PR DESCRIPTION
## **User description**
## Summary
- `docs/journeys/README.md` — journeys index modelled on the hwLedger `add-rich-journey-embeds-to-docs-v10` exemplar. Codifies the canonical layout (page + manifest + stub tree), the rich-media stub convention (`RICH-MEDIA-STUB` comment pair), the manifest contract (`must_contain` / `must_not_contain` / `expected_exit`), and spec linkage to `FUNCTIONAL_REQUIREMENTS.md` + `kitty-specs/`.
- `docs/journeys/assets/stubs/.gitkeep` — placeholder so the stub tree exists in fresh checkouts.
- `docs/templates/journey-template.md` — canonical page template enforced by `tooling/trace-validator/` (eco-024) and the eco-021 autograder. Includes YAML front-matter, user story, ACs, steps with one stub per transition, traceability table, and eval checklist.
- `docs/templates/bdd-feature-template.feature` — BDD template with one Scenario per AC, `@fr-XXX` tags for trace binding, and the stable-name contract enforced by eco-021.

## Why
Implements the docs surface of `kitty-specs/eco-022-rich-journey-embeds`. The hwLedger exemplar in `codex/add-rich-journey-embeds-to-docs-v10` is the model; this PR ports the same contract to AgilePlus and binds it to the local `FUNCTIONAL_REQUIREMENTS.md` registry and the FR-024 trace rows.

## Test plan
- [ ] `git show --stat HEAD` on the branch lists exactly 4 files: `docs/journeys/README.md`, `docs/journeys/assets/stubs/.gitkeep`, `docs/templates/journey-template.md`, `docs/templates/bdd-feature-template.feature`.
- [ ] `grep -E '^---$|^[a-z_]+:' docs/journeys/README.md` confirms the front-matter is parseable YAML.
- [ ] `grep -E '^\s+@fr=' docs/templates/bdd-feature-template.feature` confirms the per-AC tagger contract.
- [ ] `git ls-tree -r HEAD -- docs/journeys docs/templates` shows the four files at HEAD with no extraneous entries.
- [ ] No existing spec under `kitty-specs/` or `docs/requirements/agileplus-frnfr.md` is regressed by this PR (docs-only change).

## Out of scope
- The autograder wiring (`phenotype-journey lint` + `verify`) is left to a follow-up work package, gated on eco-021 acceptance.
- The `docs/operations/journey-traceability.md` adopter list and the per-flow pages (e.g. `docs/journeys/dashboard-health-check.md`) already exist and are unaffected; future flows should follow the new template.

## Notes for reviewer
- Branch base: `origin/main` @ `7f54ee095`.
- Pre-commit trufflehog scan passed (0 verified secrets, 0 unverified).
- The branch is small and docs-only: 4 files, 371 insertions, 0 deletions, 0 modifications.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only additions with no runtime, auth, or data-path changes; existing specs are referenced but not modified.
> 
> **Overview**
> Introduces the **docs/journeys** contract for eco-022: a new index README that defines layout, **RICH-MEDIA-STUB** rules, manifest shape, and trace links to `FUNCTIONAL_REQUIREMENTS.md` and kitty-specs, plus an adoption checklist and explicit follow-ups (manifests, `phenotype-journey lint` / verify in CI).
> 
> Adds copy-paste **templates** for journey pages (YAML front-matter, ACs, per-step stubs, traceability table, eval checklist) and BDD features (one scenario per AC with `@fr` tags). A **`.gitkeep`** under `docs/journeys/assets/stubs/` reserves the stub asset tree for fresh clones.
> 
> No autograder wiring or per-flow journey pages in this PR—docs-only scaffolding aligned with the hwLedger exemplar.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecbb8cf13eefa2f1cab69fc465a45370ff505433. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Add the canonical journey docs and BDD templates for rich media flows**

### What Changed
- Added a journeys guide that explains the required page layout, trace links, rich-media stub rules, manifest expectations, and approval checklist for new journey docs
- Added a standard journey page template with front matter, user story, acceptance criteria, step-by-step stub placeholders, traceability table, and evaluation checklist
- Added a matching BDD feature template so each journey can be described with one scenario per acceptance criterion and linked FR tags
- Added a tracked stub directory placeholder so journey media can live in a stable location from the start

### Impact
`✅ Clearer journey documentation setup`
`✅ Faster authoring of new BDD-backed journeys`
`✅ Fewer broken trace links in journey pages`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
