### PR TITLE
feat(cli): MVP write-commands (project/epic/story/wp/dep/cycle/transition/next-ready) + governance fail-closed fix

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -7,6 +7,15 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
+      # The workspace has relative-path deps on the phenoShared sibling
+      # (agileplus-domain/application -> ../../../phenoShared/crates/phenotype-error-core),
+      # which resolves to $GITHUB_WORKSPACE/../phenoShared. Clone it there so
+      # cargo can load those manifests during clippy/test.
+      - name: Checkout phenoShared sibling
+        run: |
+          git clone --depth 1 \
+            "https://x-access-token:${{ github.token }}@github.com/KooshaPari/phenoShared.git" \
+            "${{ github.workspace }}/../phenoShared"
       - uses: dtolnay/rust-toolchain@stable
       - uses: arduino/setup-protoc@v3
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ exclude = ["AgilePlus/rust", "rust", "crates/phenotype-config"]
 version = "0.1.0"
 edition = "2021"
 license = "MIT"
-rust-version = "1.85"
+rust-version = "1.88"
 
 [package]
 name = "agileplus"

--- a/clippy.toml
+++ b/clippy.toml
@@ -5,7 +5,7 @@
 # `[workspace.package].rust-version`. Without this override, clippy emits
 # "the MSRV in `clippy.toml` and `Cargo.toml` differ" on every crate and the
 # `-D warnings` gate cannot pass cleanly.
-msrv                      = "1.85.0"
+msrv                      = "1.88.0"
 avoid-breaking-exported-api = true
 allow-dbg-in-tests        = true
 disallowed-methods        = []

--- a/crates/agileplus-application/src/error.rs
+++ b/crates/agileplus-application/src/error.rs
@@ -4,7 +4,7 @@
 
 use std::error::Error;
 
-use phenotype_error_core::PhenotypeErrorKind as ErrorKind;
+use phenotype_error_core::ErrorCode;
 use thiserror::Error;
 
 use agileplus_domain::error::DomainError;
@@ -24,42 +24,43 @@ pub enum AppError {
     Storage(#[source] Box<dyn Error + Send + Sync>),
 }
 
-/// Lift the application error into the canonical Phenotype error kind.
+/// Project the application error onto the canonical Phenotype wire
+/// [`ErrorCode`].
 ///
-/// `AppError::Storage` carries a boxed source; we render that into the
-/// `ErrorKind::Storage` payload so observability consumers see the cause
-/// without needing to downcast the original.
-impl From<AppError> for ErrorKind {
+/// Lossy by design: `AppError`'s boxed source / messages remain the source of
+/// truth for human-facing reporting, while [`ErrorCode`] is the stable,
+/// language-agnostic code for observability and wire responses.
+impl From<AppError> for ErrorCode {
     fn from(err: AppError) -> Self {
         match err {
             AppError::Domain(d) => d.into(),
-            AppError::NotFound(s) => Self::NotFound(s),
-            AppError::Storage(src) => Self::Storage(src.to_string()),
+            AppError::NotFound(_) => Self::NotFound,
+            AppError::Storage(_) => Self::InternalError,
         }
     }
 }
 
 #[cfg(test)]
-mod kind_lift_tests {
+mod code_projection_tests {
     use super::*;
 
     #[test]
-    fn not_found_lifts_to_not_found() {
-        let k: ErrorKind = AppError::NotFound("user 1".into()).into();
-        assert!(matches!(k, ErrorKind::NotFound(s) if s == "user 1"));
+    fn not_found_projects_to_not_found() {
+        let c: ErrorCode = AppError::NotFound("user 1".into()).into();
+        assert_eq!(c, ErrorCode::NotFound);
     }
 
     #[test]
     fn domain_validation_chains_through() {
         let app = AppError::Domain(DomainError::Validation("name required".into()));
-        let k: ErrorKind = app.into();
-        assert!(matches!(k, ErrorKind::Validation(s) if s == "name required"));
+        let c: ErrorCode = app.into();
+        assert_eq!(c, ErrorCode::ValidationError);
     }
 
     #[test]
-    fn storage_lifts_to_storage_with_source_string() {
+    fn storage_projects_to_internal_error() {
         let src: Box<dyn Error + Send + Sync> = "db down".to_string().into();
-        let k: ErrorKind = AppError::Storage(src).into();
-        assert!(matches!(k, ErrorKind::Storage(s) if s == "db down"));
+        let c: ErrorCode = AppError::Storage(src).into();
+        assert_eq!(c, ErrorCode::InternalError);
     }
 }

--- a/crates/agileplus-cache/tests/integration_tests.rs
+++ b/crates/agileplus-cache/tests/integration_tests.rs
@@ -302,6 +302,6 @@ fn test_cache_config_clone() {
 #[test]
 fn test_cache_config_debug() {
     let config = CacheConfig::default();
-    let debug_str = format!("{:?}", config);
+    let debug_str = format!("{config:?}");
     assert!(debug_str.contains("CacheConfig"));
 }

--- a/crates/agileplus-cli/Cargo.toml
+++ b/crates/agileplus-cli/Cargo.toml
@@ -6,7 +6,7 @@ license.workspace = true
 rust-version.workspace = true
 
 [[bin]]
-name = "agileplus-cli"
+name = "agileplus"
 path = "src/main.rs"
 
 [dependencies]

--- a/crates/agileplus-cli/src/commands/mod.rs
+++ b/crates/agileplus-cli/src/commands/mod.rs
@@ -8,6 +8,7 @@ pub mod list_epics;
 pub mod list_projects;
 pub mod list_stories;
 pub mod list_tests;
+pub mod mvp;
 pub mod seed_requirements;
 
 // ── stub modules (excluded until upstream deps are resolved) ──────────────────

--- a/crates/agileplus-cli/src/commands/mvp.rs
+++ b/crates/agileplus-cli/src/commands/mvp.rs
@@ -1,0 +1,404 @@
+//! MVP project/epic/story/work-package command surface.
+
+use std::str::FromStr;
+
+use anyhow::{anyhow, bail, Context, Result};
+use chrono::NaiveDate;
+use clap::{Args, Subcommand, ValueEnum};
+
+use agileplus_domain::{
+    domain::{
+        cycle::{Cycle, CycleFeature},
+        epic::Epic,
+        project::Project,
+        story::{Story, StoryStatus},
+        work_package::{DependencyType, WorkPackage, WpDependency, WpState},
+    },
+    ports::StoragePort,
+};
+
+#[derive(Debug, Subcommand)]
+pub enum ProjectCmd {
+    /// Create a project.
+    Create(ProjectCreateArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct ProjectCreateArgs {
+    #[arg(long)]
+    pub slug: String,
+
+    #[arg(long)]
+    pub name: String,
+
+    #[arg(long)]
+    pub description: Option<String>,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum EpicCmd {
+    /// Create an epic.
+    Create(EpicCreateArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct EpicCreateArgs {
+    #[arg(long)]
+    pub project: i64,
+
+    #[arg(long)]
+    pub title: String,
+
+    #[arg(long)]
+    pub description: String,
+
+    #[arg(long)]
+    pub requirement: Option<String>,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum StoryCmd {
+    /// Create a story.
+    Create(StoryCreateArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct StoryCreateArgs {
+    #[arg(long)]
+    pub epic: i64,
+
+    #[arg(long)]
+    pub title: String,
+
+    #[arg(long)]
+    pub description: String,
+
+    #[arg(long)]
+    pub points: Option<u32>,
+
+    #[arg(long)]
+    pub requirement: Option<String>,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum WpCmd {
+    /// Create a work package for a story.
+    Create(WpCreateArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct WpCreateArgs {
+    #[arg(long)]
+    pub story: i64,
+
+    #[arg(long)]
+    pub title: String,
+
+    #[arg(long = "file-scope")]
+    pub file_scope: String,
+
+    #[arg(long)]
+    pub acceptance: String,
+
+    #[arg(long)]
+    pub seq: Option<i32>,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum DepCmd {
+    /// Add a work-package dependency.
+    Add(DepAddArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct DepAddArgs {
+    #[arg(long)]
+    pub wp: i64,
+
+    #[arg(long = "depends-on")]
+    pub depends_on: i64,
+
+    #[arg(long = "type", value_enum)]
+    pub dep_type: DepTypeArg,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum DepTypeArg {
+    Explicit,
+    FileOverlap,
+    Data,
+}
+
+#[derive(Debug, Args)]
+pub struct CycleCreateArgs {
+    #[arg(long)]
+    pub name: String,
+
+    #[arg(long)]
+    pub start: String,
+
+    #[arg(long)]
+    pub end: String,
+}
+
+#[derive(Debug, Args)]
+pub struct CycleAddArgs {
+    #[arg(long)]
+    pub cycle: i64,
+
+    #[arg(long, conflicts_with = "story")]
+    pub epic: Option<i64>,
+
+    #[arg(long, conflicts_with = "epic")]
+    pub story: Option<i64>,
+}
+
+#[derive(Debug, Args)]
+pub struct TransitionArgs {
+    #[arg(long, conflicts_with = "story")]
+    pub wp: Option<i64>,
+
+    #[arg(long, conflicts_with = "wp")]
+    pub story: Option<i64>,
+
+    #[arg(long)]
+    pub to: String,
+}
+
+#[derive(Debug, Args)]
+pub struct NextReadyArgs {
+    #[arg(long)]
+    pub cycle: Option<i64>,
+
+    #[arg(long)]
+    pub json: bool,
+}
+
+pub async fn project_create<S: StoragePort>(args: &ProjectCreateArgs, storage: &S) -> Result<()> {
+    let mut project = Project::new(&args.name, &args.slug)?;
+    project.description = args.description.clone();
+    let id = storage
+        .create_project(&project)
+        .await
+        .context("creating project")?;
+    println!("project_id: {id}");
+    Ok(())
+}
+
+pub async fn epic_create<S: StoragePort>(args: &EpicCreateArgs, storage: &S) -> Result<()> {
+    let mut epic = Epic::new(args.project, &args.title)?;
+    epic.description = Some(args.description.clone());
+    epic.requirement_id = args.requirement.clone();
+    let id = storage.create_epic(&epic).await.context("creating epic")?;
+    println!("epic_id: {id}");
+    Ok(())
+}
+
+pub async fn story_create<S: StoragePort>(args: &StoryCreateArgs, storage: &S) -> Result<()> {
+    let epic = storage
+        .get_epic_by_id(args.epic)
+        .await
+        .context("loading epic")?
+        .ok_or_else(|| anyhow!("epic {} not found", args.epic))?;
+    let mut story = Story::new(args.epic, epic.project_id, &args.title, args.points)?;
+    story.description = Some(args.description.clone());
+    story.requirement_id = args.requirement.clone();
+    let id = storage
+        .create_story(&story)
+        .await
+        .context("creating story")?;
+    println!("story_id: {id}");
+    Ok(())
+}
+
+pub async fn wp_create<S: StoragePort>(args: &WpCreateArgs, storage: &S) -> Result<()> {
+    let seq = args.seq.unwrap_or(1);
+    let mut wp = WorkPackage::new(0, &args.title, seq, &args.acceptance);
+    wp.file_scope = parse_csv(&args.file_scope);
+    let id = storage
+        .create_work_package_for_story(args.story, &wp)
+        .await
+        .context("creating work package")?;
+    println!("wp_id: {id}");
+    Ok(())
+}
+
+pub async fn dep_add<S: StoragePort>(args: &DepAddArgs, storage: &S) -> Result<()> {
+    let dep = WpDependency {
+        wp_id: args.wp,
+        depends_on: args.depends_on,
+        dep_type: args.dep_type.into(),
+    };
+    storage
+        .add_wp_dependency(&dep)
+        .await
+        .context("adding work package dependency")?;
+    println!("dependency: {} -> {}", args.wp, args.depends_on);
+    Ok(())
+}
+
+pub async fn cycle_create<S: StoragePort>(args: &CycleCreateArgs, storage: &S) -> Result<()> {
+    let start = parse_date(&args.start)?;
+    let end = parse_date(&args.end)?;
+    let cycle = Cycle::new(&args.name, start, end, None).map_err(anyhow::Error::msg)?;
+    let id = storage
+        .create_cycle(&cycle)
+        .await
+        .context("creating cycle")?;
+    println!("cycle_id: {id}");
+    Ok(())
+}
+
+pub async fn cycle_add<S: StoragePort>(args: &CycleAddArgs, storage: &S) -> Result<()> {
+    match (args.epic, args.story) {
+        (Some(epic_id), None) => {
+            let stories = storage
+                .list_stories_by_epic(epic_id)
+                .await
+                .context("listing epic stories")?;
+            if stories.is_empty() {
+                bail!("epic {epic_id} has no stories to add");
+            }
+            for story in stories {
+                storage
+                    .add_story_to_cycle(args.cycle, story.id)
+                    .await
+                    .with_context(|| format!("adding story {} to cycle", story.id))?;
+            }
+            println!("cycle_story_count: added epic {epic_id}");
+        }
+        (None, Some(story_id)) => {
+            storage
+                .add_story_to_cycle(args.cycle, story_id)
+                .await
+                .context("adding story to cycle")?;
+            println!("cycle_story: {} -> {}", args.cycle, story_id);
+        }
+        _ => bail!("provide exactly one of --epic or --story"),
+    }
+    Ok(())
+}
+
+pub async fn cycle_add_feature<S: StoragePort>(
+    cycle_id: i64,
+    feature_id: i64,
+    storage: &S,
+) -> Result<()> {
+    storage
+        .add_feature_to_cycle(&CycleFeature::new(cycle_id, feature_id))
+        .await
+        .context("adding feature to cycle")?;
+    println!("cycle_feature: {cycle_id} -> {feature_id}");
+    Ok(())
+}
+
+pub async fn transition<S: StoragePort>(args: &TransitionArgs, storage: &S) -> Result<()> {
+    match (args.wp, args.story) {
+        (Some(wp_id), None) => {
+            let target = parse_wp_state(&args.to)?;
+            let wp = storage
+                .get_work_package(wp_id)
+                .await
+                .context("loading work package")?
+                .ok_or_else(|| anyhow!("work package {wp_id} not found"))?;
+            if !wp.state.can_transition_to(target) {
+                bail!("illegal wp transition: {:?} -> {:?}", wp.state, target);
+            }
+            storage
+                .update_wp_state(wp_id, target)
+                .await
+                .context("updating work package state")?;
+            println!("wp_state: {wp_id} -> {}", wp_state_label(target));
+        }
+        (None, Some(story_id)) => {
+            let target = StoryStatus::from_str(&args.to)?;
+            let mut story = storage
+                .get_story_by_id(story_id)
+                .await
+                .context("loading story")?
+                .ok_or_else(|| anyhow!("story {story_id} not found"))?;
+            story.transition_status(target)?;
+            storage
+                .update_story_status(story_id, target)
+                .await
+                .context("updating story status")?;
+            println!("story_status: {story_id} -> {target}");
+        }
+        _ => bail!("provide exactly one of --wp or --story"),
+    }
+    Ok(())
+}
+
+pub async fn next_ready<S: StoragePort>(args: &NextReadyArgs, storage: &S) -> Result<()> {
+    let wps = storage
+        .get_next_ready_wps(args.cycle)
+        .await
+        .context("listing next-ready work packages")?;
+
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&wps)?);
+        return Ok(());
+    }
+
+    if wps.is_empty() {
+        println!("No next-ready work packages.");
+        return Ok(());
+    }
+
+    println!("{:<6}  {:<8}  {:<8}  {}", "ID", "FEATURE", "STATE", "TITLE");
+    println!("{}", "-".repeat(70));
+    for wp in &wps {
+        println!(
+            "{:<6}  {:<8}  {:<8}  {}",
+            wp.id,
+            wp.feature_id,
+            wp_state_label(wp.state),
+            wp.title
+        );
+    }
+    Ok(())
+}
+
+fn parse_csv(raw: &str) -> Vec<String> {
+    raw.split(',')
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+fn parse_date(raw: &str) -> Result<NaiveDate> {
+    NaiveDate::parse_from_str(raw, "%Y-%m-%d")
+        .with_context(|| format!("invalid date '{raw}', expected YYYY-MM-DD"))
+}
+
+fn parse_wp_state(raw: &str) -> Result<WpState> {
+    match raw {
+        "planned" => Ok(WpState::Planned),
+        "doing" => Ok(WpState::Doing),
+        "review" => Ok(WpState::Review),
+        "done" => Ok(WpState::Done),
+        "blocked" => Ok(WpState::Blocked),
+        _ => bail!("unknown WpState: {raw}"),
+    }
+}
+
+fn wp_state_label(state: WpState) -> &'static str {
+    match state {
+        WpState::Planned => "planned",
+        WpState::Doing => "doing",
+        WpState::Review => "review",
+        WpState::Done => "done",
+        WpState::Blocked => "blocked",
+    }
+}
+
+impl From<DepTypeArg> for DependencyType {
+    fn from(value: DepTypeArg) -> Self {
+        match value {
+            DepTypeArg::Explicit => DependencyType::Explicit,
+            DepTypeArg::FileOverlap => DependencyType::FileOverlap,
+            DepTypeArg::Data => DependencyType::Data,
+        }
+    }
+}

--- a/crates/agileplus-cli/src/main.rs
+++ b/crates/agileplus-cli/src/main.rs
@@ -180,7 +180,7 @@ fn cmd_feature_show(store: &MockStore, id: i64) {
                 f.updated_at.format("%Y-%m-%d %H:%M:%S UTC")
             );
         }
-        None => eprintln!("error: feature {} not found", id),
+        None => eprintln!("error: feature {id} not found"),
     }
 }
 

--- a/crates/agileplus-cli/src/main.rs
+++ b/crates/agileplus-cli/src/main.rs
@@ -27,6 +27,10 @@ use sync_cmd::SyncArgs;
     version
 )]
 struct Cli {
+    /// SQLite database path. Defaults to AGILEPLUS_DB, then ./agileplus.db.
+    #[arg(long, env = "AGILEPLUS_DB", value_name = "PATH", global = true)]
+    db: Option<PathBuf>,
+
     #[command(subcommand)]
     command: Command,
 }
@@ -60,6 +64,35 @@ enum Command {
     ListEpics(commands::list_epics::ListEpicsArgs),
     /// List stories, optionally filtered by epic and/or status
     ListStories(commands::list_stories::ListStoriesArgs),
+    /// Project management (MVP)
+    Project {
+        #[command(subcommand)]
+        sub: commands::mvp::ProjectCmd,
+    },
+    /// Epic management (MVP)
+    Epic {
+        #[command(subcommand)]
+        sub: commands::mvp::EpicCmd,
+    },
+    /// Story management (MVP)
+    Story {
+        #[command(subcommand)]
+        sub: commands::mvp::StoryCmd,
+    },
+    /// Work-package management (MVP)
+    Wp {
+        #[command(subcommand)]
+        sub: commands::mvp::WpCmd,
+    },
+    /// Work-package dependency management (MVP)
+    Dep {
+        #[command(subcommand)]
+        sub: commands::mvp::DepCmd,
+    },
+    /// Transition a work-package or story to a new state (MVP)
+    Transition(commands::mvp::TransitionArgs),
+    /// List planned work packages that are ready to start (MVP)
+    NextReady(commands::mvp::NextReadyArgs),
 }
 
 #[derive(Subcommand)]
@@ -83,6 +116,10 @@ enum ModuleCmd {
 enum CycleCmd {
     /// Show the current (active) cycle
     Current,
+    /// Create a cycle
+    Create(commands::mvp::CycleCreateArgs),
+    /// Add a story (or all stories of an epic) to a cycle
+    Add(commands::mvp::CycleAddArgs),
 }
 
 // ── in-memory mock store ─────────────────────────────────────────────────────
@@ -214,10 +251,18 @@ fn cmd_version() {
 
 /// Resolve the SQLite database path from `AGILEPLUS_DB` env var or fall back
 /// to `./agileplus.db` in the current directory.
-fn db_path_from_env() -> PathBuf {
-    std::env::var("AGILEPLUS_DB")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| PathBuf::from("agileplus.db"))
+fn db_path(cli: &Cli) -> PathBuf {
+    cli.db
+        .clone()
+        .unwrap_or_else(|| PathBuf::from("agileplus.db"))
+}
+
+/// Open the file-backed SQLite storage adapter at the resolved DB path.
+fn open_storage(
+    db_path: &std::path::Path,
+) -> anyhow::Result<agileplus_sqlite::SqliteStorageAdapter> {
+    agileplus_sqlite::SqliteStorageAdapter::new(db_path)
+        .map_err(|e| anyhow::anyhow!("open db: {e}"))
 }
 
 // ── entry point ──────────────────────────────────────────────────────────────
@@ -225,6 +270,7 @@ fn db_path_from_env() -> PathBuf {
 #[tokio::main]
 async fn main() {
     let cli = Cli::parse();
+    let db_path = db_path(&cli);
     let store = MockStore::seed();
 
     let result: anyhow::Result<()> = async {
@@ -238,6 +284,14 @@ async fn main() {
             },
             Command::Cycle { sub } => match sub {
                 CycleCmd::Current => cmd_cycle_current(&store),
+                CycleCmd::Create(args) => {
+                    let storage = open_storage(&db_path)?;
+                    commands::mvp::cycle_create(&args, &storage).await?;
+                }
+                CycleCmd::Add(args) => {
+                    let storage = open_storage(&db_path)?;
+                    commands::mvp::cycle_add(&args, &storage).await?;
+                }
             },
             Command::Version => cmd_version(),
             Command::Sync(args) => {
@@ -247,22 +301,64 @@ async fn main() {
                 commands::seed_requirements::run(&args)?;
             }
             Command::ListProjects(args) => {
-                let db_path = db_path_from_env();
-                let storage = agileplus_sqlite::SqliteStorageAdapter::new(&db_path)
-                    .map_err(|e| anyhow::anyhow!("open db: {e}"))?;
+                let storage = open_storage(&db_path)?;
                 commands::list_projects::run(&args, &storage).await?;
             }
             Command::ListEpics(args) => {
-                let db_path = db_path_from_env();
-                let storage = agileplus_sqlite::SqliteStorageAdapter::new(&db_path)
-                    .map_err(|e| anyhow::anyhow!("open db: {e}"))?;
+                let storage = open_storage(&db_path)?;
                 commands::list_epics::run(&args, &storage).await?;
             }
             Command::ListStories(args) => {
-                let db_path = db_path_from_env();
-                let storage = agileplus_sqlite::SqliteStorageAdapter::new(&db_path)
-                    .map_err(|e| anyhow::anyhow!("open db: {e}"))?;
+                let storage = open_storage(&db_path)?;
                 commands::list_stories::run(&args, &storage).await?;
+            }
+            Command::Project { sub } => {
+                let storage = open_storage(&db_path)?;
+                match sub {
+                    commands::mvp::ProjectCmd::Create(args) => {
+                        commands::mvp::project_create(&args, &storage).await?;
+                    }
+                }
+            }
+            Command::Epic { sub } => {
+                let storage = open_storage(&db_path)?;
+                match sub {
+                    commands::mvp::EpicCmd::Create(args) => {
+                        commands::mvp::epic_create(&args, &storage).await?;
+                    }
+                }
+            }
+            Command::Story { sub } => {
+                let storage = open_storage(&db_path)?;
+                match sub {
+                    commands::mvp::StoryCmd::Create(args) => {
+                        commands::mvp::story_create(&args, &storage).await?;
+                    }
+                }
+            }
+            Command::Wp { sub } => {
+                let storage = open_storage(&db_path)?;
+                match sub {
+                    commands::mvp::WpCmd::Create(args) => {
+                        commands::mvp::wp_create(&args, &storage).await?;
+                    }
+                }
+            }
+            Command::Dep { sub } => {
+                let storage = open_storage(&db_path)?;
+                match sub {
+                    commands::mvp::DepCmd::Add(args) => {
+                        commands::mvp::dep_add(&args, &storage).await?;
+                    }
+                }
+            }
+            Command::Transition(args) => {
+                let storage = open_storage(&db_path)?;
+                commands::mvp::transition(&args, &storage).await?;
+            }
+            Command::NextReady(args) => {
+                let storage = open_storage(&db_path)?;
+                commands::mvp::next_ready(&args, &storage).await?;
             }
         }
         Ok(())

--- a/crates/agileplus-cli/src/sync_cmd.rs
+++ b/crates/agileplus-cli/src/sync_cmd.rs
@@ -42,8 +42,7 @@ fn split_repo(repo: &str) -> Result<(&str, &str)> {
     match repo.split_once('/') {
         Some((owner, name)) if !owner.is_empty() && !name.is_empty() => Ok((owner, name)),
         _ => bail!(
-            "invalid repo format '{}': expected owner/repo (e.g. KooshaPari/AgilePlus)",
-            repo
+            "invalid repo format '{repo}': expected owner/repo (e.g. KooshaPari/AgilePlus)"
         ),
     }
 }

--- a/crates/agileplus-dashboard/src/process_detector.rs
+++ b/crates/agileplus-dashboard/src/process_detector.rs
@@ -148,7 +148,7 @@ fn format_agent_name(process_name: &str, worktree: &Option<String>) -> String {
     if let Some(wt) = worktree {
         // Extract just the project name from the worktree path
         if let Some(last_segment) = wt.split('/').next_back() {
-            return format!("{}-{}", base_name, last_segment);
+            return format!("{base_name}-{last_segment}");
         }
     }
 
@@ -173,7 +173,7 @@ fn get_process_start_time(process: &sysinfo::Process) -> Option<String> {
 /// Format an elapsed duration in seconds as a human-readable string.
 fn format_elapsed(secs: u64) -> String {
     if secs < 60 {
-        format!("{}s", secs)
+        format!("{secs}s")
     } else if secs < 3600 {
         format!("{}m", secs / 60)
     } else {

--- a/crates/agileplus-dashboard/src/routes.rs
+++ b/crates/agileplus-dashboard/src/routes.rs
@@ -957,8 +957,7 @@ pub async fn feature_media(
         .join("\n");
 
     Html(format!(
-        r#"<div class="grid grid-cols-2 gap-3 media-gallery">{}</div>"#,
-        html
+        r#"<div class="grid grid-cols-2 gap-3 media-gallery">{html}</div>"#
     ))
     .into_response()
 }
@@ -1004,7 +1003,7 @@ pub async fn agent_activity(State(state): State<SharedState>) -> Response {
 /// `process_detector::get_process_start_time` (e.g. "5m", "1h 20m").
 fn calculate_uptime(started_at: &Option<String>) -> String {
     match started_at {
-        Some(elapsed) => format!("running for {}", elapsed),
+        Some(elapsed) => format!("running for {elapsed}"),
         None => "uptime unknown".into(),
     }
 }
@@ -1771,8 +1770,7 @@ fn validate_restart_command(cmd_line: &str) -> Result<(), String> {
     let program = parts.remove(0);
     if !is_restart_command_allowed(program) {
         return Err(format!(
-            "command '{}' is not in approved restart command registry: {:?}",
-            program, ALLOWED_RESTART_PROGRAMS
+            "command '{program}' is not in approved restart command registry: {ALLOWED_RESTART_PROGRAMS:?}"
         ));
     }
 
@@ -1880,11 +1878,11 @@ pub async fn patch_service_config(
 
     match config.save() {
         Ok(_) => render(ToastPartial {
-            message: format!("Service '{}' configuration saved", name),
+            message: format!("Service '{name}' configuration saved"),
             success: true,
         }),
         Err(e) => render(ToastPartial {
-            message: format!("Failed to save: {}", e),
+            message: format!("Failed to save: {e}"),
             success: false,
         }),
     }
@@ -1997,11 +1995,11 @@ pub async fn test_agent_connection(
             true,
             "Local provider requires no external credentials".to_string(),
         ),
-        other => (false, format!("Unknown provider: {}", other)),
+        other => (false, format!("Unknown provider: {other}")),
     };
 
     let css = if ok { "text-green-400" } else { "text-red-400" };
-    Html(format!(r#"<span class="{}">{}</span>"#, css, msg)).into_response()
+    Html(format!(r#"<span class="{css}">{msg}</span>"#)).into_response()
 }
 
 // ── Router builder ───────────────────────────────────────────────────────
@@ -2032,7 +2030,7 @@ pub async fn save_plane_settings(axum::Form(form): axum::Form<PlaneSettingsForm>
             success: true,
         }),
         Err(e) => render(ToastPartial {
-            message: format!("Failed to save settings: {}", e),
+            message: format!("Failed to save settings: {e}"),
             success: false,
         }),
     }
@@ -2062,7 +2060,7 @@ pub async fn save_agent_settings(axum::Form(form): axum::Form<AgentSettingsForm>
             success: true,
         }),
         Err(e) => render(ToastPartial {
-            message: format!("Failed to save settings: {}", e),
+            message: format!("Failed to save settings: {e}"),
             success: false,
         }),
     }
@@ -2093,7 +2091,7 @@ pub async fn save_dashboard_settings(
             success: true,
         }),
         Err(e) => render(ToastPartial {
-            message: format!("Failed to save settings: {}", e),
+            message: format!("Failed to save settings: {e}"),
             success: false,
         }),
     }
@@ -2130,7 +2128,7 @@ pub async fn save_services_settings(axum::Form(form): axum::Form<ServiceSettings
             success: true,
         }),
         Err(e) => render(ToastPartial {
-            message: format!("Failed to save settings: {}", e),
+            message: format!("Failed to save settings: {e}"),
             success: false,
         }),
     }

--- a/crates/agileplus-dashboard/tests/health_integration.rs
+++ b/crates/agileplus-dashboard/tests/health_integration.rs
@@ -79,26 +79,22 @@ fn run_health_checks_returns_four_healthy_services() {
         services.len()
     );
     let names: Vec<&str> = services.iter().map(|s| s.name.as_str()).collect();
-    assert!(names.contains(&"SQLite"), "Missing SQLite in {:?}", names);
+    assert!(names.contains(&"SQLite"), "Missing SQLite in {names:?}");
     assert!(
         names.contains(&"In-Memory Store"),
-        "Missing In-Memory Store in {:?}",
-        names
+        "Missing In-Memory Store in {names:?}"
     );
     assert!(
         names.contains(&"Process Metrics"),
-        "Missing Process Metrics in {:?}",
-        names
+        "Missing Process Metrics in {names:?}"
     );
     assert!(
         names.contains(&"Build Info"),
-        "Missing Build Info in {:?}",
-        names
+        "Missing Build Info in {names:?}"
     );
     assert!(
         services.iter().all(|s| s.healthy),
-        "All services must report healthy: {:?}",
-        services
+        "All services must report healthy: {services:?}"
     );
 }
 
@@ -108,8 +104,7 @@ fn at_least_one_service_reports_measurable_latency() {
     let services = run_health_checks();
     assert!(
         services.iter().any(|s| s.latency_ms.is_some()),
-        "At least one service should report measurable latency, got {:?}",
-        services
+        "At least one service should report measurable latency, got {services:?}"
     );
 }
 

--- a/crates/agileplus-domain/src/error.rs
+++ b/crates/agileplus-domain/src/error.rs
@@ -1,6 +1,6 @@
 //! Domain error types.
 
-use phenotype_error_core::PhenotypeErrorKind as ErrorKind;
+use phenotype_error_core::ErrorCode;
 use thiserror::Error;
 
 /// Top-level domain error.
@@ -53,116 +53,120 @@ pub enum DomainError {
     LockPoisoned,
 }
 
-/// Lift the AgilePlus domain error into the canonical Phenotype error kind.
+/// Project the AgilePlus domain error onto the canonical Phenotype wire
+/// [`ErrorCode`].
 ///
-/// This is a *lossy* projection: domain-specific structural data (e.g.
-/// `InvalidTransition { from, to, reason }`) is flattened into the kind's
-/// display string. The local [`DomainError`] remains the source of truth
-/// for cross-crate messaging; [`PhenotypeErrorKind`] is for cross-ecosystem
-/// reporting (logs, wire codes, observability).
-impl From<DomainError> for ErrorKind {
+/// This is a *lossy* classification: the structural payload (slugs, transition
+/// detail, free-text messages) is dropped — the local [`DomainError`] remains
+/// the source of truth for human-facing messaging, while [`ErrorCode`] is the
+/// stable, language-agnostic code used for cross-ecosystem reporting (logs,
+/// wire responses, observability, Rust↔TS parity).
+impl From<DomainError> for ErrorCode {
     fn from(err: DomainError) -> Self {
         match err {
-            DomainError::FeatureNotInModuleScope {
-                feature_slug,
-                module_slug,
-            } => Self::Domain(format!(
-                "feature '{feature_slug}' not in module '{module_slug}'"
-            )),
-            DomainError::ModuleHasDependents(s) => Self::Conflict(s),
-            DomainError::CycleNotFound(s) => Self::NotFound(format!("cycle {s}")),
-            DomainError::ModuleNotFound(s) => Self::NotFound(format!("module {s}")),
-            DomainError::FeatureNotFound(s) => Self::NotFound(format!("feature {s}")),
-            DomainError::WorkPackageNotFound(s) => Self::NotFound(format!("work package {s}")),
-            DomainError::NotFound(s) => Self::NotFound(s),
-            DomainError::NotImplemented => Self::Domain("not implemented".into()),
-            DomainError::Storage(s) => Self::Storage(s),
-            DomainError::Validation(s) => Self::Validation(s),
-            DomainError::Conflict(s) => Self::Conflict(s),
-            DomainError::InvalidTransition { from, to, reason } => {
-                Self::Domain(format!("invalid transition from {from} to {to}: {reason}"))
-            }
-            DomainError::LockPoisoned => Self::Domain("lock poisoned".into()),
+            // "not found" family
+            DomainError::CycleNotFound(_)
+            | DomainError::ModuleNotFound(_)
+            | DomainError::FeatureNotFound(_)
+            | DomainError::WorkPackageNotFound(_)
+            | DomainError::NotFound(_) => Self::NotFound,
+
+            // conflicts / already-exists
+            DomainError::ModuleHasDependents(_) | DomainError::Conflict(_) => Self::AlreadyExists,
+
+            // validation / bad input (scope + state-machine violations are
+            // invalid-argument-shaped from the caller's perspective)
+            DomainError::Validation(_)
+            | DomainError::FeatureNotInModuleScope { .. }
+            | DomainError::InvalidTransition { .. } => Self::ValidationError,
+
+            DomainError::NotImplemented => Self::NotImplemented,
+
+            // infrastructure / internal faults
+            DomainError::Storage(_) | DomainError::LockPoisoned => Self::InternalError,
         }
     }
 }
 
 #[cfg(test)]
-mod kind_lift_tests {
+mod code_projection_tests {
     use super::*;
 
     #[test]
-    fn module_not_found_lifts_to_not_found() {
-        let k: ErrorKind = DomainError::ModuleNotFound("m-1".into()).into();
-        assert!(matches!(k, ErrorKind::NotFound(s) if s == "module m-1"));
+    fn module_not_found_projects_to_not_found() {
+        let c: ErrorCode = DomainError::ModuleNotFound("m-1".into()).into();
+        assert_eq!(c, ErrorCode::NotFound);
     }
 
     #[test]
-    fn work_package_not_found_lifts_to_not_found() {
-        let k: ErrorKind = DomainError::WorkPackageNotFound("wp-7".into()).into();
-        assert!(matches!(k, ErrorKind::NotFound(s) if s == "work package wp-7"));
+    fn work_package_not_found_projects_to_not_found() {
+        let c: ErrorCode = DomainError::WorkPackageNotFound("wp-7".into()).into();
+        assert_eq!(c, ErrorCode::NotFound);
     }
 
     #[test]
-    fn cycle_not_found_lifts_to_not_found() {
-        let k: ErrorKind = DomainError::CycleNotFound("c-3".into()).into();
-        assert!(matches!(k, ErrorKind::NotFound(s) if s == "cycle c-3"));
+    fn cycle_and_feature_not_found_project_to_not_found() {
+        let c: ErrorCode = DomainError::CycleNotFound("c-3".into()).into();
+        assert_eq!(c, ErrorCode::NotFound);
+        let c: ErrorCode = DomainError::FeatureNotFound("f-9".into()).into();
+        assert_eq!(c, ErrorCode::NotFound);
+        let c: ErrorCode = DomainError::NotFound("x".into()).into();
+        assert_eq!(c, ErrorCode::NotFound);
     }
 
     #[test]
-    fn module_has_dependents_lifts_to_conflict() {
-        let k: ErrorKind = DomainError::ModuleHasDependents("m-1".into()).into();
-        assert!(matches!(k, ErrorKind::Conflict(s) if s == "m-1"));
+    fn conflicts_project_to_already_exists() {
+        let c: ErrorCode = DomainError::ModuleHasDependents("m-1".into()).into();
+        assert_eq!(c, ErrorCode::AlreadyExists);
+        let c: ErrorCode = DomainError::Conflict("dup".into()).into();
+        assert_eq!(c, ErrorCode::AlreadyExists);
     }
 
     #[test]
-    fn invalid_transition_lifts_to_domain_preserving_payload() {
-        let k: ErrorKind = DomainError::InvalidTransition {
+    fn validation_shaped_errors_project_to_validation_error() {
+        let c: ErrorCode = DomainError::Validation("name required".into()).into();
+        assert_eq!(c, ErrorCode::ValidationError);
+
+        let c: ErrorCode = DomainError::FeatureNotInModuleScope {
+            feature_slug: "f-1".into(),
+            module_slug: "m-1".into(),
+        }
+        .into();
+        assert_eq!(c, ErrorCode::ValidationError);
+
+        let c: ErrorCode = DomainError::InvalidTransition {
             from: "draft".into(),
             to: "done".into(),
             reason: "missing review".into(),
         }
         .into();
-        let s = k.to_string();
-        assert!(s.contains("draft"));
-        assert!(s.contains("done"));
-        assert!(s.contains("missing review"));
-        assert!(matches!(k, ErrorKind::Domain(_)));
+        assert_eq!(c, ErrorCode::ValidationError);
     }
 
     #[test]
-    fn validation_lifts_to_validation() {
-        let k: ErrorKind = DomainError::Validation("name required".into()).into();
-        assert!(matches!(k, ErrorKind::Validation(s) if s == "name required"));
+    fn storage_and_lock_project_to_internal_error() {
+        let c: ErrorCode = DomainError::Storage("db down".into()).into();
+        assert_eq!(c, ErrorCode::InternalError);
+        let c: ErrorCode = DomainError::LockPoisoned.into();
+        assert_eq!(c, ErrorCode::InternalError);
     }
 
     #[test]
-    fn storage_lifts_to_storage() {
-        let k: ErrorKind = DomainError::Storage("db down".into()).into();
-        assert!(matches!(k, ErrorKind::Storage(s) if s == "db down"));
+    fn not_implemented_projects_to_not_implemented() {
+        let c: ErrorCode = DomainError::NotImplemented.into();
+        assert_eq!(c, ErrorCode::NotImplemented);
     }
 
     #[test]
-    fn feature_not_in_module_scope_lifts_to_domain() {
-        let k: ErrorKind = DomainError::FeatureNotInModuleScope {
-            feature_slug: "f-1".into(),
-            module_slug: "m-1".into(),
-        }
-        .into();
-        assert!(matches!(k, ErrorKind::Domain(_)));
-        assert!(k.to_string().contains("f-1"));
-        assert!(k.to_string().contains("m-1"));
-    }
-
-    #[test]
-    fn lock_poisoned_lifts_to_domain() {
-        let k: ErrorKind = DomainError::LockPoisoned.into();
-        assert!(matches!(k, ErrorKind::Domain(_)));
-    }
-
-    #[test]
-    fn not_implemented_lifts_to_domain() {
-        let k: ErrorKind = DomainError::NotImplemented.into();
-        assert!(matches!(k, ErrorKind::Domain(_)));
+    fn domain_error_remains_source_of_truth_for_messaging() {
+        // The structural payload is preserved on DomainError itself even though
+        // the ErrorCode projection is lossy.
+        let e = DomainError::InvalidTransition {
+            from: "draft".into(),
+            to: "done".into(),
+            reason: "missing review".into(),
+        };
+        let msg = e.to_string();
+        assert!(msg.contains("draft") && msg.contains("done") && msg.contains("missing review"));
     }
 }

--- a/crates/agileplus-domain/src/ports/mod.rs
+++ b/crates/agileplus-domain/src/ports/mod.rs
@@ -72,6 +72,37 @@ pub trait StoragePort: Send + Sync {
     async fn get_wp_dependencies(&self, wp_id: i64) -> Result<Vec<WpDependency>, DomainError>;
     async fn get_ready_wps(&self, feature_id: i64) -> Result<Vec<WorkPackage>, DomainError>;
 
+    // --- MVP: story-scoped work packages ---
+    /// Create a work package and link it to a story (story_work_packages join).
+    async fn create_work_package_for_story(
+        &self,
+        _story_id: i64,
+        _wp: &WorkPackage,
+    ) -> Result<i64, DomainError> {
+        Err(DomainError::NotImplemented)
+    }
+    /// List the work packages linked to a story.
+    async fn list_wps_by_story(&self, _story_id: i64) -> Result<Vec<WorkPackage>, DomainError> {
+        Err(DomainError::NotImplemented)
+    }
+    /// List every work package across all features/stories.
+    async fn list_all_work_packages(&self) -> Result<Vec<WorkPackage>, DomainError> {
+        Err(DomainError::NotImplemented)
+    }
+    /// Return planned work packages that are ready to start: every explicit
+    /// dependency points to a Done WP AND no file in its scope overlaps a
+    /// Doing/Review WP. Optionally restricted to a cycle.
+    async fn get_next_ready_wps(
+        &self,
+        _cycle: Option<i64>,
+    ) -> Result<Vec<WorkPackage>, DomainError> {
+        Err(DomainError::NotImplemented)
+    }
+    /// Link a story to a cycle (cycle_stories join).
+    async fn add_story_to_cycle(&self, _cycle_id: i64, _story_id: i64) -> Result<(), DomainError> {
+        Err(DomainError::NotImplemented)
+    }
+
     // --- Audit ---
     async fn append_audit_entry(&self, entry: &AuditEntry) -> Result<i64, DomainError>;
     async fn get_audit_trail(&self, feature_id: i64) -> Result<Vec<AuditEntry>, DomainError>;

--- a/crates/agileplus-github/src/map.rs
+++ b/crates/agileplus-github/src/map.rs
@@ -87,7 +87,7 @@ pub fn gh_user_to_domain(
 ) -> Result<User, DomainError> {
     let effective_email = match email {
         Some(e) if e.contains('@') => e.to_string(),
-        _ => format!("{}@github.invalid", login),
+        _ => format!("{login}@github.invalid"),
     };
 
     let mut user = User::new(login, &effective_email, UserRole::Member)?;

--- a/crates/agileplus-governance/src/audit.rs
+++ b/crates/agileplus-governance/src/audit.rs
@@ -377,7 +377,7 @@ impl AuditLogger {
                 event.timestamp.to_rfc3339(),
                 event.level.to_string(),
                 event.action,
-                event.category.map(|c| format!("{:?}", c)),
+                event.category.map(|c| format!("{c:?}")),
                 event.message,
                 event.user_id,
                 event.client_ip,
@@ -420,7 +420,7 @@ impl AuditLogger {
 
         if let Some(ref category) = filter.category {
             sql.push_str(" AND category = ?");
-            params_vec.push(format!("{:?}", category));
+            params_vec.push(format!("{category:?}"));
         }
 
         if let Some(ref level) = filter.level {
@@ -594,8 +594,7 @@ impl AuditLogger {
         let now = Utc::now().to_rfc3339();
         let placeholders = ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
         let sql = format!(
-            "UPDATE audit_events SET synced_at = ? WHERE id IN ({})",
-            placeholders
+            "UPDATE audit_events SET synced_at = ? WHERE id IN ({placeholders})"
         );
 
         let mut params_vec: Vec<&dyn rusqlite::ToSql> = vec![&now];

--- a/crates/agileplus-governance/src/channel.rs
+++ b/crates/agileplus-governance/src/channel.rs
@@ -44,10 +44,10 @@ impl ReleaseChannel {
     /// Get the version suffix for this channel
     pub fn version_suffix(&self, iteration: u32) -> String {
         match self {
-            ReleaseChannel::Alpha => format!("-alpha.{}", iteration),
-            ReleaseChannel::Canary => format!("-canary.{}", iteration),
-            ReleaseChannel::Beta => format!("-beta.{}", iteration),
-            ReleaseChannel::Rc => format!("-rc.{}", iteration),
+            ReleaseChannel::Alpha => format!("-alpha.{iteration}"),
+            ReleaseChannel::Canary => format!("-canary.{iteration}"),
+            ReleaseChannel::Beta => format!("-beta.{iteration}"),
+            ReleaseChannel::Rc => format!("-rc.{iteration}"),
             ReleaseChannel::Prod => String::new(), // No suffix for prod
         }
     }
@@ -55,10 +55,10 @@ impl ReleaseChannel {
     /// Get the PEP 440 compliant suffix for PyPI
     pub fn pep440_suffix(&self, iteration: u32) -> String {
         match self {
-            ReleaseChannel::Alpha => format!("a{}", iteration),
-            ReleaseChannel::Canary => format!("rc{}", iteration), // PEP 440 doesn't have canary
-            ReleaseChannel::Beta => format!("b{}", iteration),
-            ReleaseChannel::Rc => format!("rc{}", iteration),
+            ReleaseChannel::Alpha => format!("a{iteration}"),
+            ReleaseChannel::Canary => format!("rc{iteration}"), // PEP 440 doesn't have canary
+            ReleaseChannel::Beta => format!("b{iteration}"),
+            ReleaseChannel::Rc => format!("rc{iteration}"),
             ReleaseChannel::Prod => String::new(),
         }
     }
@@ -145,7 +145,7 @@ impl FromStr for ReleaseChannel {
             "beta" | "b" => Ok(ReleaseChannel::Beta),
             "rc" | "release-candidate" => Ok(ReleaseChannel::Rc),
             "prod" | "production" | "stable" | "p" => Ok(ReleaseChannel::Prod),
-            _ => Err(format!("Unknown channel: {}", s)),
+            _ => Err(format!("Unknown channel: {s}")),
         }
     }
 }

--- a/crates/agileplus-governance/src/policy.rs
+++ b/crates/agileplus-governance/src/policy.rs
@@ -378,7 +378,7 @@ impl PolicyEngine {
                 || policy
                     .conditions
                     .iter()
-                    .all(|c| self.evaluate_condition(c, context));
+                    .all(|c| Self::evaluate_condition(c, context));
 
             if all_conditions_met {
                 let reason = policy
@@ -402,8 +402,12 @@ impl PolicyEngine {
         }
     }
 
-    /// Evaluate a single condition
-    fn evaluate_condition(&self, condition: &PolicyCondition, context: &PolicyContext) -> bool {
+    /// Evaluate a single condition.
+    ///
+    /// Associated (no `&self`): condition evaluation depends only on the
+    /// condition tree and the request context, not on engine state. Keeping it
+    /// `&self`-free also satisfies `clippy::only_used_in_recursion`.
+    fn evaluate_condition(condition: &PolicyCondition, context: &PolicyContext) -> bool {
         match condition {
             PolicyCondition::Equals { key, value } => context.get(key).is_none_or(|v| v == *value),
             PolicyCondition::Contains { key, value } => {
@@ -437,13 +441,13 @@ impl PolicyEngine {
             PolicyCondition::Env { name, value } => {
                 std::env::var(name).ok().is_none_or(|v| v == *value)
             }
-            PolicyCondition::Not { condition } => !self.evaluate_condition(condition, context),
+            PolicyCondition::Not { condition } => !Self::evaluate_condition(condition, context),
             PolicyCondition::And { conditions } => conditions
                 .iter()
-                .all(|c| self.evaluate_condition(c, context)),
+                .all(|c| Self::evaluate_condition(c, context)),
             PolicyCondition::Or { conditions } => conditions
                 .iter()
-                .any(|c| self.evaluate_condition(c, context)),
+                .any(|c| Self::evaluate_condition(c, context)),
         }
     }
 

--- a/crates/agileplus-governance/src/policy.rs
+++ b/crates/agileplus-governance/src/policy.rs
@@ -409,16 +409,16 @@ impl PolicyEngine {
     /// `&self`-free also satisfies `clippy::only_used_in_recursion`.
     fn evaluate_condition(condition: &PolicyCondition, context: &PolicyContext) -> bool {
         match condition {
-            PolicyCondition::Equals { key, value } => context.get(key).is_none_or(|v| v == *value),
+            PolicyCondition::Equals { key, value } => context.get(key).is_some_and(|v| v == *value),
             PolicyCondition::Contains { key, value } => {
-                context.get(key).is_none_or(|v| match (v, value) {
+                context.get(key).is_some_and(|v| match (v, value) {
                     (serde_json::Value::String(s), serde_json::Value::String(pattern)) => {
                         s.contains(pattern)
                     }
                     _ => false,
                 })
             }
-            PolicyCondition::Matches { key, pattern } => context.get(key).is_none_or(|v| {
+            PolicyCondition::Matches { key, pattern } => context.get(key).is_some_and(|v| {
                 if let serde_json::Value::String(s) = v {
                     regex::Regex::new(pattern)
                         .map(|r| r.is_match(s.as_str()))
@@ -437,9 +437,9 @@ impl PolicyEngine {
                         None
                     }
                 })
-                .is_none_or(|c| c >= *channel),
+                .is_some_and(|c| c >= *channel),
             PolicyCondition::Env { name, value } => {
-                std::env::var(name).ok().is_none_or(|v| v == *value)
+                std::env::var(name).ok().is_some_and(|v| v == *value)
             }
             PolicyCondition::Not { condition } => !Self::evaluate_condition(condition, context),
             PolicyCondition::And { conditions } => conditions

--- a/crates/agileplus-governance/src/types.rs
+++ b/crates/agileplus-governance/src/types.rs
@@ -68,7 +68,7 @@ impl std::str::FromStr for ActionCategory {
             "audit" => Ok(Self::Audit),
             "config" => Ok(Self::Config),
             "general" => Ok(Self::General),
-            _ => Err(format!("Unknown action category: {}", s)),
+            _ => Err(format!("Unknown action category: {s}")),
         }
     }
 }
@@ -103,7 +103,7 @@ impl std::str::FromStr for OperationResult {
             "success" => Ok(OperationResult::Success),
             "failure" => Ok(OperationResult::Failure),
             "partial_success" | "partialsuccess" => Ok(OperationResult::PartialSuccess),
-            _ => Err(format!("Unknown result: {}", s)),
+            _ => Err(format!("Unknown result: {s}")),
         }
     }
 }
@@ -138,7 +138,7 @@ impl std::str::FromStr for LogLevel {
             "info" => Ok(LogLevel::Info),
             "warn" | "warning" => Ok(LogLevel::Warn),
             "error" | "err" => Ok(LogLevel::Error),
-            _ => Err(format!("Unknown log level: {}", s)),
+            _ => Err(format!("Unknown log level: {s}")),
         }
     }
 }

--- a/crates/agileplus-grpc/src/conversions.rs
+++ b/crates/agileplus-grpc/src/conversions.rs
@@ -38,7 +38,7 @@ pub fn wp_to_proto(wp: DomainWorkPackage) -> ProtoWpStatus {
         pr_url: wp.pr_url.unwrap_or_default(),
         pr_state: wp
             .pr_state
-            .map(|ps| format!("{:?}", ps).to_lowercase())
+            .map(|ps| format!("{ps:?}").to_lowercase())
             .unwrap_or_default(),
         depends_on: Vec::new(), // Populated separately when needed
         file_scope: wp.file_scope,

--- a/crates/agileplus-grpc/tests/pact_schema.rs
+++ b/crates/agileplus-grpc/tests/pact_schema.rs
@@ -66,11 +66,10 @@ fn wp_state_encoding_contract() {
     ];
 
     for (state, expected_str) in state_cases {
-        let encoded = format!("{:?}", state).to_lowercase();
+        let encoded = format!("{state:?}").to_lowercase();
         assert_eq!(
             encoded, expected_str,
-            "WpState::{:?} must encode as '{}'",
-            state, expected_str
+            "WpState::{state:?} must encode as '{expected_str}'"
         );
     }
 }
@@ -96,8 +95,7 @@ fn feature_state_encoding_contract() {
         let displayed = state.to_string();
         assert_eq!(
             displayed, expected_display,
-            "FeatureState::{:?} must display as '{}'",
-            state, expected_display
+            "FeatureState::{state:?} must display as '{expected_display}'"
         );
     }
 }

--- a/crates/agileplus-p2p/src/git_merge/tests.rs
+++ b/crates/agileplus-p2p/src/git_merge/tests.rs
@@ -16,8 +16,7 @@ fn make_event_line(seq: i64) -> String {
 
 fn conflict_block(ours: &str, theirs: &str) -> String {
     format!(
-        "<<<<<<< HEAD\n{}\n=======\n{}\n>>>>>>> branch\n",
-        ours, theirs
+        "<<<<<<< HEAD\n{ours}\n=======\n{theirs}\n>>>>>>> branch\n"
     )
 }
 
@@ -32,7 +31,7 @@ fn resolve_jsonl_deduplicates() {
     let ev2 = make_event_line(2);
 
     // Both sides contain ev1; only ours has ev2.
-    let content = conflict_block(&format!("{}\n{}", ev1, ev2), &ev1);
+    let content = conflict_block(&format!("{ev1}\n{ev2}"), &ev1);
     std::fs::write(&path, content).unwrap();
 
     let changed = resolve_jsonl_conflict(&path).unwrap();
@@ -124,7 +123,7 @@ fn resolve_git_conflicts_end_to_end() {
     let ev2 = make_event_line(2);
     std::fs::write(
         events_dir.join("1.jsonl"),
-        conflict_block(&format!("{}\n{}", ev1, ev2), &ev1),
+        conflict_block(&format!("{ev1}\n{ev2}"), &ev1),
     )
     .unwrap();
 

--- a/crates/agileplus-p2p/src/import.rs
+++ b/crates/agileplus-p2p/src/import.rs
@@ -423,7 +423,7 @@ mod tests {
         std::fs::create_dir_all(&events_dir).unwrap();
         let ev = make_event("Feature", 1, 1);
         let line = serde_json::to_string(&ev).unwrap();
-        std::fs::write(events_dir.join("1.jsonl"), format!("{}\n", line)).unwrap();
+        std::fs::write(events_dir.join("1.jsonl"), format!("{line}\n")).unwrap();
 
         let es = MemEventStore::default();
         let ss = MemSnapshotStore::default();
@@ -447,7 +447,7 @@ mod tests {
         let events_dir = dir.join("events/Feature");
         std::fs::create_dir_all(&events_dir).unwrap();
         let line = serde_json::to_string(&ev).unwrap();
-        std::fs::write(events_dir.join("1.jsonl"), format!("{}\n", line)).unwrap();
+        std::fs::write(events_dir.join("1.jsonl"), format!("{line}\n")).unwrap();
 
         let stats = import_state(dir, &es, &ss).await.unwrap();
         assert_eq!(stats.events_imported, 0, "duplicate should be skipped");

--- a/crates/agileplus-p2p/src/lib.rs
+++ b/crates/agileplus-p2p/src/lib.rs
@@ -103,7 +103,7 @@ impl P2pBehaviour {
         let daemon = ServiceDaemon::new().map_err(|e| P2pError::MdnsStart(e.to_string()))?;
 
         // Register this node so other peers can discover it.
-        let host_name = format!("{}.local.", instance_name);
+        let host_name = format!("{instance_name}.local.");
         let service_info = mdns_sd::ServiceInfo::new(
             SERVICE_TYPE,
             instance_name,

--- a/crates/agileplus-plane/src/client/endpoints.rs
+++ b/crates/agileplus-plane/src/client/endpoints.rs
@@ -6,15 +6,13 @@ pub(super) struct ClientEndpoints;
 impl ClientEndpoints {
     pub(super) fn work_items_url(base_url: &str, workspace_slug: &str, project_id: &str) -> String {
         format!(
-            "{}/api/v1/workspaces/{}/projects/{}/work-items/",
-            base_url, workspace_slug, project_id
+            "{base_url}/api/v1/workspaces/{workspace_slug}/projects/{project_id}/work-items/"
         )
     }
 
     pub(super) fn modules_url(base_url: &str, workspace_slug: &str, project_id: &str) -> String {
         format!(
-            "{}/api/v1/workspaces/{}/projects/{}/modules/",
-            base_url, workspace_slug, project_id
+            "{base_url}/api/v1/workspaces/{workspace_slug}/projects/{project_id}/modules/"
         )
     }
 
@@ -25,8 +23,7 @@ impl ClientEndpoints {
         module_id: &str,
     ) -> String {
         format!(
-            "{}/api/v1/workspaces/{}/projects/{}/modules/{}/",
-            base_url, workspace_slug, project_id, module_id
+            "{base_url}/api/v1/workspaces/{workspace_slug}/projects/{project_id}/modules/{module_id}/"
         )
     }
 
@@ -37,8 +34,7 @@ impl ClientEndpoints {
         module_id: &str,
     ) -> String {
         format!(
-            "{}/api/v1/workspaces/{}/projects/{}/modules/{}/module-issues/",
-            base_url, workspace_slug, project_id, module_id
+            "{base_url}/api/v1/workspaces/{workspace_slug}/projects/{project_id}/modules/{module_id}/module-issues/"
         )
     }
 
@@ -50,15 +46,13 @@ impl ClientEndpoints {
         work_item_id: &str,
     ) -> String {
         format!(
-            "{}/api/v1/workspaces/{}/projects/{}/modules/{}/module-issues/{}/",
-            base_url, workspace_slug, project_id, module_id, work_item_id
+            "{base_url}/api/v1/workspaces/{workspace_slug}/projects/{project_id}/modules/{module_id}/module-issues/{work_item_id}/"
         )
     }
 
     pub(super) fn cycles_url(base_url: &str, workspace_slug: &str, project_id: &str) -> String {
         format!(
-            "{}/api/v1/workspaces/{}/projects/{}/cycles/",
-            base_url, workspace_slug, project_id
+            "{base_url}/api/v1/workspaces/{workspace_slug}/projects/{project_id}/cycles/"
         )
     }
 
@@ -69,8 +63,7 @@ impl ClientEndpoints {
         cycle_id: &str,
     ) -> String {
         format!(
-            "{}/api/v1/workspaces/{}/projects/{}/cycles/{}/",
-            base_url, workspace_slug, project_id, cycle_id
+            "{base_url}/api/v1/workspaces/{workspace_slug}/projects/{project_id}/cycles/{cycle_id}/"
         )
     }
 
@@ -81,8 +74,7 @@ impl ClientEndpoints {
         cycle_id: &str,
     ) -> String {
         format!(
-            "{}/api/v1/workspaces/{}/projects/{}/cycles/{}/cycle-issues/",
-            base_url, workspace_slug, project_id, cycle_id
+            "{base_url}/api/v1/workspaces/{workspace_slug}/projects/{project_id}/cycles/{cycle_id}/cycle-issues/"
         )
     }
 
@@ -94,8 +86,7 @@ impl ClientEndpoints {
         work_item_id: &str,
     ) -> String {
         format!(
-            "{}/api/v1/workspaces/{}/projects/{}/cycles/{}/cycle-issues/{}/",
-            base_url, workspace_slug, project_id, cycle_id, work_item_id
+            "{base_url}/api/v1/workspaces/{workspace_slug}/projects/{project_id}/cycles/{cycle_id}/cycle-issues/{work_item_id}/"
         )
     }
 
@@ -106,15 +97,13 @@ impl ClientEndpoints {
         work_item_id: &str,
     ) -> String {
         format!(
-            "{}/api/v1/workspaces/{}/projects/{}/work-items/{}/",
-            base_url, workspace_slug, project_id, work_item_id
+            "{base_url}/api/v1/workspaces/{workspace_slug}/projects/{project_id}/work-items/{work_item_id}/"
         )
     }
 
     pub(super) fn labels_url(base_url: &str, workspace_slug: &str, project_id: &str) -> String {
         format!(
-            "{}/api/v1/workspaces/{}/projects/{}/labels/",
-            base_url, workspace_slug, project_id
+            "{base_url}/api/v1/workspaces/{workspace_slug}/projects/{project_id}/labels/"
         )
     }
 }

--- a/crates/agileplus-plane/src/client/mock.rs
+++ b/crates/agileplus-plane/src/client/mock.rs
@@ -55,14 +55,14 @@ impl InMemoryPlaneClient {
                 updated_at: Some(chrono::Utc::now().to_rfc3339()),
             });
         }
-        anyhow::bail!("issue {} not found", id)
+        anyhow::bail!("issue {id} not found")
     }
 
     pub async fn get_work_item(&self, id: &str) -> anyhow::Result<PlaneWorkItemResponse> {
         self.issues
             .get(id)
             .cloned()
-            .ok_or_else(|| anyhow::anyhow!("issue {} not found", id))
+            .ok_or_else(|| anyhow::anyhow!("issue {id} not found"))
     }
 
     pub async fn list_work_items(&self) -> anyhow::Result<Vec<PlaneWorkItemResponse>> {

--- a/crates/agileplus-plane/src/sync_queue.rs
+++ b/crates/agileplus-plane/src/sync_queue.rs
@@ -328,7 +328,7 @@ mod tests {
     fn queue_full_error() {
         let mut q = SyncQueue::new();
         for i in 0..QUEUE_CAPACITY {
-            q.enqueue(SyncOpKind::CreateIssue, format!("{}", i))
+            q.enqueue(SyncOpKind::CreateIssue, format!("{i}"))
                 .unwrap();
         }
         let err = q.enqueue(SyncOpKind::CreateIssue, "overflow".into());

--- a/crates/agileplus-sqlite/src/lib.rs
+++ b/crates/agileplus-sqlite/src/lib.rs
@@ -176,6 +176,38 @@ impl StoragePort for SqliteStorageAdapter {
         work_packages::get_ready_wps(&conn, feature_id)
     }
 
+    async fn create_work_package_for_story(
+        &self,
+        story_id: i64,
+        wp: &WorkPackage,
+    ) -> Result<i64, DomainError> {
+        let conn = self.lock()?;
+        work_packages::create_work_package_for_story(&conn, story_id, wp)
+    }
+
+    async fn list_wps_by_story(&self, story_id: i64) -> Result<Vec<WorkPackage>, DomainError> {
+        let conn = self.lock()?;
+        work_packages::list_wps_by_story(&conn, story_id)
+    }
+
+    async fn list_all_work_packages(&self) -> Result<Vec<WorkPackage>, DomainError> {
+        let conn = self.lock()?;
+        work_packages::list_all_work_packages(&conn)
+    }
+
+    async fn get_next_ready_wps(
+        &self,
+        cycle: Option<i64>,
+    ) -> Result<Vec<WorkPackage>, DomainError> {
+        let conn = self.lock()?;
+        work_packages::get_next_ready_wps(&conn, cycle)
+    }
+
+    async fn add_story_to_cycle(&self, cycle_id: i64, story_id: i64) -> Result<(), DomainError> {
+        let conn = self.lock()?;
+        cycles::add_story_to_cycle(&conn, cycle_id, story_id)
+    }
+
     // -- Audit CRUD --
 
     async fn append_audit_entry(&self, entry: &AuditEntry) -> Result<i64, DomainError> {

--- a/crates/agileplus-sqlite/src/lib/tests/mod.rs
+++ b/crates/agileplus-sqlite/src/lib/tests/mod.rs
@@ -15,6 +15,7 @@ use agileplus_domain::ports::{ContentStoragePort, StoragePort};
 mod feature_work_packages;
 mod governance_metrics;
 mod modules_cycles;
+mod mvp_story_work_packages;
 
 fn make_adapter() -> SqliteStorageAdapter {
     SqliteStorageAdapter::in_memory().expect("in-memory adapter")

--- a/crates/agileplus-sqlite/src/lib/tests/mvp_story_work_packages.rs
+++ b/crates/agileplus-sqlite/src/lib/tests/mvp_story_work_packages.rs
@@ -1,0 +1,178 @@
+use super::*;
+use agileplus_domain::domain::{
+    epic::Epic,
+    project::Project,
+    story::Story,
+    work_package::{DependencyType, WorkPackage, WpDependency, WpState},
+};
+
+async fn make_story(db: &SqliteStorageAdapter) -> i64 {
+    let project_id = StoragePort::create_project(
+        db,
+        &Project::new("MVP Project", "mvp-project").expect("project"),
+    )
+    .await
+    .expect("create project");
+    let epic_id = StoragePort::create_epic(
+        db,
+        &Epic::new(project_id, "Render Foundation").expect("epic"),
+    )
+    .await
+    .expect("create epic");
+    StoragePort::create_story(
+        db,
+        &Story::new(epic_id, project_id, "Shader fallback", Some(5)).expect("story"),
+    )
+    .await
+    .expect("create story")
+}
+
+fn scoped_wp(title: &str, seq: i32, files: &[&str]) -> WorkPackage {
+    let mut wp = WorkPackage::new(0, title, seq, "acceptance");
+    wp.file_scope = files.iter().map(|file| file.to_string()).collect();
+    wp
+}
+
+#[tokio::test]
+async fn story_work_package_create_lists_by_story() {
+    let db = make_adapter();
+    let story_id = make_story(&db).await;
+
+    let wp_id = StoragePort::create_work_package_for_story(
+        &db,
+        story_id,
+        &scoped_wp("VertexLit chain", 1, &["Core.cs", "VoxelRender.cs"]),
+    )
+    .await
+    .unwrap();
+
+    let wps = StoragePort::list_wps_by_story(&db, story_id).await.unwrap();
+    assert_eq!(wps.len(), 1);
+    assert_eq!(wps[0].id, wp_id);
+    assert_eq!(wps[0].title, "VertexLit chain");
+    assert_eq!(wps[0].file_scope, vec!["Core.cs", "VoxelRender.cs"]);
+}
+
+#[tokio::test]
+async fn story_work_package_dependencies_are_persisted() {
+    let db = make_adapter();
+    let story_id = make_story(&db).await;
+    let wp1 = StoragePort::create_work_package_for_story(
+        &db,
+        story_id,
+        &scoped_wp("VertexLit chain", 1, &["Core.cs"]),
+    )
+    .await
+    .unwrap();
+    let wp2 = StoragePort::create_work_package_for_story(
+        &db,
+        story_id,
+        &scoped_wp("wp2", 2, &["Core.cs"]),
+    )
+    .await
+    .unwrap();
+
+    StoragePort::add_wp_dependency(
+        &db,
+        &WpDependency {
+            wp_id: wp2,
+            depends_on: wp1,
+            dep_type: DependencyType::FileOverlap,
+        },
+    )
+    .await
+    .unwrap();
+
+    let deps = StoragePort::get_wp_dependencies(&db, wp2).await.unwrap();
+    assert_eq!(deps.len(), 1);
+    assert_eq!(deps[0].depends_on, wp1);
+    assert_eq!(deps[0].dep_type, DependencyType::FileOverlap);
+}
+
+#[tokio::test]
+async fn work_package_transition_persists_state() {
+    let db = make_adapter();
+    let story_id = make_story(&db).await;
+    let wp_id = StoragePort::create_work_package_for_story(
+        &db,
+        story_id,
+        &scoped_wp("Transition target", 1, &["Core.cs"]),
+    )
+    .await
+    .unwrap();
+
+    StoragePort::update_wp_state(&db, wp_id, WpState::Doing)
+        .await
+        .unwrap();
+
+    let wp = StoragePort::get_work_package(&db, wp_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(wp.state, WpState::Doing);
+}
+
+#[tokio::test]
+async fn next_ready_excludes_unsatisfied_dependency_and_file_overlap() {
+    let db = make_adapter();
+    let story_id = make_story(&db).await;
+
+    let in_flight = StoragePort::create_work_package_for_story(
+        &db,
+        story_id,
+        &scoped_wp("in flight", 1, &["Core.cs"]),
+    )
+    .await
+    .unwrap();
+    let overlap_blocked = StoragePort::create_work_package_for_story(
+        &db,
+        story_id,
+        &scoped_wp("overlap blocked", 2, &["Core.cs"]),
+    )
+    .await
+    .unwrap();
+    let dep_blocker = StoragePort::create_work_package_for_story(
+        &db,
+        story_id,
+        &scoped_wp("dep blocker", 3, &["VoxelRender.cs"]),
+    )
+    .await
+    .unwrap();
+    let dep_blocked = StoragePort::create_work_package_for_story(
+        &db,
+        story_id,
+        &scoped_wp("dep blocked", 4, &["Lighting.cs"]),
+    )
+    .await
+    .unwrap();
+    let ready = StoragePort::create_work_package_for_story(
+        &db,
+        story_id,
+        &scoped_wp("ready", 5, &["Sky.cs"]),
+    )
+    .await
+    .unwrap();
+
+    StoragePort::add_wp_dependency(
+        &db,
+        &WpDependency {
+            wp_id: dep_blocked,
+            depends_on: dep_blocker,
+            dep_type: DependencyType::Explicit,
+        },
+    )
+    .await
+    .unwrap();
+    StoragePort::update_wp_state(&db, in_flight, WpState::Doing)
+        .await
+        .unwrap();
+
+    let next_ready = StoragePort::get_next_ready_wps(&db, None).await.unwrap();
+    let ids = next_ready.iter().map(|wp| wp.id).collect::<Vec<_>>();
+
+    assert!(ids.contains(&dep_blocker));
+    assert!(ids.contains(&ready));
+    assert!(!ids.contains(&in_flight));
+    assert!(!ids.contains(&overlap_blocked));
+    assert!(!ids.contains(&dep_blocked));
+}

--- a/crates/agileplus-sqlite/src/migrations/022_story_wp_cycle_links.sql
+++ b/crates/agileplus-sqlite/src/migrations/022_story_wp_cycle_links.sql
@@ -1,0 +1,23 @@
+-- UP
+CREATE TABLE IF NOT EXISTS story_work_packages (
+    story_id INTEGER NOT NULL REFERENCES stories(id) ON DELETE CASCADE,
+    wp_id    INTEGER NOT NULL REFERENCES work_packages(id) ON DELETE CASCADE,
+    PRIMARY KEY (story_id, wp_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_story_work_packages_wp ON story_work_packages(wp_id);
+
+CREATE TABLE IF NOT EXISTS cycle_stories (
+    cycle_id INTEGER NOT NULL REFERENCES cycles(id) ON DELETE CASCADE,
+    story_id INTEGER NOT NULL REFERENCES stories(id) ON DELETE CASCADE,
+    added_at TEXT    NOT NULL,
+    PRIMARY KEY (cycle_id, story_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_cycle_stories_story ON cycle_stories(story_id);
+
+-- DOWN
+DROP INDEX IF EXISTS idx_cycle_stories_story;
+DROP TABLE IF EXISTS cycle_stories;
+DROP INDEX IF EXISTS idx_story_work_packages_wp;
+DROP TABLE IF EXISTS story_work_packages;

--- a/crates/agileplus-sqlite/src/migrations/mod.rs
+++ b/crates/agileplus-sqlite/src/migrations/mod.rs
@@ -28,6 +28,7 @@ const MIGRATION_018: &str = include_str!("018_create_users.sql");
 const MIGRATION_019: &str = include_str!("019_create_epics.sql");
 const MIGRATION_020: &str = include_str!("020_create_stories.sql");
 const MIGRATION_021: &str = include_str!("021_add_requirement_id.sql");
+const MIGRATION_022: &str = include_str!("022_story_wp_cycle_links.sql");
 
 /// All migrations in order: (name, up_sql, down_sql)
 const MIGRATIONS: &[(&str, &str)] = &[
@@ -51,6 +52,7 @@ const MIGRATIONS: &[(&str, &str)] = &[
     ("019_create_epics", MIGRATION_019),
     ("020_create_stories", MIGRATION_020),
     ("021_add_requirement_id", MIGRATION_021),
+    ("022_story_wp_cycle_links", MIGRATION_022),
 ];
 
 /// Parse the UP section from a migration SQL file.

--- a/crates/agileplus-sqlite/src/repository/cycles/mod.rs
+++ b/crates/agileplus-sqlite/src/repository/cycles/mod.rs
@@ -217,6 +217,34 @@ pub fn add_feature_to_cycle(conn: &Connection, entry: &CycleFeature) -> Result<(
     Ok(())
 }
 
+/// Link a story to a cycle via the `cycle_stories` join. Idempotent.
+pub fn add_story_to_cycle(
+    conn: &Connection,
+    cycle_id: i64,
+    story_id: i64,
+) -> Result<(), DomainError> {
+    let exists: Option<i64> = conn
+        .query_row(
+            "SELECT id FROM cycles WHERE id = ?1",
+            params![cycle_id],
+            |row| row.get(0),
+        )
+        .optional()
+        .map_err(map_err)?;
+    if exists.is_none() {
+        return Err(DomainError::CycleNotFound(cycle_id.to_string()));
+    }
+
+    let now = chrono::Utc::now().to_rfc3339();
+    conn.execute(
+        "INSERT OR IGNORE INTO cycle_stories (cycle_id, story_id, added_at)
+         VALUES (?1, ?2, ?3)",
+        params![cycle_id, story_id, now],
+    )
+    .map_err(map_err)?;
+    Ok(())
+}
+
 pub fn remove_feature_from_cycle(
     conn: &Connection,
     cycle_id: i64,

--- a/crates/agileplus-sqlite/src/repository/work_packages.rs
+++ b/crates/agileplus-sqlite/src/repository/work_packages.rs
@@ -304,6 +304,180 @@ pub fn get_ready_wps(conn: &Connection, feature_id: i64) -> Result<Vec<WorkPacka
     rows.collect::<rusqlite::Result<Vec<_>>>().map_err(map_err)
 }
 
+/// Create a work package and link it to a story via `story_work_packages`.
+pub fn create_work_package_for_story(
+    conn: &Connection,
+    story_id: i64,
+    wp: &WorkPackage,
+) -> Result<i64, DomainError> {
+    let mut wp = wp.clone();
+    if wp.feature_id == 0 {
+        wp.feature_id = feature_id_for_story(conn, story_id)?;
+    }
+
+    let id = create_work_package(conn, &wp)?;
+    conn.execute(
+        "INSERT OR IGNORE INTO story_work_packages (story_id, wp_id) VALUES (?1, ?2)",
+        params![story_id, id],
+    )
+    .map_err(map_err)?;
+    Ok(id)
+}
+
+fn feature_id_for_story(conn: &Connection, story_id: i64) -> Result<i64, DomainError> {
+    let existing: Option<i64> = conn
+        .query_row(
+            "SELECT wp.feature_id
+             FROM work_packages wp
+             JOIN story_work_packages swp ON swp.wp_id = wp.id
+             WHERE swp.story_id = ?1
+             ORDER BY wp.id
+             LIMIT 1",
+            params![story_id],
+            |row| row.get(0),
+        )
+        .optional()
+        .map_err(map_err)?;
+    if let Some(feature_id) = existing {
+        return Ok(feature_id);
+    }
+
+    let story_title: String = conn
+        .query_row(
+            "SELECT title FROM stories WHERE id = ?1",
+            params![story_id],
+            |row| row.get(0),
+        )
+        .optional()
+        .map_err(map_err)?
+        .ok_or_else(|| DomainError::NotFound(format!("story {story_id}")))?;
+
+    let slug = format!("story-{story_id}");
+    let name = format!("Story {story_id}: {story_title}");
+    let now = chrono::Utc::now().to_rfc3339();
+    conn.execute(
+        "INSERT OR IGNORE INTO features
+         (slug, friendly_name, state, spec_hash, target_branch, created_at, updated_at)
+         VALUES (?1, ?2, 'planned', ?3, 'main', ?4, ?5)",
+        params![slug, name, vec![0_u8; 32], now, now],
+    )
+    .map_err(map_err)?;
+
+    conn.query_row(
+        "SELECT id FROM features WHERE slug = ?1",
+        params![slug],
+        |row| row.get(0),
+    )
+    .map_err(map_err)
+}
+
+/// List the work packages linked to a story, ordered by sequence.
+pub fn list_wps_by_story(
+    conn: &Connection,
+    story_id: i64,
+) -> Result<Vec<WorkPackage>, DomainError> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT wp.id,wp.feature_id,wp.title,wp.state,wp.sequence,wp.file_scope,
+                    wp.acceptance_criteria,wp.agent_id,wp.pr_url,wp.pr_state,
+                    wp.worktree_path,wp.created_at,wp.updated_at
+             FROM work_packages wp
+             JOIN story_work_packages swp ON swp.wp_id = wp.id
+             WHERE swp.story_id = ?1
+             ORDER BY wp.sequence",
+        )
+        .map_err(map_err)?;
+    let rows = stmt
+        .query_map(params![story_id], row_to_wp)
+        .map_err(map_err)?;
+    rows.collect::<rusqlite::Result<Vec<_>>>().map_err(map_err)
+}
+
+/// List every work package across all features/stories.
+pub fn list_all_work_packages(conn: &Connection) -> Result<Vec<WorkPackage>, DomainError> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT id,feature_id,title,state,sequence,file_scope,acceptance_criteria,
+                    agent_id,pr_url,pr_state,worktree_path,created_at,updated_at
+             FROM work_packages ORDER BY id",
+        )
+        .map_err(map_err)?;
+    let rows = stmt.query_map([], row_to_wp).map_err(map_err)?;
+    rows.collect::<rusqlite::Result<Vec<_>>>().map_err(map_err)
+}
+
+/// Return planned work packages that are ready to start.
+///
+/// A planned WP is ready iff:
+///   * every explicit dependency points to a Done WP, AND
+///   * no file in its `file_scope` overlaps the scope of any Doing/Review WP.
+///
+/// When `cycle` is `Some`, restrict to WPs whose story belongs to that cycle.
+pub fn get_next_ready_wps(
+    conn: &Connection,
+    cycle: Option<i64>,
+) -> Result<Vec<WorkPackage>, DomainError> {
+    let base_sql = "
+        SELECT wp.id,wp.feature_id,wp.title,wp.state,wp.sequence,wp.file_scope,
+               wp.acceptance_criteria,wp.agent_id,wp.pr_url,wp.pr_state,
+               wp.worktree_path,wp.created_at,wp.updated_at
+        FROM work_packages wp
+        WHERE wp.state = 'planned'
+          AND NOT EXISTS (
+              SELECT 1 FROM wp_dependencies d
+              JOIN work_packages dep ON dep.id = d.depends_on
+              WHERE d.wp_id = wp.id
+                AND d.dep_type = 'explicit'
+                AND dep.state != 'done'
+          )";
+
+    let candidates: Vec<WorkPackage> = if let Some(cycle_id) = cycle {
+        let sql = format!(
+            "{base_sql}
+              AND wp.id IN (
+                  SELECT swp.wp_id FROM story_work_packages swp
+                  JOIN cycle_stories cs ON cs.story_id = swp.story_id
+                  WHERE cs.cycle_id = ?1
+              )
+            ORDER BY wp.sequence"
+        );
+        let mut stmt = conn.prepare(&sql).map_err(map_err)?;
+        let rows = stmt
+            .query_map(params![cycle_id], row_to_wp)
+            .map_err(map_err)?;
+        rows.collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(map_err)?
+    } else {
+        let sql = format!("{base_sql} ORDER BY wp.sequence");
+        let mut stmt = conn.prepare(&sql).map_err(map_err)?;
+        let rows = stmt.query_map([], row_to_wp).map_err(map_err)?;
+        rows.collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(map_err)?
+    };
+
+    // Union of file scopes for all in-flight (Doing/Review) WPs.
+    let mut in_flight_files: std::collections::HashSet<String> = std::collections::HashSet::new();
+    {
+        let mut stmt = conn
+            .prepare("SELECT file_scope FROM work_packages WHERE state IN ('doing','review')")
+            .map_err(map_err)?;
+        let rows = stmt
+            .query_map([], |row| row.get::<_, String>(0))
+            .map_err(map_err)?;
+        for scope_json in rows {
+            let scope_json = scope_json.map_err(map_err)?;
+            let files: Vec<String> = serde_json::from_str(&scope_json).unwrap_or_default();
+            in_flight_files.extend(files);
+        }
+    }
+
+    let ready = candidates
+        .into_iter()
+        .filter(|wp| !wp.file_scope.iter().any(|f| in_flight_files.contains(f)))
+        .collect();
+    Ok(ready)
+}
+
 /// Extension trait to add `.optional()` on rusqlite query results.
 trait OptionalExt<T> {
     fn optional(self) -> rusqlite::Result<Option<T>>;

--- a/crates/agileplus-telemetry/src/config.rs
+++ b/crates/agileplus-telemetry/src/config.rs
@@ -231,7 +231,7 @@ mod tests {
     #[test]
     fn valid_yaml_parses() {
         let mut f = tempfile::NamedTempFile::new().unwrap();
-        write!(f, "{}", DEFAULT_CONFIG_YAML).unwrap();
+        write!(f, "{DEFAULT_CONFIG_YAML}").unwrap();
         let cfg = TelemetryConfig::load_from(f.path()).unwrap();
         assert!(cfg.otlp.is_some());
         assert_eq!(cfg.sampling.trace_ratio, 1.0);

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,7 +2,7 @@
 # SOTA: pin the toolchain so any developer or CI runner that uses rustup
 # automatically picks up the exact compiler we ship against. Bump MSRV in
 # lockstep with Cargo.toml's `[workspace.package].rust-version`.
-channel    = "1.85.0"
+channel    = "1.88.0"
 profile    = "minimal"
 components = ["rustfmt", "clippy"]
 

--- a/xtask-anti-patterns/src/main.rs
+++ b/xtask-anti-patterns/src/main.rs
@@ -213,7 +213,7 @@ fn is_lib_path(p: &Path) -> bool {
 }
 
 fn strip_call<'a>(line: &'a str, fn_name: &str) -> Option<&'a str> {
-    let needle = format!(".{}", fn_name);
+    let needle = format!(".{fn_name}");
     let pos = line.find(&needle)?;
     let rest = &line[pos + needle.len()..];
     // require opening paren


### PR DESCRIPTION
De-stubs the AgilePlus CLI to a working MVP surface driving the full DAG: project/epic/story/wp create, dep add, cycle create/add, transition, and next-ready (returns WPs with deps Done + no file_scope overlap with in-flight WPs — structural file-conflict isolation). Adds migration 022 (story_work_packages + cycle_stories) + StoragePort methods + SQLite impls. Round-trip verified: next-ready correctly excludes a file-overlap/unsatisfied-dep WP.

Also fix(governance): policy conditions fail-closed on missing key/env (is_none_or→is_some_and) — HIGH security fix (was fail-open authorization bypass).