### PR TITLE
test(application): cover use-cases

### DIFF
--- a/crates/agileplus-application/src/lib.rs
+++ b/crates/agileplus-application/src/lib.rs
@@ -631,6 +631,61 @@ mod tests {
         assert!(matches!(&events[0], DomainEvent::FeatureCreated { slug, .. } if slug == "auth"));
     }
 
+    #[tokio::test]
+    async fn create_feature_defaults_target_branch_and_spec_hash() {
+        let repo = Arc::new(InMemoryFeatureRepo::default());
+        let pub_ = Arc::new(SpyPublisher::default());
+        let uc = CreateFeature::new(repo.clone(), pub_.clone());
+
+        let out = uc
+            .execute(CreateFeatureCmd {
+                slug: "spec-default".to_string(),
+                friendly_name: "Spec-driven".to_string(),
+                spec_hash: None,
+                target_branch: None,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(out.feature.target_branch, "main");
+        assert_eq!(out.feature.spec_hash, [0u8; 32]);
+
+        let events = pub_.emitted().await;
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            &events[0],
+            DomainEvent::FeatureCreated { slug, .. } if slug == "spec-default"
+        ));
+    }
+
+    #[tokio::test]
+    async fn create_feature_preserves_target_branch_and_spec_hash() {
+        let repo = Arc::new(InMemoryFeatureRepo::default());
+        let pub_ = Arc::new(SpyPublisher::default());
+        let uc = CreateFeature::new(repo.clone(), pub_.clone());
+        let spec_hash = [11u8; 32];
+
+        let out = uc
+            .execute(CreateFeatureCmd {
+                slug: "branched-feature".to_string(),
+                friendly_name: "Branch-aware feature".to_string(),
+                spec_hash: Some(spec_hash),
+                target_branch: Some("feature/login".to_string()),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(out.feature.target_branch, "feature/login");
+        assert_eq!(out.feature.spec_hash, spec_hash);
+
+        let events = pub_.emitted().await;
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            &events[0],
+            DomainEvent::FeatureCreated { slug, .. } if slug == "branched-feature"
+        ));
+    }
+
     // --- AdvanceFeature ---
 
     #[tokio::test]
@@ -911,5 +966,36 @@ mod tests {
             .unwrap_err();
 
         assert!(matches!(err, AppError::Domain(_)));
+    }
+
+    #[tokio::test]
+    async fn create_epic_trims_title_and_emits_expected_event() {
+        let repo = Arc::new(InMemoryEpicRepo::default());
+        let pub_ = Arc::new(SpyPublisher::default());
+        let uc = CreateEpic::new(repo.clone(), pub_.clone());
+
+        let out = uc
+            .execute(CreateEpicCmd {
+                project_id: 42,
+                title: "  API hardening  ".to_string(),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(out.id, 1);
+
+        let stored = repo.get_by_id(1).await.unwrap().unwrap();
+        assert_eq!(stored.title, "API hardening");
+
+        let events = pub_.emitted().await;
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            &events[0],
+            DomainEvent::EpicCreated {
+                project_id: 42,
+                title,
+                ..
+            } if title == "API hardening"
+        ));
     }
 }


### PR DESCRIPTION
Add focused unit tests to agileplus-application use cases.

## Summary
- Cover CreateFeature behavior for target branch and spec hash defaults/preservation.
- Add coverage for CreateEpic trimmed title handling and emitted EpicCreated payload.

## Scope guardrails
- No production code changes, tests only in application crate.
- Branched from main as requested.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes in the application crate; no runtime or API behavior is modified.
> 
> **Overview**
> Adds **unit tests only** in `agileplus-application`’s inline test module—no production changes.
> 
> **CreateFeature:** Two tests assert that omitted `spec_hash` / `target_branch` yield defaults (`[0u8; 32]`, `"main"`) on the returned feature and still emit `FeatureCreated`, and that explicit values are kept unchanged.
> 
> **CreateEpic:** One test verifies padded titles are stored and published as trimmed text (`EpicCreated` includes the trimmed title and correct `project_id`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25c4d2d358711396c4ae275c9803c90e93800f34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->