### PR TITLE
test(domain): cover entity invariants

### DIFF
--- a/crates/agileplus-domain/src/domain/feature.rs
+++ b/crates/agileplus-domain/src/domain/feature.rs
@@ -78,3 +78,27 @@ impl Feature {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_transition_updates_state() {
+        let mut feature = Feature::new("auth", "Authentication", [0; 32], None);
+
+        feature.transition(FeatureState::Specified).unwrap();
+
+        assert_eq!(feature.state, FeatureState::Specified);
+    }
+
+    #[test]
+    fn invalid_transition_is_rejected_without_mutating_state() {
+        let mut feature = Feature::new("auth", "Authentication", [0; 32], None);
+
+        let err = feature.transition(FeatureState::Shipped).unwrap_err();
+
+        assert_eq!(feature.state, FeatureState::Created);
+        assert!(err.contains("invalid transition Created -> Shipped"));
+    }
+}

--- a/crates/agileplus-domain/src/domain/work_package.rs
+++ b/crates/agileplus-domain/src/domain/work_package.rs
@@ -103,3 +103,33 @@ impl WorkPackage {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_work_package_starts_planned_with_empty_scope() {
+        let wp = WorkPackage::new(42, "Implement login", 3, "User can sign in");
+
+        assert_eq!(wp.feature_id, 42);
+        assert_eq!(wp.title, "Implement login");
+        assert_eq!(wp.state, WpState::Planned);
+        assert_eq!(wp.sequence, 3);
+        assert!(wp.file_scope.is_empty());
+        assert_eq!(wp.acceptance_criteria, "User can sign in");
+    }
+
+    #[test]
+    fn work_package_state_machine_rejects_skipped_lifecycle_steps() {
+        assert!(!WpState::Planned.can_transition_to(WpState::Done));
+        assert!(!WpState::Review.can_transition_to(WpState::Blocked));
+        assert!(!WpState::Done.can_transition_to(WpState::Doing));
+    }
+
+    #[test]
+    fn work_package_state_machine_allows_blocked_recovery_path() {
+        assert!(WpState::Doing.can_transition_to(WpState::Blocked));
+        assert!(WpState::Blocked.can_transition_to(WpState::Doing));
+    }
+}


### PR DESCRIPTION
## Summary

- Add unit coverage for `Feature::transition` state mutation and rejection behavior.
- Add unit coverage for `WorkPackage` construction defaults and state transition invariants.

## Validation

- `cargo fmt --package agileplus-domain`
- `cargo test -p agileplus-domain`

Note: local validation required cloning the expected sibling path dependency `KooshaPari/phenoShared` to `../phenoShared`, because the workspace resolves `phenotype-error-core` from that path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only additions with no runtime or API behavior changes.
> 
> **Overview**
> Adds **unit tests only** in `agileplus-domain`—no production logic changes.
> 
> **`Feature`:** Tests that `transition` succeeds on allowed moves (e.g. Created → Specified) and that illegal jumps (e.g. Created → Shipped) return an error **without** changing `state`.
> 
> **`WorkPackage` / `WpState`:** Tests `WorkPackage::new` defaults (Planned, empty `file_scope`, fields copied from args) and documents `WpState::can_transition_to`—disallowed skips (Planned → Done, etc.) and the blocked recovery path (Doing ↔ Blocked).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9bfeb05d73ba781b064321a46fe5473931c1a0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->