### PR TITLE
layer: chore/audit-safe-workflows-0605 — chore(workflows): AgilePlus safe audit normalization (parse-

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -9,6 +9,13 @@ on:
   schedule:
     - cron: '37 5 * * 3'  # weekly Wednesday
   workflow_dispatch:
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 jobs:
   audit:

--- a/.github/workflows/cargo-machete.yml
+++ b/.github/workflows/cargo-machete.yml
@@ -1,4 +1,14 @@
 name: Cargo Machete
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 on:
   push:
@@ -6,10 +16,6 @@ on:
   schedule:
     - cron: "0 3 * * 1"
   workflow_dispatch:
-
-permissions:
-  contents: read
-
 jobs:
   detect-unused-dependencies:
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,13 @@ on:
       - "docs/**"
       - ".github/workflows/deploy.yml"
   workflow_dispatch:
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 jobs:
   deploy:

--- a/.github/workflows/doc-links.yml
+++ b/.github/workflows/doc-links.yml
@@ -1,13 +1,15 @@
 name: Doc Links
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
 on: [push, pull_request]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-
-permissions:
-  contents: read
-
 jobs:
   links:
     runs-on: ubuntu-24.04

--- a/.github/workflows/evidence-capture.yml
+++ b/.github/workflows/evidence-capture.yml
@@ -1,4 +1,9 @@
 name: Evidence Capture
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -10,10 +15,6 @@ on:
       - "feat/**"
       - "fix/**"
       - "chore/**"
-
-permissions:
-  contents: read
-
 jobs:
   capture-evidence:
     name: Capture evidence bundle

--- a/.github/workflows/fr-coverage.yml
+++ b/.github/workflows/fr-coverage.yml
@@ -1,13 +1,15 @@
 name: FR Coverage
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
 on: [pull_request]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-
-permissions:
-  contents: read
-
 jobs:
   coverage:
     runs-on: ubuntu-24.04

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -1,10 +1,5 @@
 name: quality-gate
 on: [pull_request]
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/rust-security.yml
+++ b/.github/workflows/rust-security.yml
@@ -1,9 +1,4 @@
 name: Rust Security
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 on:
   push:
     branches: [main]

--- a/.github/workflows/sast-quick.yml
+++ b/.github/workflows/sast-quick.yml
@@ -1,9 +1,4 @@
 name: SAST Quick Check
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 on:
   pull_request:
   push:

--- a/.github/workflows/security-guard.yml
+++ b/.github/workflows/security-guard.yml
@@ -1,4 +1,14 @@
 name: Security Guard
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 on:
   pull_request:
@@ -6,10 +16,6 @@ on:
   push:
     branches:
       - "**"
-
-permissions:
-  contents: read
-
 jobs:
   guard:
     runs-on: ubuntu-24.04

--- a/.github/workflows/self-merge-gate.yml
+++ b/.github/workflows/self-merge-gate.yml
@@ -1,4 +1,9 @@
 name: self-merge-gate
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -8,10 +13,6 @@ concurrency:
 # See: https://github.com/KooshaPari/phenoShared/blob/main/.github/workflows/self-merge-gate.yml
 
 on: [pull_request_review]
-
-permissions:
-  contents: read
-
 jobs:
   gate:
     uses: KooshaPari/phenoShared/.github/workflows/self-merge-gate.yml@438e2e71e448c9f1f47f184d3ca4acbb28928677  # main

--- a/.github/workflows/snyk-scan.yml
+++ b/.github/workflows/snyk-scan.yml
@@ -1,9 +1,4 @@
 name: Snyk Security Scan
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 on:
   push:
     branches: [main]

--- a/.github/workflows/sync-canary.yml
+++ b/.github/workflows/sync-canary.yml
@@ -4,6 +4,13 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 permissions:
   contents: write

--- a/.github/workflows/tag-automation.yml
+++ b/.github/workflows/tag-automation.yml
@@ -1,9 +1,4 @@
 name: Tag Automation
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 # Delegates to phenoShared reusable workflow.
 # See: https://github.com/KooshaPari/phenoShared/blob/main/.github/workflows/tag-automation.yml
 
@@ -11,6 +6,13 @@ on:
   push:
     tags:
       - 'v*'
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 jobs:
   tag:

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -1,9 +1,4 @@
 ﻿name: TruffleHog Secrets Scan
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 on:
   push:
     branches: [main, "chore/**", "feat/**", "fix/**"]


### PR DESCRIPTION
## **User description**
Layered PR: `chore/audit-safe-workflows-0605` → integration/consolidate (1 commits). Part of the consolidation stack toward main. Review-gated; FF-merge preferred, no squash.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Duplicate YAML keys in ci, sync-canary, and multiple workflows can cause GitHub Actions to ignore intended triggers, permissions, or concurrency; removing concurrency from security workflows increases overlapping run load but not app runtime risk.
> 
> **Overview**
> This PR **normalizes GitHub Actions workflow metadata** by adding top-level **`permissions: contents: read`** and a shared **`concurrency`** pattern (`${{ github.workflow }}-${{ github.ref }}`, `cancel-in-progress: true`) to workflows such as **cargo-audit**, **deploy**, **sync-canary**, and **tag-automation**, and by relocating those blocks ahead of `jobs` in several files (e.g. **doc-links**, **evidence-capture**, **security-guard**).
> 
> It also **removes** the workflow-level **concurrency** block from **quality-gate**, **rust-security**, **sast-quick**, **snyk-scan**, and **trufflehog**, so those runs are no longer deduplicated/cancelled the same way.
> 
> **CI** gains an additional concurrency stanza while **keeping** the existing `ci-${{ github.ref }}` group, so the file now declares **two `concurrency` keys**. Several workflows end up with **duplicate `on:`** entries (minimal `workflow_dispatch` block plus the real triggers), and **sync-canary** duplicates **`permissions`** and **`concurrency`** with conflicting values (`contents: read` vs `contents: write`, different concurrency groups)—likely **YAML merge/parse hazards** that can change which triggers and cancellation behavior actually apply.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad6254c1b2195569d73135a76549cb92835bf937. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Add manual triggers and standard run controls to several workflows**

### What Changed
- Added manual run support to multiple GitHub Actions workflows so they can be started from the Actions page
- Standardized run permissions and cancellation behavior across release, audit, coverage, and security checks
- Removed automatic run cancellation from some security workflows, so those checks can now finish even if a newer run starts

### Impact
`✅ Manual workflow runs for more CI checks`
`✅ Fewer duplicate workflow runs in active branches`
`✅ Security scans are less likely to be interrupted`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
