### PR TITLE
layer: chore/l2-40-trace-dashboard-2026-06-11 — feat(agileplus-cli): add ap trace link + ap dashboard (L2 #4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,9 +98,11 @@ dependencies = [
  "async-trait",
  "chrono",
  "clap",
+ "comfy-table",
  "rusqlite",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tokio-test",
  "tracing",
@@ -1110,6 +1112,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "comfy-table"
+version = "7.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
+dependencies = [
+ "crossterm",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "config"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1280,6 +1293,29 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "document-features",
+ "parking_lot",
+ "rustix",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "crunchy"
@@ -1518,6 +1554,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
 dependencies = [
  "const-random",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -3678,6 +3723,12 @@ name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"

--- a/crates/agileplus-cli/Cargo.toml
+++ b/crates/agileplus-cli/Cargo.toml
@@ -24,6 +24,8 @@ rusqlite = { version = "0.32", features = ["bundled"] }
 async-trait.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+comfy-table = "7"
 
 [dev-dependencies]
 tokio-test = "0.4"
+tempfile = "3"

--- a/crates/agileplus-cli/src/commands/dashboard.rs
+++ b/crates/agileplus-cli/src/commands/dashboard.rs
@@ -1,0 +1,672 @@
+//! `ap dashboard` subcommand — render an in-flight DAG view of the
+//! AgilePlus SQLite database.  Aggregates:
+//!
+//!   1. **Work package state counts** (planned / doing / review /
+//!      done / blocked) — kanban-style summary, rendered with a
+//!      [`comfy_table::Table`] for visual alignment and a unicode
+//!      `█` bar to convey relative weight at a glance.
+//!   2. **Recent worklog entries** — most-recent N rows from the
+//!      `worklog_entries` table (L2 #39 ingest target), showing
+//!      task id, status, agent, and completion timestamp.
+//!   3. **Recent events** — most-recent N rows from the
+//!      `events` table, showing entity, event_type, actor, and
+//!      timestamp.
+//!   4. **Trace link summary** — count of edges in
+//!      `trace_links` (L2 #40 surface), grouped by link_type.
+//!
+//! Traceability: L2 #40 (V3 DAG layer 2).
+//!
+//! ## Usage
+//!
+//! ```text
+//! ap dashboard [OPTIONS]
+//!
+//! Options:
+//!       --limit <N>        How many rows to show per "recent" section.
+//!                          [default: 5]
+//!       --db <PATH>        SQLite database path.  [default: $AGILEPLUS_DB
+//!                          or ./agileplus.db]
+//!       --json             Emit the same data as a structured JSON
+//!                          document instead of the ASCII table.
+//!       --no-color         Suppress ANSI color escape codes in the
+//!                          ASCII table output.
+//! ```
+
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+use clap::Args;
+use comfy_table::{
+    presets::UTF8_FULL, Attribute, Cell, Color, ContentArrangement, Row, Table,
+};
+use rusqlite::{params, Connection};
+use serde::Serialize;
+
+#[cfg_attr(not(test), allow(unused_imports))]
+use agileplus_domain::domain::work_package::WpState;
+#[cfg_attr(not(test), allow(unused_imports))]
+use agileplus_sqlite::migrations::MigrationRunner;
+
+use crate::commands::trace::{open_db, resolve_db_path};
+
+// ── CLI surface ─────────────────────────────────────────────────────────────
+
+#[derive(Debug, Args)]
+pub struct DashboardArgs {
+    /// How many rows to show per "recent" section.
+    #[arg(long, value_name = "N", default_value_t = 5)]
+    pub limit: i64,
+
+    /// SQLite database path. Defaults to `$AGILEPLUS_DB` or `./agileplus.db`.
+    #[arg(long, value_name = "PATH")]
+    pub db: Option<PathBuf>,
+
+    /// Emit JSON instead of the ASCII table.
+    #[arg(long)]
+    pub json: bool,
+
+    /// Suppress ANSI color codes in the table output.
+    #[arg(long)]
+    pub no_color: bool,
+}
+
+// ── Aggregated view model ───────────────────────────────────────────────────
+
+/// Aggregated, in-flight DAG view.  All counts are computed in a single
+/// pass over the SQLite database.
+#[derive(Debug, Clone, Serialize)]
+pub struct DashboardSnapshot {
+    pub generated_at: String,
+    pub db_path: String,
+    pub work_packages: WpStateBreakdown,
+    pub recent_worklog_entries: Vec<WorklogEntryRow>,
+    pub recent_events: Vec<EventRow>,
+    pub trace_link_summary: Vec<TraceLinkCount>,
+}
+
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct WpStateBreakdown {
+    pub total: i64,
+    pub planned: i64,
+    pub doing: i64,
+    pub review: i64,
+    pub done: i64,
+    pub blocked: i64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct WorklogEntryRow {
+    pub id: i64,
+    pub task_id: String,
+    pub agent_id: String,
+    pub status: String,
+    pub verification_status: String,
+    pub completed_at: Option<String>,
+    pub ingested_at: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct EventRow {
+    pub id: i64,
+    pub entity_type: String,
+    pub entity_id: i64,
+    pub event_type: String,
+    pub actor: String,
+    pub timestamp: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TraceLinkCount {
+    pub link_type: String,
+    pub count: i64,
+}
+
+// ── Public entry point ─────────────────────────────────────────────────────
+
+pub fn run(args: &DashboardArgs) -> Result<()> {
+    let db_path = resolve_db_path(args.db.as_deref());
+    let conn = open_db(&db_path)?;
+    let limit = args.limit.clamp(1, 100);
+
+    let snapshot = collect_snapshot(&conn, &db_path, limit)?;
+
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&snapshot)?);
+        return Ok(());
+    }
+
+    print_ascii(&snapshot, args.no_color);
+    Ok(())
+}
+
+/// Build the [`DashboardSnapshot`] from the given open connection.
+/// Public so unit tests can exercise the aggregation logic against a
+/// fixture database without going through the CLI.
+pub fn collect_snapshot(
+    conn: &Connection,
+    db_path: &Path,
+    limit: i64,
+) -> Result<DashboardSnapshot> {
+    let wp = load_wp_breakdown(conn)?;
+    let worklogs = load_recent_worklog_entries(conn, limit)?;
+    let events = load_recent_events(conn, limit)?;
+    let trace = load_trace_link_counts(conn)?;
+
+    Ok(DashboardSnapshot {
+        generated_at: chrono::Utc::now().to_rfc3339(),
+        db_path: db_path.display().to_string(),
+        work_packages: wp,
+        recent_worklog_entries: worklogs,
+        recent_events: events,
+        trace_link_summary: trace,
+    })
+}
+
+// ── Aggregation queries ────────────────────────────────────────────────────
+
+pub(crate) fn load_wp_breakdown(conn: &Connection) -> Result<WpStateBreakdown> {
+    // work_packages.state is a TEXT column with a CHECK constraint
+    // mirroring `WpState`.  We aggregate with conditional sums so a
+    // single round-trip returns the full breakdown.
+    let mut stmt = conn.prepare(
+        "SELECT \
+            COUNT(*) AS total, \
+            SUM(CASE WHEN state = 'planned' THEN 1 ELSE 0 END) AS planned, \
+            SUM(CASE WHEN state = 'doing'   THEN 1 ELSE 0 END) AS doing, \
+            SUM(CASE WHEN state = 'review'  THEN 1 ELSE 0 END) AS review, \
+            SUM(CASE WHEN state = 'done'    THEN 1 ELSE 0 END) AS done, \
+            SUM(CASE WHEN state = 'blocked' THEN 1 ELSE 0 END) AS blocked \
+         FROM work_packages",
+    )?;
+    let row = stmt.query_row([], |r| {
+        let total: i64 = r.get(0)?;
+        // SUM returns NULL for an empty table; coalesce to 0.
+        let planned: i64 = r.get::<_, Option<i64>>(1)?.unwrap_or(0);
+        let doing: i64 = r.get::<_, Option<i64>>(2)?.unwrap_or(0);
+        let review: i64 = r.get::<_, Option<i64>>(3)?.unwrap_or(0);
+        let done: i64 = r.get::<_, Option<i64>>(4)?.unwrap_or(0);
+        let blocked: i64 = r.get::<_, Option<i64>>(5)?.unwrap_or(0);
+        Ok(WpStateBreakdown {
+            total,
+            planned,
+            doing,
+            review,
+            done,
+            blocked,
+        })
+    })?;
+    Ok(row)
+}
+
+pub(crate) fn load_recent_worklog_entries(
+    conn: &Connection,
+    limit: i64,
+) -> Result<Vec<WorklogEntryRow>> {
+    // Tolerate a missing table (L2 #38 migrations not yet applied):
+    // the worklog_entries table is consumed but not strictly required
+    // for the dashboard to render.
+    let table_exists: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master \
+             WHERE type='table' AND name='worklog_entries'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap_or(0);
+    if table_exists == 0 {
+        return Ok(Vec::new());
+    }
+
+    let mut stmt = conn.prepare(
+        "SELECT id, task_id, agent_id, status, verification_status, completed_at, ingested_at \
+         FROM worklog_entries \
+         ORDER BY id DESC \
+         LIMIT ?1",
+    )?;
+    let rows = stmt
+        .query_map(params![limit], |r| {
+            Ok(WorklogEntryRow {
+                id: r.get(0)?,
+                task_id: r.get(1)?,
+                agent_id: r.get(2)?,
+                status: r.get(3)?,
+                verification_status: r.get(4)?,
+                completed_at: r.get(5)?,
+                ingested_at: r.get(6)?,
+            })
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    Ok(rows)
+}
+
+pub(crate) fn load_recent_events(conn: &Connection, limit: i64) -> Result<Vec<EventRow>> {
+    let mut stmt = conn.prepare(
+        "SELECT id, entity_type, entity_id, event_type, actor, timestamp \
+         FROM events \
+         ORDER BY id DESC \
+         LIMIT ?1",
+    )?;
+    let rows = stmt
+        .query_map(params![limit], |r| {
+            Ok(EventRow {
+                id: r.get(0)?,
+                entity_type: r.get(1)?,
+                entity_id: r.get(2)?,
+                event_type: r.get(3)?,
+                actor: r.get(4)?,
+                timestamp: r.get(5)?,
+            })
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    Ok(rows)
+}
+
+pub(crate) fn load_trace_link_counts(conn: &Connection) -> Result<Vec<TraceLinkCount>> {
+    let table_exists: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master \
+             WHERE type='table' AND name='trace_links'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap_or(0);
+    if table_exists == 0 {
+        return Ok(Vec::new());
+    }
+    let mut stmt = conn.prepare(
+        "SELECT link_type, COUNT(*) AS n \
+         FROM trace_links \
+         GROUP BY link_type \
+         ORDER BY n DESC, link_type ASC",
+    )?;
+    let rows = stmt
+        .query_map([], |r| {
+            Ok(TraceLinkCount {
+                link_type: r.get(0)?,
+                count: r.get(1)?,
+            })
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    Ok(rows)
+}
+
+// ── ASCII rendering ────────────────────────────────────────────────────────
+
+fn print_ascii(snap: &DashboardSnapshot, no_color: bool) {
+    let title = format!(
+        "agileplus dashboard — generated {} — db: {}",
+        truncate(&snap.generated_at, 19),
+        snap.db_path
+    );
+    println!("\n{}\n", title);
+    println!("{}", "-".repeat(title.len().max(60)));
+
+    render_wp_section(&snap.work_packages, no_color);
+    render_worklog_section(&snap.recent_worklog_entries, no_color);
+    render_events_section(&snap.recent_events, no_color);
+    render_trace_links_section(&snap.trace_link_summary, no_color);
+
+    println!();
+}
+
+fn render_wp_section(wp: &WpStateBreakdown, no_color: bool) {
+    println!("\n[ Work packages by state ]  total = {}", wp.total);
+    let mut table = Table::new();
+    table
+        .load_preset(UTF8_FULL)
+        .set_content_arrangement(ContentArrangement::Dynamic)
+        .set_header(Row::from(vec![
+            hcell("STATE", no_color),
+            hcell("COUNT", no_color),
+            hcell("BAR", no_color),
+        ]));
+
+    let max_count = wp
+        .planned
+        .max(wp.doing)
+        .max(wp.review)
+        .max(wp.done)
+        .max(wp.blocked)
+        .max(1);
+    let bar_width: usize = 24;
+    let push = |table: &mut Table, label: &str, count: i64, color: Color| {
+        let bar = build_bar(count, max_count, bar_width);
+        let mut cell = Cell::new(format!("{count:<5}  {bar}"));
+        if !no_color {
+            cell = cell.fg(color);
+        }
+        let mut label_cell = Cell::new(label);
+        if !no_color {
+            label_cell = label_cell.add_attribute(Attribute::Bold).fg(color);
+        }
+        table.add_row(Row::from(vec![label_cell, cell]));
+    };
+    push(&mut table, "planned", wp.planned, Color::White);
+    push(&mut table, "doing", wp.doing, Color::Yellow);
+    push(&mut table, "review", wp.review, Color::Cyan);
+    push(&mut table, "done", wp.done, Color::Green);
+    push(&mut table, "blocked", wp.blocked, Color::Red);
+
+    println!("{table}");
+}
+
+fn render_worklog_section(rows: &[WorklogEntryRow], no_color: bool) {
+    println!("\n[ Recent worklog entries ]  ({} shown)", rows.len());
+    if rows.is_empty() {
+        println!("    <no worklog entries ingested yet>");
+        return;
+    }
+    let mut table = Table::new();
+    table
+        .load_preset(UTF8_FULL)
+        .set_content_arrangement(ContentArrangement::Dynamic)
+        .set_header(Row::from(vec![
+            hcell("TASK", no_color),
+            hcell("STATUS", no_color),
+            hcell("VERIFY", no_color),
+            hcell("AGENT", no_color),
+            hcell("COMPLETED", no_color),
+        ]));
+    for r in rows {
+        table.add_row(Row::from(vec![
+            Cell::new(&r.task_id),
+            colorize_status(&r.status, no_color),
+            colorize_status(&r.verification_status, no_color),
+            Cell::new(truncate(&r.agent_id, 20)),
+            Cell::new(r.completed_at.as_deref().map(|s| truncate(s, 19)).unwrap_or_else(|| "—".to_string())),
+        ]));
+    }
+    println!("{table}");
+}
+
+fn render_events_section(rows: &[EventRow], no_color: bool) {
+    println!("\n[ Recent events ]  ({} shown)", rows.len());
+    if rows.is_empty() {
+        println!("    <no events recorded>");
+        return;
+    }
+    let mut table = Table::new();
+    table
+        .load_preset(UTF8_FULL)
+        .set_content_arrangement(ContentArrangement::Dynamic)
+        .set_header(Row::from(vec![
+            hcell("ID", no_color),
+            hcell("ENTITY", no_color),
+            hcell("EVENT", no_color),
+            hcell("ACTOR", no_color),
+            hcell("TIMESTAMP", no_color),
+        ]));
+    for r in rows {
+        let entity = format!("{}:{}", r.entity_type, r.entity_id);
+        table.add_row(Row::from(vec![
+            Cell::new(r.id),
+            Cell::new(truncate(&entity, 24)),
+            Cell::new(truncate(&r.event_type, 24)),
+            Cell::new(truncate(&r.actor, 20)),
+            Cell::new(truncate(&r.timestamp, 19)),
+        ]));
+    }
+    println!("{table}");
+}
+
+fn render_trace_links_section(rows: &[TraceLinkCount], no_color: bool) {
+    println!("\n[ Trace links by type ]  total = {}", rows.iter().map(|r| r.count).sum::<i64>());
+    if rows.is_empty() {
+        println!("    <no trace links recorded>");
+        return;
+    }
+    let mut table = Table::new();
+    table
+        .load_preset(UTF8_FULL)
+        .set_content_arrangement(ContentArrangement::Dynamic)
+        .set_header(Row::from(vec![hcell("LINK TYPE", no_color), hcell("COUNT", no_color)]));
+    for r in rows {
+        table.add_row(Row::from(vec![Cell::new(&r.link_type), Cell::new(r.count)]));
+    }
+    println!("{table}");
+}
+
+fn hcell(text: &str, no_color: bool) -> Cell {
+    let cell = Cell::new(text);
+    if no_color {
+        cell
+    } else {
+        cell.add_attribute(Attribute::Bold).fg(Color::Magenta)
+    }
+}
+
+fn colorize_status(s: &str, no_color: bool) -> Cell {
+    let color = match s {
+        "completed" | "passed" | "done" => Some(Color::Green),
+        "running" | "doing" | "in_progress" | "review" => Some(Color::Yellow),
+        "blocked" | "failed" => Some(Color::Red),
+        "pending" | "todo" | "planned" | "not_run" => Some(Color::White),
+        "cancelled" | "partial" => Some(Color::Cyan),
+        _ => None,
+    };
+    let cell = Cell::new(s);
+    if no_color {
+        cell
+    } else if let Some(c) = color {
+        cell.fg(c)
+    } else {
+        cell
+    }
+}
+
+fn build_bar(count: i64, max: i64, width: usize) -> String {
+    if max <= 0 || count <= 0 {
+        return " ".repeat(width);
+    }
+    let filled = (count as f64 / max as f64 * width as f64).round() as usize;
+    let filled = filled.min(width);
+    let mut s = String::with_capacity(width);
+    for _ in 0..filled {
+        s.push('\u{2588}'); // full block
+    }
+    for _ in filled..width {
+        s.push(' ');
+    }
+    s
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        return s.to_string();
+    }
+    let t: String = s.chars().take(max.saturating_sub(1)).collect();
+    format!("{t}…")
+}
+
+// ── Unit tests ─────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::Connection;
+
+    /// Build a fully-migrated, in-memory SQLite connection suitable for
+    /// exercising the dashboard aggregations.
+    fn make_conn() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("PRAGMA foreign_keys=ON;").unwrap();
+        MigrationRunner::new(&conn).run_all().unwrap();
+        conn
+    }
+
+    /// Seed the bare minimum rows required to render every dashboard
+    /// section: 1 feature, 5 work packages (one per state), 2
+    /// worklog_entries rows, 1 event, 1 trace_link.
+    fn seed_minimal(conn: &Connection) {
+        conn.execute_batch(
+            "INSERT INTO features (id, slug, friendly_name, spec_hash, state, created_at, updated_at) \
+             VALUES (1, 'feat-x', 'Feat X', x'00', 'specified', '2026-06-11T00:00:00Z', '2026-06-11T00:00:00Z');",
+        )
+        .unwrap();
+        let states = ["planned", "doing", "review", "done", "blocked"];
+        for (i, state) in states.iter().enumerate() {
+            let id = i as i64 + 1;
+            conn.execute(
+                "INSERT INTO work_packages (id, feature_id, title, state, sequence, file_scope, \
+                 acceptance_criteria, agent_id, pr_url, pr_state, worktree_path, created_at, updated_at) \
+                 VALUES (?1, 1, ?2, ?3, 1, '[]', '', NULL, NULL, NULL, NULL, \
+                         '2026-06-11T00:00:00Z', '2026-06-11T00:00:00Z')",
+                rusqlite::params![id, format!("wp-{}", id), state],
+            )
+            .unwrap();
+        }
+        conn.execute(
+            "INSERT INTO worklog_entries (task_id, agent_id, status, commit_sha, files_changed_json, \
+             verification_status, verification_notes, verification_cmds, started_at, completed_at, ingested_at) \
+             VALUES ('L2-40', 'l2-subagent-40', 'completed', NULL, '[]', 'passed', '', '[]', \
+                     '2026-06-11T00:00:00Z', '2026-06-11T00:30:00Z', '2026-06-11T00:31:00Z')",
+            (),
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO events (entity_type, entity_id, event_type, payload, actor, timestamp, \
+             prev_hash, hash, sequence) \
+             VALUES ('work_package', 1, 'created', '{}', 'tester', '2026-06-11T00:00:00Z', \
+                     x'00', x'00', 1)",
+            (),
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO trace_links (from_kind, from_id, to_kind, to_id, link_type, note, \
+             created_by, created_at) \
+             VALUES ('work_package', '1', 'feature', '1', 'implements', '', 'tester', \
+                     '2026-06-11T00:00:00Z')",
+            (),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn wp_breakdown_aggregates_by_state() {
+        let conn = make_conn();
+        seed_minimal(&conn);
+        let wp = load_wp_breakdown(&conn).unwrap();
+        assert_eq!(wp.total, 5);
+        assert_eq!(wp.planned, 1);
+        assert_eq!(wp.doing, 1);
+        assert_eq!(wp.review, 1);
+        assert_eq!(wp.done, 1);
+        assert_eq!(wp.blocked, 1);
+    }
+
+    #[test]
+    fn wp_breakdown_empty_table_returns_zeros() {
+        let conn = make_conn();
+        let wp = load_wp_breakdown(&conn).unwrap();
+        assert_eq!(wp.total, 0);
+        assert_eq!(wp.planned, 0);
+    }
+
+    #[test]
+    fn worklog_section_returns_recent_rows() {
+        let conn = make_conn();
+        seed_minimal(&conn);
+        let rows = load_recent_worklog_entries(&conn, 5).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].task_id, "L2-40");
+        assert_eq!(rows[0].status, "completed");
+        assert_eq!(rows[0].verification_status, "passed");
+    }
+
+    #[test]
+    fn events_section_returns_recent_rows() {
+        let conn = make_conn();
+        seed_minimal(&conn);
+        let rows = load_recent_events(&conn, 5).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].entity_type, "work_package");
+        assert_eq!(rows[0].event_type, "created");
+    }
+
+    #[test]
+    fn trace_link_section_groups_by_type() {
+        let conn = make_conn();
+        seed_minimal(&conn);
+        // add a second link of the same type to test grouping
+        conn.execute(
+            "INSERT INTO trace_links (from_kind, from_id, to_kind, to_id, link_type, note, \
+             created_by, created_at) \
+             VALUES ('work_package', '2', 'feature', '1', 'implements', '', 'tester', \
+                     '2026-06-11T00:00:00Z')",
+            (),
+        )
+        .unwrap();
+        let rows = load_trace_link_counts(&conn).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].link_type, "implements");
+        assert_eq!(rows[0].count, 2);
+    }
+
+    #[test]
+    fn snapshot_aggregates_every_section() {
+        let conn = make_conn();
+        seed_minimal(&conn);
+        let snap = collect_snapshot(&conn, &PathBuf::from(":memory:"), 5).unwrap();
+        assert_eq!(snap.work_packages.total, 5);
+        assert_eq!(snap.recent_worklog_entries.len(), 1);
+        assert_eq!(snap.recent_events.len(), 1);
+        assert_eq!(snap.trace_link_summary.len(), 1);
+    }
+
+    #[test]
+    fn build_bar_renders_full_block_at_max() {
+        let bar = build_bar(10, 10, 8);
+        assert_eq!(bar.chars().count(), 8);
+        assert!(bar.chars().all(|c| c == '\u{2588}'));
+    }
+
+    #[test]
+    fn build_bar_renders_zero_width_at_zero_count() {
+        let bar = build_bar(0, 10, 8);
+        assert_eq!(bar.chars().count(), 8);
+        assert!(bar.chars().all(|c| c == ' '));
+    }
+
+    #[test]
+    fn build_bar_renders_proportional_fill() {
+        let bar = build_bar(5, 10, 10);
+        // 5/10 * 10 = 5 blocks, 5 spaces
+        let filled = bar.chars().filter(|c| *c == '\u{2588}').count();
+        let spaces = bar.chars().filter(|c| *c == ' ').count();
+        assert_eq!(filled, 5);
+        assert_eq!(spaces, 5);
+    }
+
+    #[test]
+    fn truncate_keeps_short_strings() {
+        assert_eq!(truncate("abc", 5), "abc");
+    }
+
+    #[test]
+    fn truncate_shortens_long_strings() {
+        assert_eq!(truncate("abcdefgh", 5), "abcd…");
+    }
+
+    #[test]
+    fn wp_state_enum_values_match_sql_check() {
+        // Defensive: every WpState variant must map to a valid SQL state
+        // string.  This protects against drift between domain enum
+        // and the SQL CHECK constraint in migration 002.
+        let pairs: [(WpState, &str); 5] = [
+            (WpState::Planned, "planned"),
+            (WpState::Doing, "doing"),
+            (WpState::Review, "review"),
+            (WpState::Done, "done"),
+            (WpState::Blocked, "blocked"),
+        ];
+        for (state, sql) in pairs {
+            assert_eq!(
+                serde_json::to_string(&state)
+                    .unwrap()
+                    .trim_matches('"'),
+                sql,
+                "WpState::{state:?} does not serialize to `{sql}`"
+            );
+        }
+    }
+}

--- a/crates/agileplus-cli/src/commands/mod.rs
+++ b/crates/agileplus-cli/src/commands/mod.rs
@@ -3,12 +3,14 @@
 // compilation until those upstream gaps are filled.  They are kept in the
 // source tree for reference.
 
+pub mod dashboard;
 pub mod list;
 pub mod list_epics;
 pub mod list_projects;
 pub mod list_stories;
 pub mod list_tests;
 pub mod seed_requirements;
+pub mod trace;
 pub mod worklog;
 
 // ── stub modules (excluded until upstream deps are resolved) ──────────────────

--- a/crates/agileplus-cli/src/commands/trace.rs
+++ b/crates/agileplus-cli/src/commands/trace.rs
@@ -1,0 +1,573 @@
+//! `ap trace link <from> <to>` subcommand — inserts a row into the
+//! `trace_links` table to record a directed edge between two domain
+//! entities.  Also supports the inverse / list-view surface used by
+//! `ap dashboard`.
+//!
+//! Traceability: L2 #40 (V3 DAG layer 2).
+//!
+//! ## Argument shape
+//!
+//! ```text
+//! ap trace link <from> <to> [OPTIONS]
+//!
+//! Arguments:
+//!   <from>  Source entity ref in the form `<kind>:<id>`, e.g. `wp:42`
+//!   <to>    Target entity ref in the form `<kind>:<id>`, e.g. `feature:7`
+//!
+//! Options:
+//!       --link-type <LINK>   One of: parent_of, child_of, depends_on,
+//!                            blocks, implements, verifies, references,
+//!                            duplicates.  [default: implements]
+//!       --note <NOTE>        Free-form note.  [default: ""]
+//!       --by <ACTOR>         Actor recording the link.  [default:
+//!                            $USER or "system"]
+//!       --db <PATH>          SQLite database path.  [default: $AGILEPLUS_DB
+//!                            or ./agileplus.db]
+//! ```
+//!
+//! ## Example
+//!
+//! ```bash
+//! ap trace link wp:42 feature:7 --link-type implements \
+//!     --note "WP-42 implements the dashboard's WpState filter"
+//! ```
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{anyhow, bail, Context, Result};
+use clap::{Args, Parser, Subcommand};
+use rusqlite::{params, Connection};
+
+use agileplus_sqlite::migrations::MigrationRunner;
+
+// ── CLI surface ─────────────────────────────────────────────────────────────
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "trace",
+    about = "Manage trace links between domain entities",
+    long_about = "Create, list, and inspect directed edges between AgilePlus \
+                  domain entities (work_package, feature, story, epic, ...).  \
+                  Edges are persisted in the `trace_links` table."
+)]
+pub struct TraceArgs {
+    #[command(subcommand)]
+    pub sub: TraceCmd,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum TraceCmd {
+    /// Insert a directed trace link between two entities.
+    Link(LinkArgs),
+    /// List the most-recent trace links (default 25).
+    List(ListArgs),
+    /// Show every trace link that touches a given entity.
+    Show(ShowArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct LinkArgs {
+    /// Source entity ref `<kind>:<id>` (e.g. `wp:42`).
+    pub from: String,
+
+    /// Target entity ref `<kind>:<id>` (e.g. `feature:7`).
+    pub to: String,
+
+    /// Edge semantic. One of: parent_of, child_of, depends_on, blocks,
+    /// implements, verifies, references, duplicates.
+    #[arg(long, value_name = "TYPE", default_value = "implements")]
+    pub link_type: String,
+
+    /// Free-form note attached to the link.
+    #[arg(long, value_name = "NOTE", default_value = "")]
+    pub note: String,
+
+    /// Actor recording the link (e.g. user id, agent id).
+    #[arg(long, value_name = "ACTOR")]
+    pub by: Option<String>,
+
+    /// SQLite database path. Defaults to `$AGILEPLUS_DB` or `./agileplus.db`.
+    #[arg(long, value_name = "PATH")]
+    pub db: Option<PathBuf>,
+}
+
+#[derive(Debug, Args)]
+pub struct ListArgs {
+    /// Maximum number of rows to return.
+    #[arg(long, value_name = "N", default_value_t = 25)]
+    pub limit: i64,
+    /// SQLite database path.
+    #[arg(long, value_name = "PATH")]
+    pub db: Option<PathBuf>,
+}
+
+#[derive(Debug, Args)]
+pub struct ShowArgs {
+    /// Entity ref to query, `<kind>:<id>` (e.g. `wp:42`).
+    pub entity: String,
+    /// SQLite database path.
+    #[arg(long, value_name = "PATH")]
+    pub db: Option<PathBuf>,
+}
+
+// ── Allowed enumerations (mirror CHECK constraints) ────────────────────────
+
+const ALLOWED_KINDS: &[&str] = &[
+    "work_package",
+    "feature",
+    "story",
+    "epic",
+    "project",
+    "cycle",
+    "module",
+    "requirement",
+    "external",
+];
+
+const ALLOWED_LINK_TYPES: &[&str] = &[
+    "parent_of",
+    "child_of",
+    "depends_on",
+    "blocks",
+    "implements",
+    "verifies",
+    "references",
+    "duplicates",
+];
+
+// ── Public entry points ───────────────────────────────────────────────────
+
+/// Dispatch the `trace` subcommand.  Each variant opens the DB itself so
+/// the caller can hand off via the `agileplus-cli` main entry point.
+pub fn run(args: &TraceArgs) -> Result<()> {
+    match &args.sub {
+        TraceCmd::Link(a) => run_link(a),
+        TraceCmd::List(a) => run_list(a),
+        TraceCmd::Show(a) => run_show(a),
+    }
+}
+
+pub fn run_link(args: &LinkArgs) -> Result<()> {
+    let (from_kind, from_id) = parse_ref(&args.from, "from")?;
+    let (to_kind, to_id) = parse_ref(&args.to, "to")?;
+
+    if !ALLOWED_KINDS.contains(&from_kind.as_str()) {
+        bail!(
+            "invalid --from-kind `{from_kind}`; allowed: {}",
+            ALLOWED_KINDS.join(", ")
+        );
+    }
+    if !ALLOWED_KINDS.contains(&to_kind.as_str()) {
+        bail!(
+            "invalid --to-kind `{to_kind}`; allowed: {}",
+            ALLOWED_KINDS.join(", ")
+        );
+    }
+    if !ALLOWED_LINK_TYPES.contains(&args.link_type.as_str()) {
+        bail!(
+            "invalid --link-type `{}`; allowed: {}",
+            args.link_type,
+            ALLOWED_LINK_TYPES.join(", ")
+        );
+    }
+    if from_kind == to_kind && from_id == to_id {
+        bail!("refusing to create a self-link `{from_kind}:{from_id}` -> `{to_kind}:{to_id}`");
+    }
+
+    let db_path = resolve_db_path(args.db.as_deref());
+    let conn = open_db(&db_path)?;
+    let actor = args
+        .by
+        .clone()
+        .or_else(|| std::env::var("USER").ok())
+        .or_else(|| std::env::var("USERNAME").ok())
+        .unwrap_or_else(|| "system".to_string());
+    let now = chrono::Utc::now().to_rfc3339();
+
+    // Idempotent insert: a UNIQUE(from_kind, from_id, to_kind, to_id, link_type)
+    // constraint de-duplicates identical links.  Use INSERT OR IGNORE so
+    // re-running the same `ap trace link` is a no-op.
+    let inserted = conn.execute(
+        "INSERT OR IGNORE INTO trace_links \
+            (from_kind, from_id, to_kind, to_id, link_type, note, created_by, created_at) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+        params![
+            from_kind,
+            from_id,
+            to_kind,
+            to_id,
+            args.link_type,
+            args.note,
+            actor,
+            now
+        ],
+    )?;
+
+    if inserted == 0 {
+        println!(
+            "trace link already exists: {from_kind}:{from_id} --{}--> {to_kind}:{to_id}",
+            args.link_type
+        );
+    } else {
+        let row_id = conn.last_insert_rowid();
+        println!(
+            "trace link #{row_id}: {from_kind}:{from_id} --{}--> {to_kind}:{to_id}",
+            args.link_type
+        );
+        if !args.note.is_empty() {
+            println!("  note: {}", args.note);
+        }
+        println!("  by:   {actor}");
+    }
+
+    Ok(())
+}
+
+pub fn run_list(args: &ListArgs) -> Result<()> {
+    let db_path = resolve_db_path(args.db.as_deref());
+    let conn = open_db(&db_path)?;
+    let limit = args.limit.clamp(1, 500);
+
+    let mut stmt = conn.prepare(
+        "SELECT id, from_kind, from_id, to_kind, to_id, link_type, created_at \
+         FROM trace_links \
+         ORDER BY id DESC \
+         LIMIT ?1",
+    )?;
+    let rows = stmt
+        .query_map(params![limit], |r| {
+            Ok(TraceLinkRow {
+                id: r.get::<_, i64>(0)?,
+                from_kind: r.get(1)?,
+                from_id: r.get(2)?,
+                to_kind: r.get(3)?,
+                to_id: r.get(4)?,
+                link_type: r.get(5)?,
+                created_at: r.get(6)?,
+            })
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+
+    if rows.is_empty() {
+        println!("No trace links recorded.");
+        return Ok(());
+    }
+
+    println!("{:<4}  {:<22}  {:<22}  {:<14}  {}", "ID", "FROM", "TO", "LINK", "CREATED");
+    println!("{}", "-".repeat(80));
+    for row in &rows {
+        println!(
+            "{:<4}  {:<22}  {:<22}  {:<14}  {}",
+            row.id,
+            format!("{}:{}", row.from_kind, row.from_id),
+            format!("{}:{}", row.to_kind, row.to_id),
+            row.link_type,
+            truncate(&row.created_at, 19)
+        );
+    }
+    println!("\n{} trace link(s) shown (limit={limit}).", rows.len());
+
+    Ok(())
+}
+
+pub fn run_show(args: &ShowArgs) -> Result<()> {
+    let (kind, id) = parse_ref(&args.entity, "entity")?;
+    let db_path = resolve_db_path(args.db.as_deref());
+    let conn = open_db(&db_path)?;
+
+    let mut stmt = conn.prepare(
+        "SELECT id, from_kind, from_id, to_kind, to_id, link_type, note, created_by, created_at \
+         FROM trace_links \
+         WHERE (from_kind = ?1 AND from_id = ?2) OR (to_kind = ?1 AND to_id = ?2) \
+         ORDER BY id ASC",
+    )?;
+    let rows = stmt
+        .query_map(params![kind, id], |r| {
+            Ok(TraceLinkDetail {
+                id: r.get::<_, i64>(0)?,
+                from_kind: r.get(1)?,
+                from_id: r.get(2)?,
+                to_kind: r.get(3)?,
+                to_id: r.get(4)?,
+                link_type: r.get(5)?,
+                note: r.get(6)?,
+                created_by: r.get(7)?,
+                created_at: r.get(8)?,
+            })
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+
+    if rows.is_empty() {
+        println!("No trace links touch `{kind}:{id}`.");
+        return Ok(());
+    }
+
+    println!("Trace links touching `{kind}:{id}` ({}):", rows.len());
+    for r in &rows {
+        let direction = if r.from_kind == kind && r.from_id == id {
+            "OUT"
+        } else {
+            "IN "
+        };
+        println!(
+            "  [{:>3}] {direction} {}:{} --{}--> {}:{}  (by {} @ {})",
+            r.id, r.from_kind, r.from_id, r.link_type, r.to_kind, r.to_id, r.created_by, r.created_at
+        );
+        if !r.note.is_empty() {
+            println!("        note: {}", r.note);
+        }
+    }
+
+    Ok(())
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+/// Parse `<kind>:<id>` (e.g. `wp:42`, `feature:7`).
+pub(crate) fn parse_ref(raw: &str, slot: &str) -> Result<(String, String)> {
+    let (kind, id) = raw
+        .split_once(':')
+        .ok_or_else(|| anyhow!("{slot} must be in `<kind>:<id>` form, got `{raw}`"))?;
+    if kind.is_empty() || id.is_empty() {
+        bail!("{slot} must be in `<kind>:<id>` form, got `{raw}`");
+    }
+    Ok((kind.to_string(), id.to_string()))
+}
+
+/// Open the SQLite database and run any pending migrations so the
+/// `trace_links` table exists.
+pub(crate) fn open_db(path: &Path) -> Result<Connection> {
+    let conn = Connection::open(path)
+        .with_context(|| format!("opening sqlite db at {}", path.display()))?;
+    conn.execute_batch("PRAGMA foreign_keys=ON;")
+        .context("enabling foreign_keys pragma")?;
+    let runner = MigrationRunner::new(&conn);
+    runner.run_all().context("running migrations")?;
+    Ok(conn)
+}
+
+pub(crate) fn resolve_db_path(override_path: Option<&Path>) -> PathBuf {
+    override_path
+        .map(|p| p.to_path_buf())
+        .or_else(|| std::env::var("AGILEPLUS_DB").ok().map(PathBuf::from))
+        .unwrap_or_else(|| PathBuf::from("agileplus.db"))
+}
+
+pub(crate) fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        return s.to_string();
+    }
+    let t: String = s.chars().take(max.saturating_sub(1)).collect();
+    format!("{t}…")
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct TraceLinkRow {
+    pub id: i64,
+    pub from_kind: String,
+    pub from_id: String,
+    pub to_kind: String,
+    pub to_id: String,
+    pub link_type: String,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct TraceLinkDetail {
+    pub id: i64,
+    pub from_kind: String,
+    pub from_id: String,
+    pub to_kind: String,
+    pub to_id: String,
+    pub link_type: String,
+    pub note: String,
+    pub created_by: String,
+    pub created_at: String,
+}
+
+// ── Unit tests ────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_ref_accepts_kind_id() {
+        let (k, i) = parse_ref("wp:42", "from").unwrap();
+        assert_eq!(k, "wp");
+        assert_eq!(i, "42");
+    }
+
+    #[test]
+    fn parse_ref_rejects_missing_colon() {
+        assert!(parse_ref("wp42", "from").is_err());
+    }
+
+    #[test]
+    fn parse_ref_rejects_empty_segments() {
+        assert!(parse_ref(":42", "from").is_err());
+        assert!(parse_ref("wp:", "from").is_err());
+    }
+
+    #[test]
+    fn truncate_keeps_short_strings() {
+        assert_eq!(truncate("abc", 5), "abc");
+        assert_eq!(truncate("2026-06-11T00:00:00Z", 20), "2026-06-11T00:00:00Z");
+    }
+
+    #[test]
+    fn truncate_shortens_long_strings() {
+        assert_eq!(truncate("2026-06-11T00:00:00.123456+00:00", 10), "2026-06-1…");
+    }
+
+    #[test]
+    fn link_inserts_row_into_trace_links_table() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("trace-test.db");
+        let conn = open_db(&db).unwrap();
+
+        let from_kind = "work_package";
+        let from_id = "42";
+        let to_kind = "feature";
+        let to_id = "7";
+        let link_type = "implements";
+        let now = chrono::Utc::now().to_rfc3339();
+        conn.execute(
+            "INSERT INTO trace_links (from_kind, from_id, to_kind, to_id, link_type, note, created_by, created_at) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            params![from_kind, from_id, to_kind, to_id, link_type, "smoke", "tester", now],
+        )
+        .unwrap();
+
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM trace_links", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 1);
+
+        let (fk, fi, tk, ti, lt): (String, String, String, String, String) = conn
+            .query_row(
+                "SELECT from_kind, from_id, to_kind, to_id, link_type FROM trace_links",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?, r.get(4)?)),
+            )
+            .unwrap();
+        assert_eq!(fk, from_kind);
+        assert_eq!(fi, from_id);
+        assert_eq!(tk, to_kind);
+        assert_eq!(ti, to_id);
+        assert_eq!(lt, link_type);
+    }
+
+    #[test]
+    fn link_is_idempotent_via_unique_constraint() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("trace-idem.db");
+        let conn = open_db(&db).unwrap();
+        let now = chrono::Utc::now().to_rfc3339();
+        let args = [
+            ("work_package", "1", "feature", "1", "implements"),
+            ("work_package", "1", "feature", "1", "implements"), // dup
+        ];
+        for (fk, fi, tk, ti, lt) in args {
+            conn.execute(
+                "INSERT OR IGNORE INTO trace_links \
+                 (from_kind, from_id, to_kind, to_id, link_type, note, created_by, created_at) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, '', 'tester', ?6)",
+                params![fk, fi, tk, ti, lt, now],
+            )
+            .unwrap();
+        }
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM trace_links", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 1, "duplicate link should be deduped");
+    }
+
+    #[test]
+    fn run_link_writes_a_row_to_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("run-link.db");
+        let args = LinkArgs {
+            from: "work_package:99".to_string(),
+            to: "feature:5".to_string(),
+            link_type: "implements".to_string(),
+            note: "unit test".to_string(),
+            by: Some("test-suite".to_string()),
+            db: Some(db.clone()),
+        };
+        run_link(&args).unwrap();
+
+        let conn = open_db(&db).unwrap();
+        let note: String = conn
+            .query_row(
+                "SELECT note FROM trace_links WHERE from_id = '99' AND to_id = '5'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(note, "unit test");
+    }
+
+    #[test]
+    fn run_link_rejects_self_link() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("run-self.db");
+        let args = LinkArgs {
+            from: "work_package:1".to_string(),
+            to: "work_package:1".to_string(),
+            link_type: "depends_on".to_string(),
+            note: String::new(),
+            by: None,
+            db: Some(db),
+        };
+        let err = run_link(&args).unwrap_err();
+        assert!(format!("{err:#}").contains("self-link"));
+    }
+
+    #[test]
+    fn run_link_rejects_unknown_link_type() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("run-bad-type.db");
+        let args = LinkArgs {
+            from: "work_package:1".to_string(),
+            to: "feature:1".to_string(),
+            link_type: "made_up".to_string(),
+            note: String::new(),
+            by: None,
+            db: Some(db),
+        };
+        let err = run_link(&args).unwrap_err();
+        assert!(format!("{err:#}").contains("invalid --link-type"));
+    }
+
+    #[test]
+    fn run_show_returns_rows_for_both_directions() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("run-show.db");
+        let conn = open_db(&db).unwrap();
+        let now = chrono::Utc::now().to_rfc3339();
+        // Outgoing
+        conn.execute(
+            "INSERT INTO trace_links (from_kind, from_id, to_kind, to_id, link_type, note, created_by, created_at) \
+             VALUES ('work_package', '5', 'feature', '3', 'implements', '', 'tester', ?1)",
+            params![now],
+        )
+        .unwrap();
+        // Incoming
+        conn.execute(
+            "INSERT INTO trace_links (from_kind, from_id, to_kind, to_id, link_type, note, created_by, created_at) \
+             VALUES ('story', '11', 'work_package', '5', 'verifies', '', 'tester', ?1)",
+            params![now],
+        )
+        .unwrap();
+        drop(conn);
+
+        let args = ShowArgs {
+            entity: "work_package:5".to_string(),
+            db: Some(db),
+        };
+        // run_show prints to stdout; we only verify the call returns Ok
+        // (and that the SQL joins both outgoing + incoming rows).
+        run_show(&args).unwrap();
+    }
+}

--- a/crates/agileplus-cli/src/main.rs
+++ b/crates/agileplus-cli/src/main.rs
@@ -60,6 +60,10 @@ enum Command {
     ListEpics(commands::list_epics::ListEpicsArgs),
     /// List stories, optionally filtered by epic and/or status
     ListStories(commands::list_stories::ListStoriesArgs),
+    /// Manage directed trace links between domain entities (L2 #40)
+    Trace(commands::trace::TraceArgs),
+    /// Render an in-flight DAG view of the SQLite database (L2 #40)
+    Dashboard(commands::dashboard::DashboardArgs),
     /// Worklog schema management (validate/convert/schema/list)
     Worklog(commands::worklog::WorklogArgs),
 }
@@ -294,6 +298,12 @@ async fn main() {
                 let storage = agileplus_sqlite::SqliteStorageAdapter::new(&db_path)
                     .map_err(|e| anyhow::anyhow!("open db: {e}"))?;
                 commands::list_stories::run(&args, &storage).await?;
+            }
+            Command::Trace(args) => {
+                commands::trace::run(&args)?;
+            }
+            Command::Dashboard(args) => {
+                commands::dashboard::run(&args)?;
             }
             Command::Worklog(args) => {
                 commands::worklog::run(&args)?;

--- a/crates/agileplus-sqlite/src/migrations/022_create_trace_links.sql
+++ b/crates/agileplus-sqlite/src/migrations/022_create_trace_links.sql
@@ -1,0 +1,36 @@
+-- UP
+-- Trace links: directed edges between domain entities (work_package ↔
+-- feature, work_package ↔ work_package, story ↔ epic, etc.).  Used by
+-- `ap trace link <from> <to>` and rendered by `ap dashboard` as part
+-- of the in-flight DAG view.
+CREATE TABLE IF NOT EXISTS trace_links (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    from_kind  TEXT    NOT NULL CHECK(from_kind IN (
+                  'work_package','feature','story','epic','project',
+                  'cycle','module','requirement','external')),
+    from_id    TEXT    NOT NULL,                 -- stringified id (e.g. "42")
+    to_kind    TEXT    NOT NULL CHECK(to_kind IN (
+                  'work_package','feature','story','epic','project',
+                  'cycle','module','requirement','external')),
+    to_id      TEXT    NOT NULL,                 -- stringified id
+    link_type  TEXT    NOT NULL CHECK(link_type IN (
+                  'parent_of','child_of','depends_on','blocks',
+                  'implements','verifies','references','duplicates')),
+    note       TEXT    NOT NULL DEFAULT '',
+    created_by TEXT    NOT NULL DEFAULT 'system',
+    created_at TEXT    NOT NULL,
+    UNIQUE(from_kind, from_id, to_kind, to_id, link_type)
+);
+
+CREATE INDEX IF NOT EXISTS idx_trace_links_from
+    ON trace_links(from_kind, from_id);
+CREATE INDEX IF NOT EXISTS idx_trace_links_to
+    ON trace_links(to_kind, to_id);
+CREATE INDEX IF NOT EXISTS idx_trace_links_type
+    ON trace_links(link_type);
+
+-- DOWN
+DROP INDEX IF EXISTS idx_trace_links_type;
+DROP INDEX IF EXISTS idx_trace_links_to;
+DROP INDEX IF EXISTS idx_trace_links_from;
+DROP TABLE IF EXISTS trace_links;

--- a/crates/agileplus-sqlite/src/migrations/023_create_worklog_entries.sql
+++ b/crates/agileplus-sqlite/src/migrations/023_create_worklog_entries.sql
@@ -1,0 +1,37 @@
+-- UP
+-- Worklog entries: a normalized, queryable projection of the
+-- `worklogs/*.json` corpus (per `WORKLOG_SCHEMA_2026_06_10.md`).
+-- `ap worklog emit` (L2 #39) writes rows here; `ap dashboard`
+-- (L2 #40) renders the most-recent N rows as part of the in-flight
+-- DAG view.
+CREATE TABLE IF NOT EXISTS worklog_entries (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id             TEXT    NOT NULL,             -- e.g. "L2-40"
+    agent_id            TEXT    NOT NULL,
+    status              TEXT    NOT NULL CHECK(status IN (
+                            'pending','running','blocked',
+                            'completed','failed','cancelled')),
+    commit_sha          TEXT,                          -- nullable
+    files_changed_json  TEXT    NOT NULL DEFAULT '[]', -- JSON array of paths
+    verification_status TEXT    NOT NULL CHECK(verification_status IN (
+                            'passed','failed','not_run','partial')) DEFAULT 'not_run',
+    verification_notes  TEXT    NOT NULL DEFAULT '',
+    verification_cmds   TEXT    NOT NULL DEFAULT '[]', -- JSON array
+    started_at          TEXT,                          -- nullable (ISO-8601)
+    completed_at        TEXT,                          -- nullable (ISO-8601)
+    ingested_at         TEXT    NOT NULL,
+    UNIQUE(task_id, commit_sha)
+);
+
+CREATE INDEX IF NOT EXISTS idx_worklog_entries_task
+    ON worklog_entries(task_id);
+CREATE INDEX IF NOT EXISTS idx_worklog_entries_status
+    ON worklog_entries(status);
+CREATE INDEX IF NOT EXISTS idx_worklog_entries_completed
+    ON worklog_entries(completed_at);
+
+-- DOWN
+DROP INDEX IF EXISTS idx_worklog_entries_completed;
+DROP INDEX IF EXISTS idx_worklog_entries_status;
+DROP INDEX IF EXISTS idx_worklog_entries_task;
+DROP TABLE IF EXISTS worklog_entries;

--- a/crates/agileplus-sqlite/src/migrations/mod.rs
+++ b/crates/agileplus-sqlite/src/migrations/mod.rs
@@ -28,6 +28,8 @@ const MIGRATION_018: &str = include_str!("018_create_users.sql");
 const MIGRATION_019: &str = include_str!("019_create_epics.sql");
 const MIGRATION_020: &str = include_str!("020_create_stories.sql");
 const MIGRATION_021: &str = include_str!("021_add_requirement_id.sql");
+const MIGRATION_022: &str = include_str!("022_create_trace_links.sql");
+const MIGRATION_023: &str = include_str!("023_create_worklog_entries.sql");
 
 /// All migrations in order: (name, up_sql, down_sql)
 const MIGRATIONS: &[(&str, &str)] = &[
@@ -51,6 +53,8 @@ const MIGRATIONS: &[(&str, &str)] = &[
     ("019_create_epics", MIGRATION_019),
     ("020_create_stories", MIGRATION_020),
     ("021_add_requirement_id", MIGRATION_021),
+    ("022_create_trace_links", MIGRATION_022),
+    ("023_create_worklog_entries", MIGRATION_023),
 ];
 
 /// Parse the UP section from a migration SQL file.


### PR DESCRIPTION
## **User description**
Layered PR: `chore/l2-40-trace-dashboard-2026-06-11` → integration/consolidate (1 commits). Part of the consolidation stack toward main. Review-gated; FF-merge preferred, no squash.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New schema migrations run automatically on DB open for trace/dashboard users; trace kind validation expects full names like `work_package` while docs/examples mention `wp`, which may confuse or fail links until aligned.
> 
> **Overview**
> Introduces **L2 #40** traceability and an in-flight DB view: migrations **022** (`trace_links`) and **023** (`worklog_entries`) are registered in the migration runner, and the CLI gains **`Trace`** and **`Dashboard`** top-level commands.
> 
> **`ap trace`** opens the DB (migrations applied), resolves path via `--db` / `AGILEPLUS_DB` / `./agileplus.db`, and supports **link** (idempotent `INSERT OR IGNORE`, kind/link-type validation, no self-links), **list**, and **show** for entity-centric edges. Shared helpers **`open_db`** / **`resolve_db_path`** are reused by the dashboard.
> 
> **`ap dashboard`** aggregates work-package counts by state, recent **`worklog_entries`** and **`events`**, and trace-link counts by type; optional **`--json`**, **`--limit`**, and **`--no-color`**. ASCII output uses **`comfy-table`** with colored status and bar charts. Missing optional tables degrade gracefully to empty sections.
> 
> Dependencies: **`comfy-table`** (runtime), **`tempfile`** (dev tests). Broad unit coverage for aggregation, trace CRUD rules, and CLI wiring in **`main.rs`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f5ccff2283b75a4f16ae2b7da4c9f98d72e779b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Add trace links and a dashboard view for the SQLite database**

### What Changed
- Added `ap trace` to create, list, and inspect directed links between entities such as work packages, features, stories, and epics
- `ap trace link` now rejects invalid entity types, unknown link types, and self-links, and повторные links are ignored instead of creating duplicates
- Added `ap dashboard` to show work package counts by state, recent worklog entries, recent events, and trace-link counts; it also supports JSON output and a no-color mode
- New database migrations create the `trace_links` and `worklog_entries` tables so these views work end to end

### Impact
`✅ Easier traceability between work items`
`✅ Faster checks on work package and worklog status`
`✅ Fewer duplicate trace links`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
