### PR TITLE
layer: chore/stale-pr-bot-2026-06-08 — chore(ci): add actions/stale bot (30-day idle, 7-day close)

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,29 @@
+name: 'Close Stale Issues / PRs'
+description: 'Mark issues and PRs as stale after 30 days of inactivity, close them 7 days later. Exempts security, pinned, and in-progress items.'
+
+on:
+  schedule:
+    - cron: '0 0 * * *'  # Daily at 00:00 UTC
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark and close stale issues / PRs
+        uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e  # v9.0.0
+        with:
+          days-before-stale: 30
+          days-before-close: 7
+          stale-issue-label: 'stale'
+          close-issue-label: 'closed-stale'
+          exempt-issue-labels: 'security,pinned,in-progress'
+          exempt-pr-labels: 'security,pinned,in-progress'
+          operations-per-run: 100
+          remove-stale-when-updated: true
+          # Mark both issues and PRs
+          only: 'issues, pulls'


### PR DESCRIPTION
## **User description**
Layered PR: `chore/stale-pr-bot-2026-06-08` → integration/consolidate (1 commits). Part of the consolidation stack toward main. Review-gated; FF-merge preferred, no squash.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only automation with scoped write permissions; main operational risk is incorrectly closing long-idle but still wanted issues/PRs if labels are missing.
> 
> **Overview**
> Adds a new GitHub Actions workflow that runs **daily** (and on manual dispatch) to automate stale issue and PR hygiene using **`actions/stale` v9.0.0** (pinned by commit SHA).
> 
> After **30 days** of inactivity, matching issues and PRs get the **`stale`** label; **7 days** later they are closed and tagged **`closed-stale`**. Items labeled **`security`**, **`pinned`**, or **`in-progress`** are exempt. Activity removes the stale label (`remove-stale-when-updated`), and each run is capped at **100** operations. The job is granted **issues** and **pull-requests** write permissions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33d160c8886924947d54945770a5063d82fa7bca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
Add an automatic stale cleanup workflow for issues and pull requests

### What Changed
- Issues and pull requests with 30 days of inactivity are labeled as stale, then closed 7 days later if there is still no activity
- Items labeled `security`, `pinned`, or `in-progress` are left open
- Stale labels are removed when activity resumes
- The cleanup runs every day and can also be started manually

### Impact
`✅ Fewer long-idle open issues and pull requests`
`✅ Less manual cleanup for maintainers`
`✅ Fewer accidental closures of active or protected items`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
