### PR TITLE
fix(agileplus): address 5 gemini-code-assist bot review comments

### DIFF
--- a/crates/agileplus-hook/src/dispatch.rs
+++ b/crates/agileplus-hook/src/dispatch.rs
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 //! Hook dispatcher — matches claim events to registered hooks.
 
+use std::collections::HashMap;
 use std::process::Command;
+use std::sync::{Mutex, OnceLock};
 
 use regex::Regex;
 use tracing::{info, warn};
@@ -11,6 +13,17 @@ use agileplus_triage::claim::Claim;
 
 use crate::registry::HookRegistry;
 use crate::{HookAction, HookTrigger};
+
+/// Process-wide cache of compiled hook condition regexes.
+///
+/// Hook patterns are typically configured once at startup and then matched
+/// against many claim events; compiling once avoids per-event overhead.
+/// Each compiled regex is leaked into a `'static` reference because hook
+/// patterns live for the entire process lifetime in practice.
+fn regex_cache() -> &'static Mutex<HashMap<String, &'static Regex>> {
+    static CACHE: OnceLock<Mutex<HashMap<String, &'static Regex>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
 
 /// Result of a single hook dispatch.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -49,23 +62,36 @@ impl HookDispatcher {
             if hook.trigger != trigger {
                 continue;
             }
-            // apply regex condition if present
+            // apply regex condition if present (cached per-pattern compile)
             if let Some(ref pattern) = hook.condition {
                 let pat = pattern.as_str();
-                match Regex::new(pat) {
-                    Ok(re) => {
-                        if !re.is_match(&claim.resource) {
-                            results.push((hook.id.clone(), DispatchResult::Filtered));
-                            continue;
+                let re: &'static Regex = {
+                    let cache = regex_cache().lock().expect("regex cache poisoned");
+                    if let Some(re) = cache.get(pat).copied() {
+                        re
+                    } else {
+                        drop(cache);
+                        match Regex::new(pat) {
+                            Ok(re) => {
+                                let leaked: &'static Regex = Box::leak(Box::new(re));
+                                let mut cache =
+                                    regex_cache().lock().expect("regex cache poisoned");
+                                cache.insert(pat.to_owned(), leaked);
+                                leaked
+                            }
+                            Err(e) => {
+                                results.push((
+                                    hook.id.clone(),
+                                    DispatchResult::Failed(format!("bad regex: {e}")),
+                                ));
+                                continue;
+                            }
                         }
                     }
-                    Err(e) => {
-                        results.push((
-                            hook.id.clone(),
-                            DispatchResult::Failed(format!("bad regex: {e}")),
-                        ));
-                        continue;
-                    }
+                };
+                if !re.is_match(&claim.resource) {
+                    results.push((hook.id.clone(), DispatchResult::Filtered));
+                    continue;
                 }
             }
             let res = match &hook.action {

--- a/crates/agileplus-refinery/src/sign.rs
+++ b/crates/agileplus-refinery/src/sign.rs
@@ -247,7 +247,6 @@ async fn amend_commit_message(repo_root: &std::path::Path, message: &str) -> Res
     let message = message.to_string();
     let root2 = repo_root.clone();
     let output = tokio::task::spawn_blocking({
-        let message = message.clone();
         let repo_root = repo_root.clone();
         move || {
             Command::new("git")
@@ -333,7 +332,6 @@ async fn write_commit_object(repo_root: &std::path::Path, content: &str) -> Resu
     let repo_root_for_reset = repo_root.clone();
     let content = content.to_string();
     let output = tokio::task::spawn_blocking({
-        let content = content.clone();
         let repo_root = repo_root.clone();
         move || {
             let mut child = Command::new("git")

--- a/crates/agileplus-triage/src/claim_watcher.rs
+++ b/crates/agileplus-triage/src/claim_watcher.rs
@@ -133,7 +133,7 @@ impl ClaimWatcher {
         to_agent: &str,
     ) -> Result<Claim, crate::claim::ClaimError> {
         let result = self.store.claim_transfer(from_id, to_id, to_agent);
-        if let Ok(ref _new_claim) = result {
+        if result.is_ok() {
             self.emit(
                 from_id,
                 ClaimEvent::Transferred {


### PR DESCRIPTION
## Summary

Rebases the original \`chore/sha-pin-2026-06-16\` branch onto current main
(\`a44461747\`) and addresses the 5 inline review comments left by
\`gemini-code-assist[bot]\` on the original PR.

## What changed

5 commits-in-effect, but the PR branch tip is a single squashed commit
containing all 5 fixes:

1. **\`crates/agileplus-domain/src/domain/cycle.rs\`** (line ~102) — Added
   \`!self.features.is_empty() &&\` guard to \`CycleWithFeatures::is_shippable()\`
   so empty cycles don't silently pass the ship gate.
   *Note:* this guard was already present in \`main\` from a prior merge,
   so no diff lands in this commit for that file.

2. **\`crates/agileplus-hook/src/dispatch.rs\`** (line ~55) — Added a
   process-wide \`OnceLock<Mutex<HashMap<String, &'static Regex>>>\` cache
   for compiled hook condition regexes. The cached pattern is leaked into
   a \`'static\` reference because hook patterns live for the entire process
   lifetime in practice. Avoids recompilation per dispatch event.

3. **\`crates/agileplus-refinery/src/sign.rs\`** (line ~239) — Removed
   redundant \`let message = message.clone();\` before the
   \`spawn_blocking\` closure; \`message\` is moved directly via the inner
   \`move ||\`. \`repo_root.clone()\` is kept (used after the call by the
   \`root2\` reference).

4. **\`crates/agileplus-refinery/src/sign.rs\`** (line ~326) — Removed
   redundant \`let content = content.clone();\` before the
   \`spawn_blocking\` closure; same rationale as #3.

5. **\`crates/agileplus-triage/src/claim_watcher.rs\`** (line ~133) —
   Replaced \`if let Ok(ref _new_claim) = result { ... }\` with idiomatic
   \`if result.is_ok() { ... }\`.

## Rebase outcome

The original PR branch contained the SHA-pin commit plus 73 commits of
incremental work that had been merged into \`main\` separately (PRs #758,
#760, #761, #756). After rebasing onto \`main\`:

- The SHA-pin commit collapses to empty (all of its changes are already
  in \`main\`).
- The intermediate work commits collapse to empty via \`git rebase\`
  detecting them as already applied (\`hint: use --reapply-cherry-picks\`).
- 2 trivial conflicts (cycle.rs, hook/Cargo.toml) were resolved by
  taking \`main\` (HEAD) — the fixes were already in main.

The branch tip contains only the 5 bot fixes, on top of \`a44461747\`.

## Verification

- \`cargo check -p agileplus-hook -p agileplus-refinery -p agileplus-triage\`
  started but timed out at 240s on large workspace (per task constraint).
  Pre-existing CI failures unrelated to these fixes (Format Check, Rust
  Quality, etc.) exist on \`main\` too — see PR #756 merge commit message.
- CI will validate the changes.

Refs: #753 (closes)