### PR TITLE
fix(w18b): repoint phenoShared git deps to DOMAIN_ROLES owners

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -208,11 +208,11 @@ utoipa = "4"
 uuid = { version = "1", features = ["v4", "v5", "serde"] }
 async-nats = "0.47"
 paste = "1"
-phenotype-error-core = { git = "https://github.com/KooshaPari/phenoShared", branch = "main" }
+phenotype-error-core = { git = "https://github.com/KooshaPari/phenotype-types", branch = "main" }
 traceability-core = { path = "crates/traceability-core" }
 indexmap = { version = "2", features = ["serde"] }
-phenotype-logging = { git = "https://github.com/KooshaPari/phenoShared", branch = "main" }
-phenotype-event-bus = { git = "https://github.com/KooshaPari/phenoShared", branch = "main" }
+phenotype-logging = { git = "https://github.com/KooshaPari/PhenoObservability", branch = "main" }
+phenotype-event-bus = { git = "https://github.com/KooshaPari/Eventra", branch = "main" }
 agileplus-api = { path = "crates/agileplus-api" }
 agileplus-artifacts = { path = "crates/agileplus-artifacts" }
 agileplus-cache = { path = "crates/agileplus-cache" }

--- a/crates/agileplus-events/Cargo.toml
+++ b/crates/agileplus-events/Cargo.toml
@@ -21,6 +21,7 @@ thiserror = { workspace = true }
 async-trait = "0.1"
 tokio = { workspace = true }
 uuid = { workspace = true }
+# Shared ecosystem crates (DOMAIN_ROLES owners per ADR-ECO-014; W18b repoint)
 phenotype-error-core.workspace = true
 
 [dev-dependencies]


### PR DESCRIPTION
## **User description**
## Summary
Repoint workspace git deps off interim phenoShared to DOMAIN_ROLES terminal owners per ADR-ECO-014 (W18b pheno fleet gate).

| Crate | From | To |
|-------|------|-----|
| phenotype-error-core | phenoShared | phenotype-types |
| phenotype-logging | phenoShared | PhenoObservability |
| phenotype-event-bus | phenoShared | Eventra |


___

## **CodeAnt-AI Description**
Repoint shared dependencies to their new source repositories

### What Changed
- The project now pulls shared error, logging, and event bus packages from their new owner repositories instead of the interim `phenoShared` repo
- The event module’s dependency note was updated to reflect the new ownership and routing path

### Impact
`✅ Continued builds after dependency repo move`
`✅ Fewer broken installs from retired shared repo links`
`✅ Clearer dependency ownership for future updates`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
