### PR TITLE
fix(harmonizer+pipeline): address 8 codeant-ai review findings (L5-110.1)

### DIFF
--- a/crates/agileplus-pipeline/src/dot_export.rs
+++ b/crates/agileplus-pipeline/src/dot_export.rs
@@ -68,8 +68,7 @@ pub fn export(graph: &Graph) -> Result<String, PipelineError> {
     }
 
     lines.push("}".to_string());
-    Ok(lines.join("
-"))
+    Ok(lines.join("\n"))
 }
 
 fn node_label(node: &agileplus_graph::Node) -> String {
@@ -92,15 +91,13 @@ fn properties_to_dot_attrs(properties: &serde_json::Value) -> Vec<String> {
             }
             let val = match value {
                 serde_json::Value::String(s) => {
-                    format!("\"{}\"", s.replace('"', "\\"").replace('
-', "\n"))
+                    format!("\"{}\"", s.replace('"', "\\\"").replace('\n', "\\n"))
                 }
                 serde_json::Value::Number(n) => n.to_string(),
                 serde_json::Value::Bool(b) => b.to_string(),
                 _ => format!(
                     "\"{}\"",
-                    value.to_string().replace('"', "\\"").replace('
-', "\n")
+                    value.to_string().replace('"', "\\\"").replace('\n', "\\n")
                 ),
             };
             attrs.push(format!("{key}={val}"));

--- a/crates/agileplus-pipeline/src/dot_parser.rs
+++ b/crates/agileplus-pipeline/src/dot_parser.rs
@@ -123,11 +123,14 @@ pub fn parse_dot(dot: &str) -> Result<Graph, PipelineError> {
 
 fn parse_attributes(attr_str: &str) -> serde_json::Value {
     let mut map = serde_json::Map::new();
+    // Match a quoted string that may contain escaped chars (e.g. `\"`, `\\`).
+    // After capture, unescape `\X` -> `X` so round-trip with `dot_export` works
+    // for values containing quotes or backslashes.
     let re = Regex::new(
         r#"(?x)
         (\w+)\s*=\s*
         (?:
-            "([^"]*)" |
+            "((?:[^"\\]|\\.)*)" |
             ([0-9]+)
         )
     "#,
@@ -137,8 +140,21 @@ fn parse_attributes(attr_str: &str) -> serde_json::Value {
     for caps in re.captures_iter(attr_str) {
         let key = caps[1].to_string();
         let value = if let Some(val) = caps.get(2) {
-            // Quoted string
-            serde_json::Value::String(val.as_str().to_string())
+            // Quoted string — unescape DOT backslash-escapes
+            let raw = val.as_str();
+            let mut out = String::with_capacity(raw.len());
+            let mut chars = raw.chars();
+            while let Some(c) = chars.next() {
+                if c == '\\' {
+                    if let Some(next) = chars.next() {
+                        out.push(next);
+                    }
+                    // stray trailing backslash: drop it
+                } else {
+                    out.push(c);
+                }
+            }
+            serde_json::Value::String(out)
         } else if let Some(val) = caps.get(3) {
             // Integer
             val.as_str()

--- a/crates/agileplus-pipeline/src/dot_parser.rs
+++ b/crates/agileplus-pipeline/src/dot_parser.rs
@@ -35,14 +35,14 @@ pub fn parse_dot(dot: &str) -> Result<Graph, PipelineError> {
 
     let node_re = Regex::new(
         r#"(?x)
-        ^\s*"?([^"]+)"?\s*\[\s*([^\]]*?)\s*\]\s*;?
+        ^\s*"?([^"\s;]+)"?\s*\[\s*([^\]]*?)\s*\]\s*;?
         "#,
     )
     .map_err(|e| PipelineError::DotParse(e.to_string()))?;
 
     let edge_re = Regex::new(
         r#"(?x)
-        ^\s*"?([^"]+)"?\s*->\s*"?([^"]+)"?\s*(?:\[\s*([^\]]*?)\s*\])?\s*;?
+        ^\s*"?([^"\s;]+)"?\s*->\s*"?([^"\s;]+)"?\s*(?:\[\s*([^\]]*?)\s*\])?\s*;?
         "#,
     )
     .map_err(|e| PipelineError::DotParse(e.to_string()))?;
@@ -60,8 +60,14 @@ pub fn parse_dot(dot: &str) -> Result<Graph, PipelineError> {
         if line == "{" || line == "}" {
             continue;
         }
-        // Skip edge lines — they are parsed in Pass 2
-        if line.contains("->") {
+        // Skip edge lines — they are parsed in Pass 2.
+        // CRITICAL: do NOT use `line.contains("->")` here. Node attributes may
+        // legitimately contain `->` inside quoted values (e.g.
+        // `command="echo a -> b"`); substring matching would silently drop
+        // those node declarations. Use the edge regex's anchored match
+        // instead, which only fires on actual DOT edge syntax at the start
+        // of the line.
+        if edge_re.is_match(line) {
             continue;
         }
 
@@ -243,5 +249,35 @@ mod tests {
         assert_eq!(node.properties["working_dir"], "/tmp");
         assert_eq!(node.properties["retries"], 3);
         assert_eq!(node.properties["timeout"], 60);
+    }
+
+    /// Regression test for codeant-ai finding #7 (Major):
+    /// Node attribute values may legitimately contain `->` (e.g. a shell
+    /// command like `echo a -> b`). The previous `line.contains("->")` edge
+    /// skip was too broad and silently dropped such nodes in Pass 1.
+    /// We must use the anchored `edge_re` so node declarations survive.
+    #[test]
+    fn parses_node_with_arrow_inside_attribute_value() {
+        let dot = r#"
+            digraph {
+                "build" [command="echo a -> b", retries=1];
+                "test" [command="cargo test"];
+                build -> test;
+            }
+        "#;
+        let graph = parse_dot(dot).expect("parse must not skip node with arrow in attribute");
+        assert_eq!(
+            graph.nodes.len(),
+            2,
+            "both nodes must be present even though 'build' has -> in its command"
+        );
+        let build = graph
+            .nodes
+            .values()
+            .find(|n| n.properties.get("command") == Some(&json!("echo a -> b")))
+            .expect("build node with arrow-in-command must be present");
+        assert_eq!(build.properties["retries"], 1);
+        assert_eq!(graph.relationships.len(), 1);
+        assert_eq!(graph.relationships[0].from_node_id, build.id);
     }
 }

--- a/crates/agileplus-pipeline/src/lib.rs
+++ b/crates/agileplus-pipeline/src/lib.rs
@@ -155,6 +155,40 @@ mod tests {
         assert_eq!(rel.rel_type, RelType::DependsOn);
     }
 
+    #[test]
+    fn graph_round_trip_preserves_embedded_quotes() {
+        // Integration regression: a value containing an embedded `"` must
+        // survive `dot_export -> parse_dot`. 764 already covers export-side
+        // and parse-side separately; this test exercises the full path.
+        let mut graph = Graph::new();
+        let n1 = Node::new(
+            NodeType::WorkPackage,
+            serde_json::json!({
+                "slug": "auth",
+                "command": "echo \"auth required\"",
+            }),
+        );
+        let n2 = Node::new(NodeType::WorkPackage, serde_json::json!({"slug": "deploy"}));
+        graph.add_node(n1.clone());
+        graph.add_node(n2.clone());
+        graph.add_relationship(Relationship::new(n1.id, n2.id, RelType::DependsOn));
+
+        let dot = dot_export::export(&graph).unwrap();
+        let parsed = dot_parser::parse_dot(&dot)
+            .expect("round-trip must not fail on embedded quotes");
+
+        assert!(parsed.nodes.contains_key(&n1.id));
+        assert!(parsed.nodes.contains_key(&n2.id));
+        assert_eq!(
+            parsed.nodes[&n1.id].properties["command"],
+            "echo \"auth required\""
+        );
+
+        let rel = &parsed.relationships[0];
+        assert_eq!(rel.from_node_id, n1.id);
+        assert_eq!(rel.to_node_id, n2.id);
+    }
+
     #[tokio::test]
     async fn topo_execution_on_three_node_graph() {
         let mut graph = Graph::new();

--- a/crates/agileplus-spec-harmonizer/src/emit.rs
+++ b/crates/agileplus-spec-harmonizer/src/emit.rs
@@ -2,6 +2,23 @@
 
 use crate::WorkPackage;
 
+/// Escape characters that would otherwise corrupt a Markdown table cell.
+/// Backslash-escape `|` and replace embedded newlines with `<br>` so the
+/// generated row always has exactly three data columns regardless of title
+/// content. CR is stripped.
+fn escape_md_cell(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        match ch {
+            '|' => out.push_str("\\|"),
+            '\r' => {} // drop CR
+            '\n' => out.push_str("<br>"),
+            c => out.push(c),
+        }
+    }
+    out
+}
+
 /// Emit NDJSON: one WorkPackage per line.
 pub fn emit_ndjson(pkgs: &[WorkPackage]) -> String {
     let mut out = String::new();
@@ -29,7 +46,8 @@ pub fn emit_markdown(pkgs: &[WorkPackage]) -> String {
         out.push_str("| ID | Title | Acceptance |\n|---|---|---|\n");
         for p in group {
             let acc = p.acceptance.len();
-            out.push_str(&format!("| `{}` | {} | {} |\n", p.id, p.title, acc));
+            let safe_title = escape_md_cell(&p.title);
+            out.push_str(&format!("| `{}` | {} | {} |\n", p.id, safe_title, acc));
         }
         out.push('\n');
     }
@@ -66,5 +84,49 @@ mod tests {
         assert!(out.contains("## gsd"));
         assert!(out.contains("## bmad"));
         assert!(out.contains("Total: **3**"));
+    }
+
+    /// Regression test for codeant-ai finding #8 (Major):
+    /// Markdown table cells must escape `|` (would split the row into extra
+    /// columns) and replace embedded newlines with `<br>` (would otherwise
+    /// break the row across two lines). The escaped output must keep the
+    /// row structure intact regardless of title content.
+    #[test]
+    fn markdown_escapes_pipe_and_newline_in_title() {
+        let mut p = pkg("1", "gsd");
+        p.title = "Login | happy-path\nsecond line".to_string();
+        let out = emit_markdown(&[p]);
+        // Pipe must be backslash-escaped so it does not split the row.
+        assert!(
+            out.contains("Login \\| happy-path"),
+            "pipe in title must be backslash-escaped; output was:\n{}",
+            out
+        );
+        // Newline must be replaced with <br> so the row stays on one line.
+        assert!(
+            out.contains("Login \\| happy-path<br>second line"),
+            "newline in title must become <br>; output was:\n{}",
+            out
+        );
+        // The data row must contain exactly four unescaped pipes (one
+        // leading + three column separators). The escape `\|` inside the
+        // title must NOT be counted as a column separator.
+        let data_row = out
+            .lines()
+            .find(|l| l.starts_with("| `gsd-1` |"))
+            .expect("data row must exist");
+        let total_pipes = data_row.chars().filter(|c| *c == '|').count();
+        let escaped_pipes = data_row.matches("\\|").count();
+        let unescaped_pipes = total_pipes - escaped_pipes;
+        assert_eq!(
+            unescaped_pipes, 4,
+            "data row must have exactly 4 unescaped pipes (3 columns + leading); row was: {}",
+            data_row
+        );
+        // Sanity: the literal "second line" must not appear on its own line.
+        assert!(
+            !out.lines().any(|l| l.trim() == "second line"),
+            "newline must not split the row across two lines"
+        );
     }
 }

--- a/crates/agileplus-spec-harmonizer/src/parsers/bmad.rs
+++ b/crates/agileplus-spec-harmonizer/src/parsers/bmad.rs
@@ -5,13 +5,13 @@
 //! ## Story <id>: <title>
 //! As a <role>, I want <capability>, so that <outcome>.
 //!
-//! ## Criteria
+//! ## Acceptance Criteria
 //! - criterion 1
 //! - criterion 2
 //! ```
 //!
-//! Differs from OpenSpec by the `## Story` heading and the `## Criteria`
-//! (not Acceptance) block label.
+//! Both `## Acceptance Criteria` (crate-documented contract) and the legacy
+//! `## Criteria` alias are recognized as the acceptance-block boundary.
 
 use crate::parsers::Parser;
 use crate::{AcceptanceCriterion, WorkPackage};
@@ -23,7 +23,9 @@ impl Parser for BmadParser {
     fn parse(&self, text: &str) -> Result<Vec<WorkPackage>, String> {
         let story = Regex::new(r"(?m)^##\s+Story\s+([A-Za-z0-9_\-]+)\s*[:\-]\s*(.+?)\s*$")
             .map_err(|e| format!("regex: {}", e))?;
-        let crit = Regex::new(r"(?m)^##\s+Criteria\s*$")
+        // Accept both `## Acceptance Criteria` (crate-level documented contract)
+        // and the legacy `## Criteria` alias as the acceptance-block boundary.
+        let crit = Regex::new(r"(?im)^##\s+(?:Acceptance\s+)?Criteria\s*$")
             .map_err(|e| format!("regex: {}", e))?;
         let bullet = Regex::new(r"^\s*-\s+(.+?)\s*$")
             .map_err(|e| format!("regex: {}", e))?;
@@ -99,5 +101,27 @@ mod tests {
         assert_eq!(out.len(), 1);
         assert_eq!(out[0].id, "bmad-S1");
         assert_eq!(out[0].acceptance.len(), 2);
+    }
+
+    /// Regression test for codeant-ai finding #2 (Critical):
+    /// `## Acceptance Criteria` (crate-documented contract) must be recognized
+    /// as the acceptance-block boundary, not only the legacy `## Criteria`.
+    #[test]
+    fn parses_bmad_story_with_acceptance_criteria_heading() {
+        let text = "## Story S1: Signup\nAs a user, I want to sign up.\n\n## Acceptance Criteria\n- email verified\n- captcha passed\n";
+        let out = BmadParser.parse(text).expect("parse");
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].id, "bmad-S1");
+        assert_eq!(
+            out[0].acceptance.len(),
+            2,
+            "Acceptance Criteria bullets must populate acceptance, not description"
+        );
+        assert_eq!(out[0].acceptance[0].text, "email verified");
+        assert_eq!(out[0].acceptance[1].text, "captcha passed");
+        assert!(
+            !out[0].description.contains("email verified"),
+            "acceptance bullet must not leak into description"
+        );
     }
 }

--- a/crates/agileplus-spec-harmonizer/src/parsers/gsd.rs
+++ b/crates/agileplus-spec-harmonizer/src/parsers/gsd.rs
@@ -26,7 +26,10 @@ impl Parser for GsdParser {
         // Match `## Task N: title` or `## Task N - title` (lenient separators)
         let heading = Regex::new(r"(?m)^##\s+Task\s+(\d+)\s*[:\-]\s*(.+?)\s*$")
             .map_err(|e| format!("regex: {}", e))?;
-        let checkbox = Regex::new(r"^\s*-\s*\[(x| )\]\s+(.+?)\s*$")
+        // Accept both lowercase `x` and uppercase `X` in checkbox markers.
+        // Apply `(?i)` at the top so the `(x| )` alternation becomes
+        // case-insensitive without restructuring the capture groups.
+        let checkbox = Regex::new(r"(?i)^\s*-\s*\[(x| )\]\s+(.+?)\s*$")
             .map_err(|e| format!("regex: {}", e))?;
         let bullet = Regex::new(r"^\s*-\s+(.+?)\s*$")
             .map_err(|e| format!("regex: {}", e))?;
@@ -140,5 +143,28 @@ mod tests {
     fn errors_when_no_heading() {
         let out = GsdParser.parse("just plain text");
         assert!(out.is_err());
+    }
+
+    /// Regression test for codeant-ai finding #3 (Major):
+    /// Uppercase `[X]` checkboxes must parse as done acceptance criteria.
+    /// Previously the checkbox regex only matched lowercase `x`, so `- [X] b`
+    /// fell through to the description branch and never created an
+    /// `AcceptanceCriterion`.
+    #[test]
+    fn parses_uppercase_x_checkbox_as_done() {
+        let text = "## Task 1: First\ndesc 1\n\n- [ ] a\n- [X] b\n- [x] c\n";
+        let out = GsdParser.parse(text).expect("parse");
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].acceptance.len(), 3, "all three checkboxes should parse");
+        assert!(!out[0].acceptance[0].done, "[ ] should be not done");
+        assert!(out[0].acceptance[1].done, "[X] uppercase should be done");
+        assert!(out[0].acceptance[2].done, "[x] lowercase should be done");
+        assert_eq!(out[0].acceptance[0].text, "a");
+        assert_eq!(out[0].acceptance[1].text, "b");
+        assert_eq!(out[0].acceptance[2].text, "c");
+        assert!(
+            !out[0].description.contains("[X]") && !out[0].description.contains("- ["),
+            "checkbox lines must not leak into description"
+        );
     }
 }

--- a/crates/agileplus-spec-harmonizer/src/parsers/kitty.rs
+++ b/crates/agileplus-spec-harmonizer/src/parsers/kitty.rs
@@ -34,6 +34,11 @@ impl Parser for KittyParser {
         let mut desc = String::new();
         let mut accs: Vec<AcceptanceCriterion> = Vec::new();
         let mut in_acc = false;
+        // Section-skip state: once we encounter a non-`Spec`, non-`Acceptance`
+        // `## ` heading (e.g. `## Notes`), subsequent non-heading lines must
+        // NOT bleed into the current spec's description. They are dropped
+        // until the next `## Spec` heading resets `skip_section = false`.
+        let mut skip_section = false;
 
         for line in text.lines() {
             if let Some(c) = spec.captures(line) {
@@ -54,6 +59,7 @@ impl Parser for KittyParser {
                     source_anchor: id,
                 });
                 in_acc = false;
+                skip_section = false;
                 desc.clear();
                 continue;
             }
@@ -63,7 +69,16 @@ impl Parser for KittyParser {
                 continue;
             }
             if line.trim_start().starts_with("## ") {
+                // Any non-Spec, non-Acceptance heading (e.g. `## Notes`) ends
+                // the current spec's content; subsequent lines must not leak
+                // into description. The flush of the current package happens
+                // at the next `## Spec` heading (handled above).
                 in_acc = false;
+                skip_section = true;
+                continue;
+            }
+            if skip_section {
+                // Inside a non-target section: drop lines until next `## Spec`.
                 continue;
             }
             if in_acc {
@@ -100,6 +115,30 @@ mod tests {
         assert_eq!(out.len(), 1);
         assert_eq!(out[0].id, "kitty-K-1");
         assert_eq!(out[0].title, "Login");
+        assert_eq!(out[0].acceptance.len(), 1);
+    }
+
+    /// Regression test for codeant-ai finding #4 (Major):
+    /// Non-`Spec` headings (e.g. `## Notes`) must not leak content into the
+    /// previous spec's description. Previously, lines under such headings
+    /// were appended to `desc` because `in_acc` was reset to `false` and the
+    /// `else` branch unconditionally appended.
+    #[test]
+    fn does_not_leak_non_spec_heading_into_description() {
+        let text = "## Spec K-1 - Login\nLine 1\n\n## Acceptance\n- bullet\n\n## Notes\nImplementation details\n\n## Spec K-2 - Logout\nClick logout.\n";
+        let out = KittyParser.parse(text).expect("parse");
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0].title, "Login");
+        assert_eq!(
+            out[0].description, "Line 1",
+            "Notes section must not leak into Login description"
+        );
+        assert!(
+            !out[0].description.contains("Implementation details"),
+            "Notes content must not appear in any description"
+        );
+        assert_eq!(out[1].title, "Logout");
+        assert_eq!(out[1].description, "Click logout.");
         assert_eq!(out[0].acceptance.len(), 1);
     }
 }

--- a/crates/agileplus-spec-harmonizer/src/parsers/openspec.rs
+++ b/crates/agileplus-spec-harmonizer/src/parsers/openspec.rs
@@ -23,7 +23,9 @@ impl Parser for OpenSpecParser {
     fn parse(&self, text: &str) -> Result<Vec<WorkPackage>, String> {
         let spec = Regex::new(r"(?m)^##\s+Spec\s+([A-Za-z0-9_\-]+)\s*[—\-:]\s*(.+?)\s*$")
             .map_err(|e| format!("regex: {}", e))?;
-        let acc = Regex::new(r"(?m)^##\s+Acceptance\s*$")
+        // Accept both `## Acceptance Criteria` (crate-level documented contract)
+        // and the legacy `## Acceptance` alias as the acceptance-block boundary.
+        let acc = Regex::new(r"(?im)^##\s+(?:Acceptance\s+Criteria|Acceptance)\s*$")
             .map_err(|e| format!("regex: {}", e))?;
         let bullet = Regex::new(r"^\s*-\s+(.+?)\s*$")
             .map_err(|e| format!("regex: {}", e))?;
@@ -33,6 +35,11 @@ impl Parser for OpenSpecParser {
         let mut desc = String::new();
         let mut accs: Vec<AcceptanceCriterion> = Vec::new();
         let mut in_acc = false;
+        // Section-skip state: once we encounter a non-`Spec`, non-`Acceptance`
+        // `## ` heading (e.g. `## Notes`), subsequent non-heading lines must
+        // NOT bleed into the current spec's description. They are dropped
+        // until the next `## Spec` heading resets `skip_section = false`.
+        let mut skip_section = false;
 
         let flush = |pkgs: &mut Vec<WorkPackage>, cur: &mut Option<WorkPackage>, desc: &mut String, accs: &mut Vec<AcceptanceCriterion>| {
             if let Some(mut p) = cur.take() {
@@ -58,6 +65,7 @@ impl Parser for OpenSpecParser {
                     source_anchor: id,
                 });
                 in_acc = false;
+                skip_section = false;
                 continue;
             }
             if current.is_none() { continue; }
@@ -66,9 +74,16 @@ impl Parser for OpenSpecParser {
                 continue;
             }
             if line.trim_start().starts_with("## ") {
-                // another major section without going through spec — flush and let next
-                // ## Spec handle the rest
+                // Any non-Spec, non-Acceptance heading (e.g. `## Notes`) ends
+                // the current spec's content; subsequent lines must not leak
+                // into description. The flush of the current package happens
+                // at the next `## Spec` heading (handled above).
                 in_acc = false;
+                skip_section = true;
+                continue;
+            }
+            if skip_section {
+                // Inside a non-target section: drop lines until next `## Spec`.
                 continue;
             }
             if in_acc {
@@ -103,5 +118,52 @@ mod tests {
         assert_eq!(out[0].acceptance.len(), 2);
         assert_eq!(out[1].title, "Logout");
         assert_eq!(out[1].acceptance.len(), 0);
+    }
+
+    /// Regression test for codeant-ai finding #5 (Major):
+    /// `## Acceptance Criteria` (crate-level documented contract) must be
+    /// recognized as the acceptance-block boundary, not only the bare
+    /// `## Acceptance`. Previously this caused silent loss of acceptance
+    /// items that were then appended into description.
+    #[test]
+    fn parses_openspec_with_acceptance_criteria_heading() {
+        let text = "## Spec ABC-1 — Login\nUsers can log in.\n\n## Acceptance Criteria\n- email + password work\n- MFA optional\n";
+        let out = OpenSpecParser.parse(text).expect("parse");
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].id, "openspec-ABC-1");
+        assert_eq!(
+            out[0].acceptance.len(),
+            2,
+            "Acceptance Criteria bullets must populate acceptance"
+        );
+        assert_eq!(out[0].acceptance[0].text, "email + password work");
+        assert_eq!(out[0].acceptance[1].text, "MFA optional");
+        assert!(
+            !out[0].description.contains("email + password work"),
+            "acceptance bullet must not leak into description"
+        );
+    }
+
+    /// Regression test for codeant-ai finding #6 (Major):
+    /// Non-`Spec` headings (e.g. `## Notes`) must not leak content into the
+    /// previous spec's description. Previously, lines under such headings
+    /// were appended to `desc` because `in_acc` was reset to `false` and the
+    /// `else` branch unconditionally appended.
+    #[test]
+    fn does_not_leak_non_spec_heading_into_description() {
+        let text = "## Spec ABC-1 — Login\nUsers can log in.\n\n## Acceptance\n- email + password work\n\n## Notes\nExtra commentary\n\n## Spec ABC-2 — Logout\nClick logout.\n";
+        let out = OpenSpecParser.parse(text).expect("parse");
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0].title, "Login");
+        assert_eq!(
+            out[0].description, "Users can log in.",
+            "Notes section must not leak into Login description"
+        );
+        assert!(
+            !out[0].description.contains("Extra commentary"),
+            "Notes content must not appear in any description"
+        );
+        assert_eq!(out[1].title, "Logout");
+        assert_eq!(out[1].description, "Click logout.");
     }
 }

--- a/docs/adr/0006-agileplus-spec-harmonizer-absorption.md
+++ b/docs/adr/0006-agileplus-spec-harmonizer-absorption.md
@@ -68,7 +68,7 @@ ingestion code is the `AgilePlus` Rust workspace.
 
 ## Consequences
 
-- `AgilePlus/crates/agileplus-spec-harmonizer/` exists as a new workspace
+- `agileplus/crates/agileplus-spec-harmonizer/` exists as a new workspace
   member. It is the canonical home of the 4-format spec harmonizer.
 - The forward-looking "front of SDD pipeline" claim is **downgraded** in
   the new README to "designed for the `agileplus-subcmds` bridge, which
@@ -83,7 +83,7 @@ ingestion code is the `AgilePlus` Rust workspace.
 
 - Source repo: `KooshaPari/agileplus-spec-harmonizer` (archived 2026-06-18)
 - Source repo: `KooshaPari/agileplus-spec-harmonizer-tool` (archived 2026-06-18)
-- Target repo: `KooshaPari/AgilePlus` (`crates/agileplus-spec-harmonizer/`)
+- Target repo: `KooshaPari/AgilePlus` (`agileplus/crates/agileplus-spec-harmonizer/`)
 - Test count: 12/12 passing (`cargo test -p agileplus-spec-harmonizer`)
 - Design constraint: "no async, no cgo" preserved (no `tokio` dep added)
 - License: MIT OR Apache-2.0 (compatible with source MIT)


### PR DESCRIPTION
## **User description**
## What
Applies minimal fixes to all 8 codeant-ai review findings left on the (now closed) original PR #762, since they were never addressed before the branch was merged via #756.

## Fixes
1. ADR-0006 path style — lowercase workspace paths
2. BMAD — `## Acceptance Criteria` heading now recognized (Critical)
3. GSD — uppercase `[X]` checkboxes (Major)
4. Kitty — non-Spec headings no longer leak into description (Major)
5. OpenSpec — `## Acceptance Criteria` heading now recognized (Major)
6. OpenSpec — non-Spec headings no longer leak into description (Major)
7. Pipeline dot_parser — edge detection no longer uses substring `->` (Major)
8. emit_markdown — table cells now escape `|` and newlines (Major)

## Tests
Each bug fix is covered by a regression test. `cargo test -p agileplus-spec-harmonizer` and `cargo test -p agileplus-pipeline` pass.

- agileplus-spec-harmonizer: 17 lib + 1 integration = 18/18 pass
- agileplus-pipeline: 11/11 pass
- Total: 29/29 pass

## Incidental
Also fixed pre-existing uncompilable `dot_export.rs` (broken `\n` escape sequences on `main`; pipeline crate didn't even compile before this PR).

Closes: codeant-ai review on #762
Refs: L5-110.1, ADR-0006


___

## **CodeAnt-AI Description**
Fix spec parsing and export output so accepted headings, task checkboxes, and generated tables behave correctly

### What Changed
- `## Acceptance Criteria` is now recognized in BMAD and OpenSpec specs, so acceptance items are captured instead of being treated like description text
- Kitty and OpenSpec no longer let content from unrelated headings like `## Notes` spill into the previous spec’s description
- GSD now treats both `[x]` and `[X]` as completed checkboxes
- Markdown exports now keep table rows intact when titles contain `|` or line breaks
- DOT export and parsing now handle quoted text and arrow-like text more safely, including node content that contains `->`
- ADR 0006 wording was updated to match the current workspace path

### Impact
`✅ Clearer spec import results`
`✅ Fewer lost acceptance criteria`
`✅ Safer markdown and DOT output`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
