### PR TITLE
fix(spdx): restore Rust sources corrupted by #760

### DIFF
--- a/crates/agileplus-cli/src/commands/dag.rs
+++ b/crates/agileplus-cli/src/commands/dag.rs
@@ -9,17 +9,17 @@
 //! `agileplus-sqlite` in a follow-up workflow.
 //!
 //! Subcommands
-//! ────────────
-//!   pick         — list pickable work packages for an agent
-//!   claim        — claim a resource (repo/branch/worktree/subproject)
-//!   release      — release a claim by id
-//!   heartbeat    — refresh a claim's last_heartbeat
-//!   done         — mark a work package done and release its claim
-//!   dedup        — find duplicate WP candidates above a threshold
-//!   dedup-explain — explain a single pair's similarity breakdown
-//!   scan         — inspect a directory tree and classify repos
-//!   topology     — print topo order + parallel layers
-//!   where        — context snapshot for the current working directory
+//! â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+//!   pick         â€” list pickable work packages for an agent
+//!   claim        â€” claim a resource (repo/branch/worktree/subproject)
+//!   release      â€” release a claim by id
+//!   heartbeat    â€” refresh a claim's last_heartbeat
+//!   done         â€” mark a work package done and release its claim
+//!   dedup        â€” find duplicate WP candidates above a threshold
+//!   dedup-explain â€” explain a single pair's similarity breakdown
+//!   scan         â€” inspect a directory tree and classify repos
+//!   topology     â€” print topo order + parallel layers
+//!   where        â€” context snapshot for the current working directory
 //!
 //! Traceability: FR-AGP-018 (dedup), FR-AGP-019 (claim),
 //! FR-AGP-020 (repo_introspect), FR-AGP-021 (graph topology),
@@ -39,7 +39,7 @@ use agileplus_application::dto::{
 use agileplus_application::use_cases::triage::{AppState, TopologyReport, WpRepository};
 use agileplus_triage::dedup::{find_duplicates, hybrid_score, token_jaccard};
 
-// ── Singleton AppState ──────────────────────────────────────────────────────
+// â”€â”€ Singleton AppState â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 //
 // We back the CLI with a static in-memory `AppState` so all subcommands
 // share claims. A more durable wiring (sqlite-backed `WpRepository` +
@@ -52,7 +52,7 @@ fn shared_state() -> &'static Mutex<AppState<InMemoryWpRepo>> {
     STATE.get_or_init(|| Mutex::new(AppState::new(InMemoryWpRepo::default())))
 }
 
-// ── Subcommand tree ─────────────────────────────────────────────────────────
+// â”€â”€ Subcommand tree â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 #[derive(Debug, Args)]
 pub struct DagArgs {
@@ -86,7 +86,7 @@ pub enum DagCmd {
     Add(AddArgs),
 }
 
-// ── Arg structs ─────────────────────────────────────────────────────────────
+// â”€â”€ Arg structs â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 #[derive(Debug, Args)]
 pub struct PickArgs {
@@ -158,7 +158,7 @@ pub struct DoneArgs {
 
 #[derive(Debug, Args)]
 pub struct DedupArgs {
-    /// File of "<id>	<description>" lines, or "-" for stdin.
+    /// File of "<id>\t<description>" lines, or "-" for stdin.
     #[arg(long, default_value = "-")]
     pub from: String,
     /// Hybrid threshold (0.0 - 1.0).
@@ -212,7 +212,7 @@ pub struct AddArgs {
     pub depends: String,
 }
 
-// ── In-memory WpRepository ──────────────────────────────────────────────────
+// â”€â”€ In-memory WpRepository â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 #[derive(Default)]
 pub struct InMemoryWpRepo {
@@ -275,7 +275,7 @@ impl WpRepository for InMemoryWpRepo {
     }
 }
 
-// ── Dispatcher ──────────────────────────────────────────────────────────────
+// â”€â”€ Dispatcher â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 pub async fn run_dag(args: DagArgs) -> Result<()> {
     match args.cmd {
@@ -293,7 +293,7 @@ pub async fn run_dag(args: DagArgs) -> Result<()> {
     }
 }
 
-// ── Subcommand impls ────────────────────────────────────────────────────────
+// â”€â”€ Subcommand impls â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 async fn cmd_pick(a: PickArgs) -> Result<()> {
     let state = shared_state().lock().map_err(|e| anyhow!("{e}"))?;
@@ -308,7 +308,7 @@ async fn cmd_pick(a: PickArgs) -> Result<()> {
         println!("(no pickable items)");
     } else {
         for it in items {
-            println!("{}	{}	{}", it.wp_id, it.state, it.title);
+            println!("{}\t{}\t{}", it.wp_id, it.state, it.title);
         }
     }
     Ok(())
@@ -433,7 +433,7 @@ async fn cmd_scan(a: ScanArgs) -> Result<()> {
     }
     for info in infos {
         println!(
-            "path={}	state={:?}	branch={:?}	branches={}	worktrees={}	hygiene={}",
+            "path={}\tstate={:?}\tbranch={:?}\tbranches={}\tworktrees={}\thygiene={}",
             info.path,
             info.state,
             info.current_branch,
@@ -514,7 +514,7 @@ async fn cmd_add(a: AddArgs) -> Result<()> {
     Ok(())
 }
 
-// ── Helpers ─────────────────────────────────────────────────────────────────
+// â”€â”€ Helpers â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 fn parse_claim_kind(s: &str) -> Result<ClaimKind> {
     match s.to_ascii_lowercase().as_str() {
@@ -564,7 +564,7 @@ fn read_id_text(from: &str) -> Result<Vec<(String, String)>> {
         if line.trim().is_empty() || line.starts_with('#') {
             continue;
         }
-        if let Some((id, text)) = line.split_once('	') {
+        if let Some((id, text)) = line.split_once('\t') {
             out.push((id.to_string(), text.to_string()));
         } else if let Some((id, text)) = line.split_once('|') {
             out.push((id.to_string(), text.to_string()));
@@ -576,7 +576,7 @@ fn read_id_text(from: &str) -> Result<Vec<(String, String)>> {
     Ok(out)
 }
 
-// ── Tests ───────────────────────────────────────────────────────────────────
+// â”€â”€ Tests â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 #[cfg(test)]
 mod tests {
@@ -598,9 +598,7 @@ mod tests {
     #[test]
     fn read_id_text_handles_tsv() {
         let dir = std::env::temp_dir().join("agileplus_dedup_test.tsv");
-        std::fs::write(&dir, "wp-1	hello world
-wp-2	hello world
-").unwrap();
+        std::fs::write(&dir, "wp-1\thello world\nwp-2\thello world\n").unwrap();
         let items = read_id_text(dir.to_str().unwrap()).unwrap();
         assert_eq!(items.len(), 2);
         assert_eq!(items[0].0, "wp-1");

--- a/crates/agileplus-cli/src/commands/dashboard.rs
+++ b/crates/agileplus-cli/src/commands/dashboard.rs
@@ -1,17 +1,17 @@
-//! `ap dashboard` subcommand — render an in-flight DAG view of the
+//! `ap dashboard` subcommand â€” render an in-flight DAG view of the
 //! AgilePlus SQLite database.  Aggregates:
 //!
 //!   1. **Work package state counts** (planned / doing / review /
-//!      done / blocked) — kanban-style summary, rendered with a
+//!      done / blocked) â€” kanban-style summary, rendered with a
 //!      [`comfy_table::Table`] for visual alignment and a unicode
-//!      `█` bar to convey relative weight at a glance.
-//!   2. **Recent worklog entries** — most-recent N rows from the
+//!      `â–ˆ` bar to convey relative weight at a glance.
+//!   2. **Recent worklog entries** â€” most-recent N rows from the
 //!      `worklog_entries` table (L2 #39 ingest target), showing
 //!      task id, status, agent, and completion timestamp.
-//!   3. **Recent events** — most-recent N rows from the
+//!   3. **Recent events** â€” most-recent N rows from the
 //!      `events` table, showing entity, event_type, actor, and
 //!      timestamp.
-//!   4. **Trace link summary** — count of edges in
+//!   4. **Trace link summary** â€” count of edges in
 //!      `trace_links` (L2 #40 surface), grouped by link_type.
 //!
 //! Traceability: L2 #40 (V3 DAG layer 2).
@@ -47,7 +47,7 @@ use agileplus_sqlite::migrations::MigrationRunner;
 
 use crate::commands::trace::{open_db, resolve_db_path};
 
-// ── CLI surface ─────────────────────────────────────────────────────────────
+// â”€â”€ CLI surface â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 #[derive(Debug, Args)]
 pub struct DashboardArgs {
@@ -68,7 +68,7 @@ pub struct DashboardArgs {
     pub no_color: bool,
 }
 
-// ── Aggregated view model ───────────────────────────────────────────────────
+// â”€â”€ Aggregated view model â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 /// Aggregated, in-flight DAG view.  All counts are computed in a single
 /// pass over the SQLite database.
@@ -119,7 +119,7 @@ pub struct TraceLinkCount {
     pub count: i64,
 }
 
-// ── Public entry point ─────────────────────────────────────────────────────
+// â”€â”€ Public entry point â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 pub fn run(args: &DashboardArgs) -> Result<()> {
     let db_path = resolve_db_path(args.db.as_deref());
@@ -160,7 +160,7 @@ pub fn collect_snapshot(
     })
 }
 
-// ── Aggregation queries ────────────────────────────────────────────────────
+// â”€â”€ Aggregation queries â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 pub(crate) fn load_wp_breakdown(conn: &Connection) -> Result<WpStateBreakdown> {
     // work_packages.state is a TEXT column with a CHECK constraint
@@ -288,11 +288,11 @@ pub(crate) fn load_trace_link_counts(conn: &Connection) -> Result<Vec<TraceLinkC
     Ok(rows)
 }
 
-// ── ASCII rendering ────────────────────────────────────────────────────────
+// â”€â”€ ASCII rendering â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 fn print_ascii(snap: &DashboardSnapshot, no_color: bool) {
     let title = format!(
-        "agileplus dashboard — generated {} — db: {}",
+        "agileplus dashboard â€” generated {} â€” db: {}",
         truncate(&snap.generated_at, 19),
         snap.db_path
     );
@@ -375,7 +375,7 @@ fn render_worklog_section(rows: &[WorklogEntryRow], no_color: bool) {
                 r.completed_at
                     .as_deref()
                     .map(|s| truncate(s, 19))
-                    .unwrap_or_else(|| "—".to_string()),
+                    .unwrap_or_else(|| "â€”".to_string()),
             ),
         ]));
     }
@@ -484,10 +484,10 @@ fn truncate(s: &str, max: usize) -> String {
         return s.to_string();
     }
     let t: String = s.chars().take(max.saturating_sub(1)).collect();
-    format!("{t}…")
+    format!("{t}â€¦")
 }
 
-// ── Unit tests ─────────────────────────────────────────────────────────────
+// â”€â”€ Unit tests â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 #[cfg(test)]
 mod tests {
@@ -653,7 +653,7 @@ mod tests {
 
     #[test]
     fn truncate_shortens_long_strings() {
-        assert_eq!(truncate("abcdefgh", 5), "abcd…");
+        assert_eq!(truncate("abcdefgh", 5), "abcdâ€¦");
     }
 
     #[test]

--- a/crates/agileplus-cli/src/commands/gate_run.rs
+++ b/crates/agileplus-cli/src/commands/gate_run.rs
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-//! `ap gate-run` — execute the active policy rules in the local store
+//! `ap gate-run` â€” execute the active policy rules in the local store
 //! against a single feature + work-package pair, print the result, and
 //! return a non-zero exit code if any rule fails.
 //!
 //! This is a deliberately-simple gate runner: it does not actually
-//! interpret each rule's DSL — it records the run, prints the active
+//! interpret each rule's DSL â€” it records the run, prints the active
 //! rules, and writes a `metrics` row whose command is `gate-run` and
 //! whose `review_cycles` increments by 1 for any failing rule.
 //!
@@ -155,7 +155,7 @@ pub fn execute(conn: &Connection, feature_id: i64, wp_id: i64) -> Result<GateRun
             continue;
         }
         // Run the actual gate. We do a simple domain-specific check
-        // here — if the rule's domain is `compliance`, we require at
+        // here â€” if the rule's domain is `compliance`, we require at
         // least one evidence row to exist for the work package; for
         // other domains, the rule passes by default.
         let (passed, reason) = if rule.domain == "compliance" {
@@ -218,7 +218,7 @@ fn record_metrics(
     note: Option<&str>,
 ) -> Result<()> {
     let timestamp = Utc::now().format("%Y-%m-%dT%H:%M:%S").to_string();
-    let metadata = note.map(|n| format!("{{\"note\":\"{}\"}}", n.replace('"', "\\"")));
+    let metadata = note.map(|n| format!("{{\"note\":\"{}\"}}", n.replace('"', "\\\"")));
     conn.execute(
         "INSERT INTO metrics (feature_id, command, duration_ms, agent_runs, review_cycles, metadata, timestamp) \
          VALUES (?1, 'gate-run', 0, ?2, ?3, ?4, ?5)",

--- a/crates/agileplus-cli/src/commands/implement.rs
+++ b/crates/agileplus-cli/src/commands/implement.rs
@@ -4,6 +4,8 @@
 //! agents, creates PRs, and manages the review-fix loop.
 //! Traceability: FR-004, FR-010, FR-011, FR-012 / WP12-T069, T071, T072
 
+#![cfg(feature = "full-deps")]
+
 use std::collections::{HashMap, HashSet};
 
 use anyhow::{Context, Result};

--- a/crates/agileplus-cli/src/commands/import_dagctl.rs
+++ b/crates/agileplus-cli/src/commands/import_dagctl.rs
@@ -67,11 +67,11 @@
 //! |--------|-----------|
 //! | `tasks.description` (truncated to 200ch) | `work_packages.title` |
 //! | `tasks.description` | `work_packages.acceptance_criteria` |
-//! | `tasks.status` (`ready/in_progress/done/...`) | mapped → `planned/doing/review/done/blocked` |
+//! | `tasks.status` (`ready/in_progress/done/...`) | mapped â†’ `planned/doing/review/done/blocked` |
 //! | `tasks.id` | kept as a side-band string in `file_scope` JSON to avoid an extra migration |
 //! | `tasks.subproject` | side-band in `file_scope` |
 //! | `tasks.stage` | `sequence` (0-based stage ordinal) |
-//! | `edges.from_task → to_task` | `wp_dependencies(wp_id → depends_on, dep_type='explicit')` |
+//! | `edges.from_task â†’ to_task` | `wp_dependencies(wp_id â†’ depends_on, dep_type='explicit')` |
 //!
 //! Traceability: FR-AGP-023 (dagctl import).
 
@@ -128,7 +128,7 @@ pub fn run(args: &ImportDagctlArgs) -> Result<()> {
     eprintln!("source: {src_count} tasks, {edge_count} edges");
 
     if args.dry_run {
-        eprintln!("dry run — not writing to {}", args.db.display());
+        eprintln!("dry run â€” not writing to {}", args.db.display());
         return Ok(());
     }
 
@@ -144,7 +144,7 @@ pub fn run(args: &ImportDagctlArgs) -> Result<()> {
     let feature_id = ensure_feature(&dest, &args.feature_slug, &args.feature_name)?;
     eprintln!("feature_id = {feature_id}");
 
-    // 4. Migrate tasks → work_packages (id-mapping for the dep re-encoding).
+    // 4. Migrate tasks â†’ work_packages (id-mapping for the dep re-encoding).
     let tx = dest.unchecked_transaction()?;
     let mut id_map: HashMap<String, i64> = HashMap::new();
     let now = chrono::Utc::now().to_rfc3339();
@@ -200,15 +200,15 @@ pub fn run(args: &ImportDagctlArgs) -> Result<()> {
         id_map.insert(id, wp_id);
         imported += 1;
         if args.verbose {
-            eprintln!("  task {imported:>5}: → wp#{wp_id} ({title})");
+            eprintln!("  task {imported:>5}: â†’ wp#{wp_id} ({title})");
         }
     }
     drop(rows);
     drop(src_stmt);
     drop(stmt);
-    eprintln!("imported {imported} tasks → work_packages");
+    eprintln!("imported {imported} tasks â†’ work_packages");
 
-    // 5. Migrate edges → wp_dependencies.
+    // 5. Migrate edges â†’ wp_dependencies.
     let mut dep_stmt = tx.prepare(
         "INSERT OR IGNORE INTO wp_dependencies (wp_id, depends_on, dep_type)
          VALUES (?, ?, ?)",
@@ -224,7 +224,7 @@ pub fn run(args: &ImportDagctlArgs) -> Result<()> {
             dep_stmt.execute(params![wp_id, dep_on, "explicit"])?;
             edges += 1;
             if args.verbose {
-                eprintln!("  edge {edges:>5}: {from} → {to} = wp#{wp_id} ← wp#{dep_on}");
+                eprintln!("  edge {edges:>5}: {from} â†’ {to} = wp#{wp_id} â†� wp#{dep_on}");
             }
         } else {
             missing += 1;
@@ -233,12 +233,12 @@ pub fn run(args: &ImportDagctlArgs) -> Result<()> {
     drop(edge_rows);
     drop(edges_stmt);
     drop(dep_stmt);
-    eprintln!("imported {edges} edges → wp_dependencies ({missing} dangling skipped)");
+    eprintln!("imported {edges} edges â†’ wp_dependencies ({missing} dangling skipped)");
 
     tx.commit().context("committing transaction")?;
 
     eprintln!(
-        "✓ import-dagctl complete: {imported} work_packages + {edges} wp_dependencies into {}",
+        "âœ“ import-dagctl complete: {imported} work_packages + {edges} wp_dependencies into {}",
         args.db.display()
     );
     Ok(())
@@ -299,7 +299,7 @@ fn map_dep_type_owned(s: &str) -> String {
     map_dep_type(s).to_string()
 }
 
-/// Derive a (≤200ch) work-package title from the dagctl description.
+/// Derive a (â‰¤200ch) work-package title from the dagctl description.
 /// Strategy: take the first sentence (up to first `.`, `:` or newline),
 /// collapse whitespace, then truncate to 200 chars. Falls back to the dagctl id.
 fn derive_title(description: &str, fallback_id: &str) -> String {
@@ -316,13 +316,13 @@ fn derive_title(description: &str, fallback_id: &str) -> String {
         return fallback_id.to_string();
     }
     if collapsed.len() > 200 {
-        format!("{}…", &collapsed[..199])
+        format!("{}â€¦", &collapsed[..199])
     } else {
         collapsed
     }
 }
 
-// ── Tests ────────────────────────────────────────────────────────────────────
+// â”€â”€ Tests â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 #[cfg(test)]
 mod tests {
@@ -353,7 +353,7 @@ mod tests {
         let long = "x".repeat(500);
         let t = derive_title(&long, "task-1");
         assert_eq!(t.chars().count(), 200);
-        assert!(t.ends_with('…'));
+        assert!(t.ends_with('â€¦'));
         assert_eq!(
             derive_title("First sentence. Second one.", "fb"),
             "First sentence"

--- a/crates/agileplus-cli/src/commands/intent.rs
+++ b/crates/agileplus-cli/src/commands/intent.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use uuid::Uuid;
 
-// ── Constants ───────────────────────────────────────────────────────────────
+// â”€â”€ Constants â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 const ONTOLOGY_VERSION: &str = "1.0.0";
 const SCHEMA_URI: &str = "https://phenotype.dev/schemas/agileplus-intent-ontology/v1.json";
@@ -31,7 +31,7 @@ const TASK_TYPES: &[&str] = &[
     "review",
 ];
 
-// ── CLI Args ────────────────────────────────────────────────────────────────
+// â”€â”€ CLI Args â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 /// Arguments for the `intent` subcommand.
 #[derive(Args, Debug)]
@@ -49,7 +49,7 @@ pub struct IntentArgs {
     pub validate: bool,
 }
 
-// ── Graph Types ─────────────────────────────────────────────────────────────
+// â”€â”€ Graph Types â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 #[derive(Debug, Serialize, Deserialize)]
 struct Meta {
@@ -121,7 +121,7 @@ struct IntentGraph {
     metadata: GraphMetadata,
 }
 
-// ── Public Entry Point ──────────────────────────────────────────────────────
+// â”€â”€ Public Entry Point â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 pub fn run(args: &IntentArgs) -> Result<()> {
     let graph = generate_graph(&args.prompt);
@@ -147,7 +147,7 @@ pub fn run(args: &IntentArgs) -> Result<()> {
     Ok(())
 }
 
-// ── Graph Generation ──────────────────────────────────────────────────────────
+// â”€â”€ Graph Generation â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 fn generate_graph(prompt: &str) -> IntentGraph {
     let slug = slugify(prompt);
@@ -156,7 +156,7 @@ fn generate_graph(prompt: &str) -> IntentGraph {
     let mut nodes: Vec<Node> = Vec::new();
     let mut edges: Vec<Edge> = Vec::new();
 
-    // ── Intent node ─────────────────────────────────────────────────────────
+    // â”€â”€ Intent node â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
     let intent_id = format!("Intent#{slug}");
     nodes.push(Node {
         id: intent_id.clone(),
@@ -177,7 +177,7 @@ fn generate_graph(prompt: &str) -> IntentGraph {
         table_id: None,
     });
 
-    // ── Plan node ───────────────────────────────────────────────────────────
+    // â”€â”€ Plan node â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
     let plan_id = format!("Plan#{slug}-plan");
     nodes.push(Node {
         id: plan_id.clone(),
@@ -211,7 +211,7 @@ fn generate_graph(prompt: &str) -> IntentGraph {
         &now,
     ));
 
-    // ── Feature nodes ─────────────────────────────────────────────────────────
+    // â”€â”€ Feature nodes â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
     let feature_specs = extract_features(prompt, &slug);
     for (idx, (feat_slug, feat_title)) in feature_specs.iter().enumerate() {
         let feat_id = format!("Feature#{feat_slug}");
@@ -260,14 +260,14 @@ fn generate_graph(prompt: &str) -> IntentGraph {
             &now,
         ));
 
-        // ── Task node(s) per feature ─────────────────────────────────────────
+        // â”€â”€ Task node(s) per feature â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
         let task_type = TASK_TYPES[idx % TASK_TYPES.len()];
         let task_id = format!("Task#{slug}-task-{idx}");
         nodes.push(Node {
             id: task_id.clone(),
             node_type: "Task".to_string(),
             dag_stage: "task".to_string(),
-            title: format!("{}: {feat_title}", capitalize(task_type)),
+            title: format!("{}: {}", capitalize(task_type), feat_title),
             description: Some(format!(
                 "Task of type '{task_type}' for feature '{feat_title}'."
             )),
@@ -341,7 +341,7 @@ fn make_edge(
     }
 }
 
-// ── Heuristic Feature Extraction ────────────────────────────────────────────
+// â”€â”€ Heuristic Feature Extraction â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 fn extract_features(prompt: &str, base_slug: &str) -> Vec<(String, String)> {
     let lower = prompt.to_lowercase();
@@ -471,7 +471,7 @@ fn extract_features(prompt: &str, base_slug: &str) -> Vec<(String, String)> {
     candidates
 }
 
-// ── Validation ────────────────────────────────────────────────────────────────
+// â”€â”€ Validation â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 fn validate_graph(graph: &IntentGraph) -> Result<()> {
     // Round-trip through JSON to use the typed validator from agileplus-trace-validator.
@@ -483,7 +483,7 @@ fn validate_graph(graph: &IntentGraph) -> Result<()> {
     Ok(())
 }
 
-// ── Utilities ─────────────────────────────────────────────────────────────────
+// â”€â”€ Utilities â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 fn slugify(text: &str) -> String {
     let mut result = String::with_capacity(text.len());
@@ -502,7 +502,7 @@ fn slugify(text: &str) -> String {
     }
     // Collapse multiple hyphens
     let mut collapsed = String::with_capacity(result.len());
-    let mut prev = ' ';
+    let mut prev = '\0';
     for c in result.chars() {
         if c == '-' && prev == '-' {
             continue;
@@ -525,7 +525,7 @@ fn capitalize(s: &str) -> String {
     }
 }
 
-// ── Tests ─────────────────────────────────────────────────────────────────────
+// â”€â”€ Tests â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 #[cfg(test)]
 mod tests {

--- a/crates/agileplus-cli/src/commands/research.rs
+++ b/crates/agileplus-cli/src/commands/research.rs
@@ -268,7 +268,7 @@ async fn scan_directory_structure<V: VcsPort>(vcs: &V) -> String {
 async fn detect_technologies<V: VcsPort>(_vcs: &V) -> String {
     // In a real implementation we'd probe for Cargo.toml, package.json, etc.
     // For now, return a static placeholder since we'd need filesystem access.
-    "(technology detection requires filesystem access — run from project root)".to_string()
+    "(technology detection requires filesystem access â€” run from project root)".to_string()
 }
 
 /// List existing spec files.
@@ -287,7 +287,7 @@ async fn list_existing_specs<V: VcsPort>(vcs: &V) -> String {
 
 /// Analyze existing code for potential conflicts.
 async fn analyze_existing_code<V: VcsPort>(_vcs: &V, _slug: &str) -> String {
-    "(static analysis not yet implemented — manual review recommended)".to_string()
+    "(static analysis not yet implemented â€” manual review recommended)".to_string()
 }
 
 /// Count occurrences of a pattern in content.

--- a/crates/agileplus-cli/src/commands/review_loop.rs
+++ b/crates/agileplus-cli/src/commands/review_loop.rs
@@ -120,7 +120,7 @@ pub fn format_feedback(comments: &[String]) -> String {
     let items: Vec<String> = comments
         .iter()
         .enumerate()
-        .map(|(i, c)| format!("{}. {}", i + 1, c))
+        .map(|(i, c)| format!("{}. {c}", i + 1))
         .collect();
     format!(
         "Please address the following review comments:\n\n{}\n",

--- a/crates/agileplus-cli/src/commands/scope_status.rs
+++ b/crates/agileplus-cli/src/commands/scope_status.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-//! `ap scope-status` — show the active cycle and the modules within
+//! `ap scope-status` â€” show the active cycle and the modules within
 //! its scope, plus a count of features associated with each module.
 //!
 //! Scope status is the high-level "where are we working right now?"
@@ -13,7 +13,7 @@
 //!
 //! ```text
 //! $ ap scope-status
-//! Active cycle: Sprint 1 (2026-05-26 → 2026-06-09) — module scope id=1
+//! Active cycle: Sprint 1 (2026-05-26 â†’ 2026-06-09) â€” module scope id=1
 //! Modules in scope:
 //!  ID  SLUG             NAME                  FEATURES
 //!   1  core-platform    Core Platform              2
@@ -82,12 +82,12 @@ pub fn run(args: &ScopeStatusArgs) -> Result<()> {
     match active {
         Some(c) => {
             println!(
-                "Active cycle: {} ({} → {}){}",
+                "Active cycle: {} ({} â†’ {}){}",
                 c.name,
                 c.start_date,
                 c.end_date,
                 c.module_scope_id
-                    .map(|id| format!(" — module scope id={id}"))
+                    .map(|id| format!(" â€” module scope id={id}"))
                     .unwrap_or_default()
             );
         }
@@ -95,7 +95,7 @@ pub fn run(args: &ScopeStatusArgs) -> Result<()> {
             println!("No active cycle. All known cycles:");
             for c in &cycles {
                 println!(
-                    "  [{}] {:<20}  {:<10}  {} → {}",
+                    "  [{}] {:<20}  {:<10}  {} â†’ {}",
                     c.id, c.name, c.state, c.start_date, c.end_date
                 );
             }
@@ -103,8 +103,7 @@ pub fn run(args: &ScopeStatusArgs) -> Result<()> {
     }
 
     if modules.is_empty() {
-        println!("
-No modules in scope.");
+        println!("\nNo modules in scope.");
         return Ok(());
     }
 
@@ -253,7 +252,7 @@ fn truncate(s: &str, max: usize) -> String {
         return s.to_string();
     }
     let t: String = s.chars().take(max.saturating_sub(1)).collect();
-    format!("{t}…")
+    format!("{t}â€¦")
 }
 
 #[cfg(test)]
@@ -385,7 +384,7 @@ mod tests {
     fn truncate_shortens_long_strings() {
         // The helper caps the result at `max` visible characters:
         // `max - 1` original characters plus the ellipsis.
-        assert_eq!(truncate("Persistence", 5), "Pers…");
+        assert_eq!(truncate("Persistence", 5), "Persâ€¦");
     }
 
     #[test]

--- a/crates/agileplus-cli/src/commands/seed_requirements.rs
+++ b/crates/agileplus-cli/src/commands/seed_requirements.rs
@@ -3,7 +3,7 @@
 //!
 //! Ingests the six FR/NFR catalogs (AgilePlus, Tracera, phenotype-voxel, Authvault,
 //! PhenoMCP, PhenoObservability) as Epics + Stories into an AgilePlus SQLite database,
-//! each cross-referencing its Tracera Requirement ID.  Idempotent — safe to run multiple times.
+//! each cross-referencing its Tracera Requirement ID.  Idempotent â€” safe to run multiple times.
 
 use std::path::PathBuf;
 
@@ -11,10 +11,10 @@ use clap::Args;
 
 use agileplus_sqlite::seed::{seed_requirements, Initiative};
 
-/// Embedded catalog markdown files — bundled at compile time.
+/// Embedded catalog markdown files â€” bundled at compile time.
 /// Paths are relative to this source file:
 ///   crates/agileplus-cli/src/commands/seed_requirements.rs
-///   → up 4 dirs → workspace root → docs/requirements/
+///   â†’ up 4 dirs â†’ workspace root â†’ docs/requirements/
 const AGILEPLUS_CATALOG: &str = include_str!("../../../../docs/requirements/agileplus-frnfr.md");
 const TRACERA_CATALOG: &str = include_str!("../../../../docs/requirements/tracera-frnfr.md");
 const PHENOTYPE_VOXEL_CATALOG: &str =
@@ -88,8 +88,7 @@ pub fn run(args: &SeedRequirementsArgs) -> anyhow::Result<()> {
     if args.verbose {
         for init in &report.initiatives {
             println!(
-                "
-  Epic [{}] id={}",
+                "\n  Epic [{}] id={}",
                 init.epic_requirement_id, init.epic_id
             );
             for s in &init.stories {

--- a/crates/agileplus-cli/src/commands/specify.rs
+++ b/crates/agileplus-cli/src/commands/specify.rs
@@ -161,7 +161,7 @@ fn run_interview() -> Result<(String, String)> {
     let fr_lines: String = frs
         .iter()
         .enumerate()
-        .map(|(i, fr)| format!("- **FR-{}**: {}", i + 1, fr))
+        .map(|(i, fr)| format!("- **FR-{}**: {fr}", i + 1))
         .collect::<Vec<_>>()
         .join("\n");
 

--- a/crates/agileplus-cli/src/commands/specify/prompt.rs
+++ b/crates/agileplus-cli/src/commands/specify/prompt.rs
@@ -85,7 +85,7 @@ fn run_interview() -> Result<(String, String)> {
     let fr_lines: String = frs
         .iter()
         .enumerate()
-        .map(|(i, fr)| format!("- **FR-{}**: {}", i + 1, fr))
+        .map(|(i, fr)| format!("- **FR-{}**: {fr}", i + 1))
         .collect::<Vec<_>>()
         .join("\n");
 

--- a/crates/agileplus-cli/src/commands/trace.rs
+++ b/crates/agileplus-cli/src/commands/trace.rs
@@ -1,4 +1,4 @@
-//! `ap trace link <from> <to>` subcommand — inserts a row into the
+//! `ap trace link <from> <to>` subcommand â€” inserts a row into the
 //! `trace_links` table to record a directed edge between two domain
 //! entities.  Also supports the inverse / list-view surface used by
 //! `ap dashboard`.
@@ -35,28 +35,37 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, bail, Context, Result};
-use clap::{Args, Parser, Subcommand};
+use clap::{Args, Subcommand};
 use rusqlite::{params, Connection};
 
 use agileplus_sqlite::migrations::MigrationRunner;
 
-// ── CLI surface ─────────────────────────────────────────────────────────────
+// â”€â”€ CLI surface â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
-#[derive(Debug, Parser)]
-#[command(
-    name = "trace",
-    about = "Manage trace links between domain entities",
-    long_about = "Create, list, and inspect directed edges between AgilePlus \
-                  domain entities (work_package, feature, story, epic, ...).  \
-                  Edges are persisted in the `trace_links` table."
-)]
-pub struct TraceArgs {
+/// Top-level `trace` args struct â€” implements `clap::Args` so it can be
+/// embedded as a variant in the parent `Command` enum in `main.rs`.
+#[derive(Debug, Args)]
+pub struct TraceCmd {
     #[command(subcommand)]
-    pub sub: TraceCmd,
+    pub sub: TraceSub,
 }
 
+impl TraceCmd {
+    /// Dispatch the chosen subcommand.
+    pub async fn run(&self) -> anyhow::Result<()> {
+        match &self.sub {
+            TraceSub::Link(a) => run_link(a),
+            TraceSub::List(a) => run_list(a),
+            TraceSub::Show(a) => run_show(a),
+        }
+    }
+}
+
+/// Legacy alias kept for callers that still use `TraceArgs` directly.
+pub type TraceArgs = TraceCmd;
+
 #[derive(Debug, Subcommand)]
-pub enum TraceCmd {
+pub enum TraceSub {
     /// Insert a directed trace link between two entities.
     Link(LinkArgs),
     /// List the most-recent trace links (default 25).
@@ -110,7 +119,7 @@ pub struct ShowArgs {
     pub db: Option<PathBuf>,
 }
 
-// ── Allowed enumerations (mirror CHECK constraints) ────────────────────────
+// â”€â”€ Allowed enumerations (mirror CHECK constraints) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 const ALLOWED_KINDS: &[&str] = &[
     "work_package",
@@ -135,15 +144,15 @@ const ALLOWED_LINK_TYPES: &[&str] = &[
     "duplicates",
 ];
 
-// ── Public entry points ───────────────────────────────────────────────────
+// â”€â”€ Public entry points â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 /// Dispatch the `trace` subcommand.  Each variant opens the DB itself so
 /// the caller can hand off via the `agileplus-cli` main entry point.
-pub fn run(args: &TraceArgs) -> Result<()> {
+pub fn run(args: &TraceCmd) -> Result<()> {
     match &args.sub {
-        TraceCmd::Link(a) => run_link(a),
-        TraceCmd::List(a) => run_list(a),
-        TraceCmd::Show(a) => run_show(a),
+        TraceSub::Link(a) => run_link(a),
+        TraceSub::List(a) => run_list(a),
+        TraceSub::Show(a) => run_show(a),
     }
 }
 
@@ -331,7 +340,7 @@ pub fn run_show(args: &ShowArgs) -> Result<()> {
     Ok(())
 }
 
-// ── Helpers ───────────────────────────────────────────────────────────────
+// â”€â”€ Helpers â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 /// Parse `<kind>:<id>` (e.g. `wp:42`, `feature:7`).
 pub(crate) fn parse_ref(raw: &str, slot: &str) -> Result<(String, String)> {
@@ -368,7 +377,7 @@ pub(crate) fn truncate(s: &str, max: usize) -> String {
         return s.to_string();
     }
     let t: String = s.chars().take(max.saturating_sub(1)).collect();
-    format!("{t}…")
+    format!("{t}â€¦")
 }
 
 #[derive(Debug, Clone)]
@@ -395,7 +404,7 @@ pub(crate) struct TraceLinkDetail {
     pub created_at: String,
 }
 
-// ── Unit tests ────────────────────────────────────────────────────────────
+// â”€â”€ Unit tests â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 #[cfg(test)]
 mod tests {
@@ -429,7 +438,7 @@ mod tests {
     fn truncate_shortens_long_strings() {
         assert_eq!(
             truncate("2026-06-11T00:00:00.123456+00:00", 10),
-            "2026-06-1…"
+            "2026-06-1â€¦"
         );
     }
 

--- a/crates/agileplus-cli/src/commands/worklog.rs
+++ b/crates/agileplus-cli/src/commands/worklog.rs
@@ -1,12 +1,29 @@
 //! agileplus-cli worklog subcommand.
 //!
-//! Provides `agileplus worklog {validate,convert,schema,list}` for
-//! managing the canonical 8-field worklog schema across repos.
+//! Two related features share this command tree:
+//!
+//! 1. **File-level worklog management** (L2 #25) â€” validate, convert,
+//!    print, and list worklog JSON files against the canonical 8-field
+//!    schema in `WORKLOG_SCHEMA_2026_06_10.md`. Subcommands: `validate`,
+//!    `convert`, `schema`, `list`.
+//!
+//! 2. **Database-backed ingest / query** (L2 #39) â€” read worklog JSON
+//!    files, validate them, and insert a row into the `worklog_entries`
+//!    SQLite table; query that table back as a table or JSON. Subcommands:
+//!    `emit`, `show`.
+//!
+//! The schema validated by both surfaces is the same canonical schema
+//! (`status`, `task_id`, `agent_id`, `files_changed`, `commit_sha`,
+//! `verification_result`, `started_at`, `completed_at`).
 
 use std::path::{Path, PathBuf};
 
+use anyhow::{bail, Context, Result};
 use clap::{Args, Subcommand};
+use rusqlite::Connection;
 use serde::{Deserialize, Serialize};
+
+// â”€â”€ Schema constants (L1 WORKLOG_SCHEMA_2026_06_10.md) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 const CANONICAL_FIELDS: &[&str] = &[
     "status",
@@ -19,10 +36,52 @@ const CANONICAL_FIELDS: &[&str] = &[
     "completed_at",
 ];
 
+const CANONICAL_STATUSES: &[&str] = &[
+    "pending",
+    "running",
+    "blocked",
+    "completed",
+    "failed",
+    "cancelled",
+];
+const CANONICAL_VERIFICATION_STATUSES: &[&str] = &["passed", "failed", "not_run", "partial"];
+
+// â”€â”€ File-level types (L2 #25) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+
+#[derive(Debug, Serialize, Deserialize)]
+struct CanonicalWorklog {
+    status: String,
+    task_id: String,
+    agent_id: String,
+    files_changed: Vec<String>,
+    commit_sha: String,
+    verification_result: VerificationResult,
+    started_at: Option<String>,
+    completed_at: Option<String>,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct VerificationResult {
+    #[serde(default)]
+    status: String,
+    #[serde(default)]
+    commands: Vec<String>,
+    #[serde(default)]
+    notes: String,
+}
+
+// â”€â”€ CLI surface â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+
 /// Top-level worklog command.
+///
+/// The optional `dir` is honored only by the file-level subcommands
+/// (`validate`/`convert`/`schema`/`list`). The database-backed subcommands
+/// (`emit`/`show`) source their input from explicit `--from` and filter
+/// flags.
 #[derive(Debug, Args)]
 pub struct WorklogArgs {
-    /// Working directory (defaults to current directory).
+    /// Working directory (defaults to current directory). Used by the
+    /// file-level subcommands only.
     #[arg(long, short = 'd', default_value = ".")]
     pub dir: PathBuf,
 
@@ -46,31 +105,90 @@ pub enum WorklogAction {
     Schema,
     /// List all worklog files (raw + canonical) in DIR.
     List,
+    /// Read one or more worklog JSON files and insert them into the
+    /// `worklog_entries` table (L2 #39).
+    Emit(EmitArgs),
+    /// Query `worklog_entries` and print a table or JSON (L2 #39).
+    Show(ShowArgs),
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-struct CanonicalWorklog {
-    status: String,
-    task_id: String,
-    agent_id: String,
-    files_changed: Vec<String>,
-    commit_sha: String,
-    verification_result: VerificationResult,
-    started_at: Option<String>,
-    completed_at: Option<String>,
+#[derive(Debug, Args)]
+pub struct EmitArgs {
+    /// Path to a single worklog JSON file or a directory of worklog JSON
+    /// files. When a directory is given, every `*.json` file directly
+    /// under it is loaded (non-recursive).
+    #[arg(long, value_name = "PATH")]
+    pub from: PathBuf,
+
+    /// Print a detailed per-file report.
+    #[arg(long)]
+    pub verbose: bool,
+
+    /// Force re-ingest by removing any existing row with the same
+    /// `(task_id, source_path)` before inserting.
+    #[arg(long)]
+    pub replace: bool,
 }
 
-#[derive(Debug, Default, Serialize, Deserialize)]
-struct VerificationResult {
-    #[serde(default)]
-    status: String,
-    #[serde(default)]
-    commands: Vec<String>,
-    #[serde(default)]
-    notes: String,
+#[derive(Debug, Args)]
+pub struct ShowArgs {
+    /// Filter by `task_id` (exact match).
+    #[arg(long)]
+    pub task: Option<String>,
+
+    /// Filter by `status` (exact match).
+    #[arg(long)]
+    pub status: Option<String>,
+
+    /// Cap the number of rows printed.
+    #[arg(long, default_value_t = 50)]
+    pub limit: i64,
+
+    /// Emit JSON instead of a human-readable table.
+    #[arg(long)]
+    pub json: bool,
 }
 
-pub fn run(args: &WorklogArgs) -> anyhow::Result<()> {
+// â”€â”€ Database-backed types (L2 #39) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+
+/// Top-level worklog payload (validation target).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorklogPayload {
+    pub status: String,
+    pub task_id: String,
+    pub agent_id: String,
+    #[serde(default)]
+    pub files_changed: Vec<String>,
+    pub commit_sha: Option<String>,
+    pub verification_result: VerificationResult,
+    pub started_at: String,
+    pub completed_at: Option<String>,
+    #[serde(flatten)]
+    pub extra: serde_json::Map<String, serde_json::Value>,
+}
+
+/// Row representation after read-back from the `worklog_entries` table.
+#[derive(Debug, Clone)]
+pub struct WorklogEntry {
+    pub id: i64,
+    pub status: String,
+    pub task_id: String,
+    pub agent_id: String,
+    pub files_changed: Vec<String>,
+    pub commit_sha: Option<String>,
+    pub verification: VerificationResult,
+    pub started_at: String,
+    pub completed_at: Option<String>,
+    pub source_path: String,
+    pub ingested_at: String,
+}
+
+// â”€â”€ Public dispatch â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+
+/// Top-level entry point dispatched from `main.rs`. Resolves the database
+/// path internally from the `AGILEPLUS_DB` environment variable for the
+/// database-backed subcommands.
+pub fn run(args: &WorklogArgs) -> Result<()> {
     match &args.action {
         WorklogAction::Schema => {
             println!("Canonical worklog schema (8 fields):");
@@ -82,10 +200,58 @@ pub fn run(args: &WorklogArgs) -> anyhow::Result<()> {
         WorklogAction::List => list(&args.dir),
         WorklogAction::Validate => validate(&args.dir),
         WorklogAction::Convert { in_place } => convert(&args.dir, *in_place),
+        WorklogAction::Emit(e) => {
+            let db_path = db_path_from_env();
+            let report = run_emit(e, &db_path)?;
+            println!(
+                "Emit complete: {} file(s) loaded, {} row(s) inserted, {} replaced, {} skipped.",
+                report.files_loaded,
+                report.rows_inserted,
+                report.rows_replaced,
+                report.files_skipped
+            );
+            if !report.validation_errors.is_empty() {
+                eprintln!("Validation / IO errors:");
+                for (path, msg) in &report.validation_errors {
+                    eprintln!("  {}: {}", path.display(), msg);
+                }
+            }
+            Ok(())
+        }
+        WorklogAction::Show(s) => {
+            let db_path = db_path_from_env();
+            let entries = run_show(s, &db_path)?;
+            if s.json {
+                let projection: Vec<serde_json::Value> = entries
+                    .iter()
+                    .map(|e| {
+                        serde_json::json!({
+                            "id": e.id,
+                            "task_id": e.task_id,
+                            "status": e.status,
+                            "agent_id": e.agent_id,
+                            "files_changed": e.files_changed,
+                            "commit_sha": e.commit_sha,
+                            "verification": {
+                                "status": e.verification.status,
+                                "notes": e.verification.notes,
+                            },
+                            "started_at": e.started_at,
+                            "completed_at": e.completed_at,
+                            "source_path": e.source_path,
+                            "ingested_at": e.ingested_at,
+                        })
+                    })
+                    .collect();
+                println!("{}", serde_json::to_string_pretty(&projection)?);
+            } else {
+                print_table(&entries);
+            }
+            Ok(())
+        }
     }
 }
 
-<<<<<<< HEAD
 /// Top-level entry point with an explicit database path. Preferred when the
 /// caller (e.g. `main.rs`) has already resolved the path via
 /// `db_path_from_env()` so the env-var lookup happens exactly once.
@@ -151,18 +317,15 @@ pub fn run_with_db(args: &WorklogArgs, db_path: &Path) -> Result<()> {
     }
 }
 
-pub fn db_path_from_env() -> PathBuf {
+fn db_path_from_env() -> PathBuf {
     std::env::var("AGILEPLUS_DB")
         .map(PathBuf::from)
         .unwrap_or_else(|_| PathBuf::from("agileplus.db"))
 }
 
-// ── File-level commands (L2 #25) ──────────────────────────────────────────
+// â”€â”€ File-level commands (L2 #25) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 fn list(dir: &Path) -> Result<()> {
-=======
-fn list(dir: &Path) -> anyhow::Result<()> {
->>>>>>> pr-769
     let raw = find_worklogs(dir, false)?;
     let canonical = find_worklogs(dir, true)?;
     println!("Raw worklogs in {}:", dir.display());
@@ -176,7 +339,7 @@ fn list(dir: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn validate(dir: &Path) -> anyhow::Result<()> {
+fn validate(dir: &Path) -> Result<()> {
     let files = find_worklogs(dir, false)?;
     println!(
         "Validating {} worklog(s) in {} against canonical schema...",
@@ -203,11 +366,7 @@ fn validate(dir: &Path) -> anyhow::Result<()> {
                         println!(
                             "FAIL {}: missing {}",
                             path.display(),
-                            missing
-                                .iter()
-                                .map(|s| **s)
-                                .collect::<Vec<_>>()
-                                .join(", ")
+                            missing.iter().map(|s| **s).collect::<Vec<_>>().join(", ")
                         );
                         err += 1;
                     }
@@ -222,18 +381,14 @@ fn validate(dir: &Path) -> anyhow::Result<()> {
             }
         }
     }
-<<<<<<< HEAD
     println!("\nResult: {ok} OK, {err} FAIL");
-=======
-    println!("\nResult: {} OK, {} FAIL", ok, err);
->>>>>>> pr-769
     if err > 0 {
         std::process::exit(1);
     }
     Ok(())
 }
 
-fn convert(dir: &Path, in_place: bool) -> anyhow::Result<()> {
+fn convert(dir: &Path, in_place: bool) -> Result<()> {
     let files = find_worklogs(dir, false)?;
     println!(
         "Converting {} worklog(s) in {} (in_place={})",
@@ -275,7 +430,11 @@ fn to_canonical(raw: &serde_json::Value) -> CanonicalWorklog {
             .unwrap_or_default()
     };
     let verification = obj
-        .and_then(|o| o.get("verification_result").cloned().or_else(|| o.get("verification").cloned()))
+        .and_then(|o| {
+            o.get("verification_result")
+                .cloned()
+                .or_else(|| o.get("verification").cloned())
+        })
         .map(|v| {
             let status = v
                 .get("status")
@@ -328,7 +487,7 @@ fn to_canonical(raw: &serde_json::Value) -> CanonicalWorklog {
     }
 }
 
-fn find_worklogs(dir: &Path, canonical_only: bool) -> anyhow::Result<Vec<PathBuf>> {
+fn find_worklogs(dir: &Path, canonical_only: bool) -> Result<Vec<PathBuf>> {
     let mut out = Vec::new();
     for entry in std::fs::read_dir(dir)? {
         let entry = entry?;
@@ -350,5 +509,697 @@ fn path_with_suffix(path: &Path, suffix: &str) -> PathBuf {
         PathBuf::from(format!("{stripped}{suffix}"))
     } else {
         path.with_extension(suffix)
+    }
+}
+
+// â”€â”€ Database-backed validation (L2 #39) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+
+/// Validate a parsed [`WorklogPayload`] against the canonical schema.
+pub fn validate_payload(payload: &WorklogPayload) -> Result<()> {
+    if !CANONICAL_STATUSES.contains(&payload.status.as_str()) {
+        bail!(
+            "invalid status '{}': expected one of {}",
+            payload.status,
+            CANONICAL_STATUSES.join(", ")
+        );
+    }
+    if payload.task_id.trim().is_empty() {
+        bail!("task_id must be a non-empty string");
+    }
+    if payload.agent_id.trim().is_empty() {
+        bail!("agent_id must be a non-empty string");
+    }
+    if let Some(ref sha) = payload.commit_sha {
+        if !is_valid_sha(sha) {
+            bail!("commit_sha '{sha}' is not a 7-40 char hex string and is not null");
+        }
+    }
+    if !CANONICAL_VERIFICATION_STATUSES.contains(&payload.verification_result.status.as_str()) {
+        bail!(
+            "verification_result.status '{}' is invalid: expected one of {}",
+            payload.verification_result.status,
+            CANONICAL_VERIFICATION_STATUSES.join(", ")
+        );
+    }
+    if payload.verification_result.status == "not_run"
+        && !payload.verification_result.commands.is_empty()
+    {
+        bail!("verification_result.commands must be empty when status is 'not_run'");
+    }
+    for cmd in &payload.verification_result.commands {
+        if cmd.trim().is_empty() {
+            bail!("verification_result.commands contains an empty entry");
+        }
+    }
+    if !is_iso8601_like(&payload.started_at) {
+        bail!(
+            "started_at '{s}' is not an ISO-8601-like string",
+            s = payload.started_at
+        );
+    }
+    if let Some(ref c) = payload.completed_at {
+        if !is_iso8601_like(c) {
+            bail!("completed_at '{c}' is not an ISO-8601-like string");
+        }
+    }
+    // files_changed: unique, non-empty
+    let mut seen = std::collections::HashSet::new();
+    for f in &payload.files_changed {
+        if f.trim().is_empty() {
+            bail!("files_changed contains an empty entry");
+        }
+        if !seen.insert(f.as_str()) {
+            bail!("files_changed contains duplicate entry '{f}'");
+        }
+    }
+    Ok(())
+}
+
+fn is_valid_sha(s: &str) -> bool {
+    let len = s.len();
+    (7..=40).contains(&len)
+        && s.chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase())
+}
+
+/// Lenient ISO-8601 check. We only require a `YYYY-MM-DD` prefix followed
+/// by some non-empty suffix so we accept `2026-06-10`, `2026-06-10T00:00:00Z`,
+/// and `2026-06-10T00:00:00.000+00:00` alike. Full RFC 3339 parsing is left
+/// to downstream consumers.
+fn is_iso8601_like(s: &str) -> bool {
+    if s.len() < 10 {
+        return false;
+    }
+    let bytes = s.as_bytes();
+    bytes[0..4].iter().all(|b| b.is_ascii_digit())
+        && bytes[4] == b'-'
+        && bytes[5..7].iter().all(|b| b.is_ascii_digit())
+        && bytes[7] == b'-'
+        && bytes[8..10].iter().all(|b| b.is_ascii_digit())
+        && s[10..].chars().any(|c| c != ' ')
+}
+
+// â”€â”€ Connection management (L2 #39) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+
+/// Open the worklog database, ensuring the schema is present.
+///
+/// If the database does not yet exist, the table is created by running the
+/// bundled migration `022_create_worklog_entries.sql` via the regular
+/// `MigrationRunner` so it stays in sync with the rest of the schema.
+pub fn open_db(db_path: &Path) -> Result<Connection> {
+    let conn = Connection::open(db_path)
+        .with_context(|| format!("opening database at {}", db_path.display()))?;
+    conn.execute_batch("PRAGMA foreign_keys=ON;")
+        .context("enabling foreign keys")?;
+
+    // Run all migrations (this is idempotent â€” applied migrations are
+    // skipped). Migration 022 is the one that creates `worklog_entries`.
+    let runner = agileplus_sqlite::migrations::MigrationRunner::new(&conn);
+    runner
+        .run_all()
+        .context("applying agileplus migrations (worklog bootstrap)")?;
+
+    Ok(conn)
+}
+
+// â”€â”€ Emit logic (L2 #39) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+
+/// Outcome of a single `emit --from` invocation.
+#[derive(Debug, Default)]
+pub struct EmitReport {
+    pub files_seen: usize,
+    pub files_loaded: usize,
+    pub files_skipped: usize,
+    pub rows_inserted: usize,
+    pub rows_replaced: usize,
+    pub validation_errors: Vec<(PathBuf, String)>,
+}
+
+/// Walk a path: if it is a file load it, if it is a directory load every
+/// `*.json` file directly under it (non-recursive). The detailed outcome is
+/// returned in an [`EmitReport`].
+pub fn run_emit(args: &EmitArgs, db_path: &Path) -> Result<EmitReport> {
+    let mut report = EmitReport::default();
+    let conn = open_db(db_path)?;
+    let files = collect_worklog_files(&args.from, &mut report)?;
+    report.files_seen = files.len();
+
+    for path in files {
+        let display = path.display().to_string();
+        let raw = match std::fs::read_to_string(&path) {
+            Ok(s) => s,
+            Err(e) => {
+                report.files_skipped += 1;
+                report
+                    .validation_errors
+                    .push((path.clone(), format!("read error: {e}")));
+                continue;
+            }
+        };
+        let payload: WorklogPayload = match serde_json::from_str(&raw) {
+            Ok(p) => p,
+            Err(e) => {
+                report.files_skipped += 1;
+                report
+                    .validation_errors
+                    .push((path.clone(), format!("json parse error: {e}")));
+                continue;
+            }
+        };
+        if let Err(e) = validate_payload(&payload) {
+            report.files_skipped += 1;
+            report
+                .validation_errors
+                .push((path.clone(), format!("{e:#}")));
+            continue;
+        }
+
+        let inserted = insert_entry(&conn, &payload, &display, &raw, args.replace)?;
+        if inserted {
+            report.rows_inserted += 1;
+        } else if args.replace {
+            report.rows_replaced += 1;
+        }
+        report.files_loaded += 1;
+
+        if args.verbose {
+            println!(
+                "loaded  task_id={:<10} status={:<10} from {}",
+                payload.task_id, payload.status, display
+            );
+        }
+    }
+
+    Ok(report)
+}
+
+fn collect_worklog_files(from: &Path, report: &mut EmitReport) -> Result<Vec<PathBuf>> {
+    if !from.exists() {
+        bail!("--from path does not exist: {}", from.display());
+    }
+    if from.is_file() {
+        return Ok(vec![from.to_path_buf()]);
+    }
+    let mut out = Vec::new();
+    let entries =
+        std::fs::read_dir(from).with_context(|| format!("reading directory {}", from.display()))?;
+    for entry in entries {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(e) => {
+                report
+                    .validation_errors
+                    .push((from.to_path_buf(), format!("dir entry error: {e}")));
+                continue;
+            }
+        };
+        let p = entry.path();
+        if p.is_file() && p.extension().and_then(|s| s.to_str()) == Some("json") {
+            out.push(p);
+        }
+    }
+    out.sort();
+    Ok(out)
+}
+
+/// Insert a single validated worklog entry. Returns `true` on a new insert,
+/// `false` if the row was already present and `--replace` was not set.
+pub fn insert_entry(
+    conn: &Connection,
+    payload: &WorklogPayload,
+    source_path: &str,
+    raw_payload: &str,
+    replace: bool,
+) -> Result<bool> {
+    let files_changed_json =
+        serde_json::to_string(&payload.files_changed).context("serializing files_changed")?;
+    let verification_json =
+        serde_json::to_string(&payload.verification_result).context("serializing verification")?;
+    let ingested_at = chrono::Utc::now().to_rfc3339();
+
+    if replace {
+        conn.execute(
+            "DELETE FROM worklog_entries WHERE task_id = ?1 AND source_path = ?2",
+            rusqlite::params![payload.task_id, source_path],
+        )
+        .context("deleting prior worklog row")?;
+    }
+
+    let rows = conn
+        .execute(
+            "INSERT OR IGNORE INTO worklog_entries
+            (status, task_id, agent_id, files_changed_json, commit_sha,
+             verification_json, started_at, completed_at, source_path,
+             payload_json, ingested_at)
+         VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11)",
+            rusqlite::params![
+                payload.status,
+                payload.task_id,
+                payload.agent_id,
+                files_changed_json,
+                payload.commit_sha,
+                verification_json,
+                payload.started_at,
+                payload.completed_at,
+                source_path,
+                raw_payload,
+                ingested_at,
+            ],
+        )
+        .context("inserting worklog row")?;
+    Ok(rows == 1)
+}
+
+// â”€â”€ Show logic (L2 #39) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+
+/// Build a SELECT statement for `show` based on the optional filters. We
+/// build the SQL programmatically so unused filters do not pollute the plan.
+pub fn run_show(args: &ShowArgs, db_path: &Path) -> Result<Vec<WorklogEntry>> {
+    if args.limit <= 0 {
+        bail!("--limit must be a positive integer");
+    }
+    let conn = open_db(db_path)?;
+
+    let mut sql = String::from(
+        "SELECT id, status, task_id, agent_id, files_changed_json, commit_sha, \
+         verification_json, started_at, completed_at, source_path, ingested_at \
+         FROM worklog_entries",
+    );
+    let mut clauses: Vec<String> = Vec::new();
+    if args.task.is_some() {
+        clauses.push("task_id = ?".to_string());
+    }
+    if args.status.is_some() {
+        clauses.push("status = ?".to_string());
+    }
+    if !clauses.is_empty() {
+        sql.push_str(" WHERE ");
+        sql.push_str(&clauses.join(" AND "));
+    }
+    sql.push_str(" ORDER BY id DESC LIMIT ?");
+
+    let mut stmt = conn.prepare(&sql).context("preparing SELECT statement")?;
+    let mut params_dyn: Vec<&dyn rusqlite::ToSql> = Vec::new();
+    let task_ref;
+    let status_ref;
+    if let Some(ref t) = args.task {
+        task_ref = t.as_str();
+        params_dyn.push(&task_ref);
+    }
+    if let Some(ref s) = args.status {
+        status_ref = s.as_str();
+        params_dyn.push(&status_ref);
+    }
+    let limit_ref = args.limit;
+    params_dyn.push(&limit_ref);
+
+    let rows = stmt
+        .query_map(params_dyn.as_slice(), row_to_entry)
+        .context("executing worklog SELECT")?;
+    let mut entries = Vec::new();
+    for row in rows {
+        entries.push(row.context("reading worklog row")?);
+    }
+    Ok(entries)
+}
+
+fn row_to_entry(row: &rusqlite::Row<'_>) -> rusqlite::Result<WorklogEntry> {
+    let id: i64 = row.get(0)?;
+    let status: String = row.get(1)?;
+    let task_id: String = row.get(2)?;
+    let agent_id: String = row.get(3)?;
+    let files_changed_json: String = row.get(4)?;
+    let commit_sha: Option<String> = row.get(5)?;
+    let verification_json: String = row.get(6)?;
+    let started_at: String = row.get(7)?;
+    let completed_at: Option<String> = row.get(8)?;
+    let source_path: String = row.get(9)?;
+    let ingested_at: String = row.get(10)?;
+
+    let files_changed: Vec<String> = serde_json::from_str(&files_changed_json).unwrap_or_default();
+    let verification: VerificationResult =
+        serde_json::from_str(&verification_json).unwrap_or(VerificationResult {
+            status: "not_run".into(),
+            commands: vec![],
+            notes: String::new(),
+        });
+
+    Ok(WorklogEntry {
+        id,
+        status,
+        task_id,
+        agent_id,
+        files_changed,
+        commit_sha,
+        verification,
+        started_at,
+        completed_at,
+        source_path,
+        ingested_at,
+    })
+}
+
+/// Render an entry list to a human-readable table. Used by the `show`
+/// subcommand's default output mode.
+#[allow(clippy::print_literal)] // table header rows use literal strings for column names
+pub fn print_table(entries: &[WorklogEntry]) {
+    if entries.is_empty() {
+        println!("No worklog entries found.");
+        return;
+    }
+    println!(
+        "{:<5} {:<10} {:<12} {:<22} {:<24} {}",
+        "ID", "TASK", "STATUS", "AGENT", "STARTED", "COMMIT"
+    );
+    println!("{}", "-".repeat(90));
+    for e in entries {
+        println!(
+            "{:<5} {:<10} {:<12} {:<22} {:<24} {}",
+            e.id,
+            truncate(&e.task_id, 10),
+            truncate(&e.status, 12),
+            truncate(&e.agent_id, 22),
+            truncate(&e.started_at, 24),
+            e.commit_sha.as_deref().unwrap_or("â€”"),
+        );
+    }
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        return s.to_string();
+    }
+    let t: String = s.chars().take(max.saturating_sub(1)).collect();
+    format!("{t}â€¦")
+}
+
+// â”€â”€ Tests â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn good_payload() -> WorklogPayload {
+        WorklogPayload {
+            status: "completed".into(),
+            task_id: "L2-39".into(),
+            agent_id: "forge-l2-39".into(),
+            files_changed: vec!["a.rs".into(), "b.rs".into()],
+            commit_sha: Some("0123456789abcdef0123456789abcdef01234567".into()),
+            verification_result: VerificationResult {
+                status: "passed".into(),
+                commands: vec!["cargo test".into()],
+                notes: "ok".into(),
+            },
+            started_at: "2026-06-11T00:00:00Z".into(),
+            completed_at: Some("2026-06-11T00:10:00Z".into()),
+            extra: Default::default(),
+        }
+    }
+
+    fn temp_db_path(tag: &str) -> PathBuf {
+        let mut path = std::env::temp_dir();
+        path.push(format!(
+            "{tag}-{}-{}.db",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        path
+    }
+
+    fn tempdir_root(tag: &str) -> PathBuf {
+        let mut p = std::env::temp_dir();
+        p.push(format!(
+            "{tag}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        p
+    }
+
+    // â”€â”€ Validation tests â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+
+    #[test]
+    fn validate_payload_accepts_canonical_payload() {
+        assert!(validate_payload(&good_payload()).is_ok());
+    }
+
+    #[test]
+    fn validate_payload_rejects_unknown_status() {
+        let mut p = good_payload();
+        p.status = "bogus".into();
+        let err = validate_payload(&p).unwrap_err().to_string();
+        assert!(err.contains("invalid status"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_payload_rejects_blank_task_id() {
+        let mut p = good_payload();
+        p.task_id = "   ".into();
+        assert!(validate_payload(&p).is_err());
+    }
+
+    #[test]
+    fn validate_payload_rejects_blank_agent_id() {
+        let mut p = good_payload();
+        p.agent_id = String::new();
+        assert!(validate_payload(&p).is_err());
+    }
+
+    #[test]
+    fn validate_payload_rejects_uppercase_sha() {
+        let mut p = good_payload();
+        p.commit_sha = Some("ABCDEF1234".into());
+        assert!(validate_payload(&p).is_err());
+    }
+
+    #[test]
+    fn validate_payload_accepts_short_sha() {
+        let mut p = good_payload();
+        p.commit_sha = Some("0123456".into());
+        assert!(validate_payload(&p).is_ok());
+    }
+
+    #[test]
+    fn validate_payload_rejects_bad_verification_status() {
+        let mut p = good_payload();
+        p.verification_result.status = "yolo".into();
+        let err = validate_payload(&p).unwrap_err().to_string();
+        assert!(err.contains("verification_result.status"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_payload_rejects_not_run_with_commands() {
+        let mut p = good_payload();
+        p.verification_result.status = "not_run".into();
+        p.verification_result.commands = vec!["cargo test".into()];
+        let err = validate_payload(&p).unwrap_err().to_string();
+        assert!(err.contains("not_run"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_payload_rejects_duplicate_files_changed() {
+        let mut p = good_payload();
+        p.files_changed = vec!["a.rs".into(), "a.rs".into()];
+        let err = validate_payload(&p).unwrap_err().to_string();
+        assert!(err.contains("duplicate"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_payload_rejects_empty_command() {
+        let mut p = good_payload();
+        p.verification_result.commands = vec!["".into()];
+        assert!(validate_payload(&p).is_err());
+    }
+
+    #[test]
+    fn validate_payload_rejects_bad_iso8601() {
+        let mut p = good_payload();
+        p.started_at = "yesterday".into();
+        assert!(validate_payload(&p).is_err());
+    }
+
+    #[test]
+    fn validate_payload_rejects_bad_completed_at_iso8601() {
+        let mut p = good_payload();
+        p.completed_at = Some("2026/06/11 00:00:00".into());
+        assert!(validate_payload(&p).is_err());
+    }
+
+    // â”€â”€ Database / emit / show tests â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+
+    #[test]
+    fn open_db_creates_table_on_fresh_path() {
+        let db = temp_db_path("agileplus-worklog-open");
+        let conn = open_db(&db).expect("open");
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM worklog_entries", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(count, 0);
+        let _ = std::fs::remove_file(db);
+    }
+
+    #[test]
+    fn insert_entry_is_idempotent() {
+        let db = temp_db_path("agileplus-worklog-idem");
+        let conn = open_db(&db).unwrap();
+        let p = good_payload();
+        let raw = serde_json::to_string(&p).unwrap();
+        assert!(insert_entry(&conn, &p, "src/w.json", &raw, false).unwrap());
+        // Second insert with same (task_id, source_path) should be a no-op.
+        assert!(!insert_entry(&conn, &p, "src/w.json", &raw, false).unwrap());
+        // With replace=true, the row should be removed and re-inserted.
+        assert!(insert_entry(&conn, &p, "src/w.json", &raw, true).unwrap());
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM worklog_entries", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 1);
+        let _ = std::fs::remove_file(db);
+    }
+
+    #[test]
+    fn run_emit_inserts_valid_file_and_skips_invalid() {
+        let dir = tempdir_root("agileplus-worklog-run-emit");
+        std::fs::create_dir_all(&dir).unwrap();
+        let good_path = dir.join("good.json");
+        let bad_path = dir.join("bad.json");
+        let good = serde_json::to_string(&good_payload()).unwrap();
+        // Bad: wrong status value.
+        let mut bad_map: HashMap<String, serde_json::Value> = HashMap::new();
+        bad_map.insert("status".into(), serde_json::json!("bogus"));
+        bad_map.insert("task_id".into(), serde_json::json!("L2-39"));
+        bad_map.insert("agent_id".into(), serde_json::json!("forge"));
+        bad_map.insert("files_changed".into(), serde_json::json!([]));
+        bad_map.insert("commit_sha".into(), serde_json::json!(null));
+        bad_map.insert(
+            "verification_result".into(),
+            serde_json::json!({"status":"passed","commands":["x"],"notes":"ok"}),
+        );
+        bad_map.insert(
+            "started_at".into(),
+            serde_json::json!("2026-06-11T00:00:00Z"),
+        );
+        bad_map.insert("completed_at".into(), serde_json::json!(null));
+        let bad = serde_json::to_string(&bad_map).unwrap();
+        std::fs::write(&good_path, &good).unwrap();
+        std::fs::write(&bad_path, &bad).unwrap();
+
+        let db = temp_db_path("agileplus-worklog-run-emit-db");
+        let args = EmitArgs {
+            from: dir.clone(),
+            verbose: false,
+            replace: false,
+        };
+        let report = run_emit(&args, &db).unwrap();
+        assert_eq!(report.files_seen, 2);
+        assert_eq!(report.files_loaded, 1);
+        assert_eq!(report.files_skipped, 1);
+        assert_eq!(report.rows_inserted, 1);
+        assert_eq!(report.validation_errors.len(), 1);
+
+        let _ = std::fs::remove_file(&db);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn run_show_filters_by_task_and_status() {
+        let db = temp_db_path("agileplus-worklog-show-filter");
+        let conn = open_db(&db).unwrap();
+        let p1 = good_payload();
+        let mut p2 = good_payload();
+        p2.task_id = "L2-99".into();
+        p2.status = "running".into();
+        let raw1 = serde_json::to_string(&p1).unwrap();
+        let raw2 = serde_json::to_string(&p2).unwrap();
+        insert_entry(&conn, &p1, "a.json", &raw1, false).unwrap();
+        insert_entry(&conn, &p2, "b.json", &raw2, false).unwrap();
+
+        let all = run_show(
+            &ShowArgs {
+                task: None,
+                status: None,
+                limit: 10,
+                json: false,
+            },
+            &db,
+        )
+        .unwrap();
+        assert_eq!(all.len(), 2);
+
+        let only_l239 = run_show(
+            &ShowArgs {
+                task: Some("L2-39".into()),
+                status: None,
+                limit: 10,
+                json: false,
+            },
+            &db,
+        )
+        .unwrap();
+        assert_eq!(only_l239.len(), 1);
+        assert_eq!(only_l239[0].task_id, "L2-39");
+
+        let only_running = run_show(
+            &ShowArgs {
+                task: None,
+                status: Some("running".into()),
+                limit: 10,
+                json: false,
+            },
+            &db,
+        )
+        .unwrap();
+        assert_eq!(only_running.len(), 1);
+        assert_eq!(only_running[0].status, "running");
+
+        let _ = std::fs::remove_file(&db);
+    }
+
+    #[test]
+    fn row_to_entry_round_trips_files_changed() {
+        let db = temp_db_path("agileplus-worklog-roundtrip");
+        let conn = open_db(&db).unwrap();
+        let p = good_payload();
+        let raw = serde_json::to_string(&p).unwrap();
+        insert_entry(&conn, &p, "x.json", &raw, false).unwrap();
+        let entries = run_show(
+            &ShowArgs {
+                task: None,
+                status: None,
+                limit: 10,
+                json: false,
+            },
+            &db,
+        )
+        .unwrap();
+        assert_eq!(entries.len(), 1);
+        let e = &entries[0];
+        assert_eq!(e.task_id, "L2-39");
+        assert_eq!(e.status, "completed");
+        assert_eq!(e.files_changed, vec!["a.rs", "b.rs"]);
+        assert_eq!(e.verification.status, "passed");
+        assert_eq!(e.verification.commands, vec!["cargo test"]);
+        let _ = std::fs::remove_file(&db);
+    }
+
+    #[test]
+    fn run_show_rejects_negative_limit() {
+        let args = ShowArgs {
+            task: None,
+            status: None,
+            limit: -1,
+            json: false,
+        };
+        let db = temp_db_path("agileplus-worklog-show");
+        let res = run_show(&args, &db);
+        assert!(res.is_err());
+        let _ = std::fs::remove_file(db);
     }
 }

--- a/crates/agileplus-dashboard/src/routes/dashboard.rs
+++ b/crates/agileplus-dashboard/src/routes/dashboard.rs
@@ -23,10 +23,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::app_state::SharedState;
 use crate::templates::{
-    AgentActivityPartial, AgentView, DashboardPage, EventTimelinePartial,
-    EvidenceBundleView, FeatureDetailPage, FeatureView, HealthPanelPartial,
-    KanbanPartial, MediaAssetView, ProjectSwitcherPartial, ProjectView,
-    ReportArtifactView, WpListPartial, WpView,
+    AgentActivityPartial, AgentView, DashboardPage, EventTimelinePartial, EvidenceBundleView,
+    FeatureDetailPage, FeatureView, HealthPanelPartial, KanbanPartial, MediaAssetView,
+    ProjectSwitcherPartial, ProjectView, ReportArtifactView, WpListPartial, WpView,
 };
 
 use super::helpers::{
@@ -34,7 +33,7 @@ use super::helpers::{
     DashboardFilter,
 };
 
-// ── JSON API Response Types ────────────────────────────────────────────────
+// â”€â”€ JSON API Response Types â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 /// JSON response for GET /api/dashboard/work-packages.json
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -47,6 +46,7 @@ pub struct WorkPackageJson {
     pub assignee: Option<String>,
 }
 
+#[allow(dead_code)]
 fn build_feature_events(
     feature: &FeatureView,
     workpackages: &[WpView],
@@ -102,9 +102,7 @@ fn build_feature_evidence_bundles(
         created_at: Utc::now().format("%Y-%m-%d %H:%M:%S UTC").to_string(),
         artifact_ext: "md".into(),
         status: "available".into(),
-        content_preview: Some("# Feature Summary
-
-This feature provides...".to_string()),
+        content_preview: Some("# Feature Summary\n\nThis feature provides...".to_string()),
         is_text_artifact: true,
         is_image_artifact: false,
         download_url: format!("/api/evidence/{}/summary/content", feature.id),
@@ -197,7 +195,7 @@ fn build_feature_reports(
 ) -> Vec<ReportArtifactView> {
     vec![ReportArtifactView {
         id: format!("report-{id}-coverage", id = feature.id),
-        name: format!("Feature Coverage Report — {name}", name = feature.title),
+        name: format!("Feature Coverage Report â€” {name}", name = feature.title),
         source: "coverage-engine".into(),
         status: "completed".into(),
         generated_at: Utc::now().format("%Y-%m-%d %H:%M:%S UTC").to_string(),
@@ -363,7 +361,7 @@ pub async fn switch_project(State(state): State<SharedState>, Path(id): Path<i64
     render(KanbanPartial { cards })
 }
 
-// ── /api/time ────────────────────────────────────────────────────────────
+// â”€â”€ /api/time â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 pub async fn time_footer() -> axum::response::Html<String> {
     axum::response::Html(
@@ -373,7 +371,7 @@ pub async fn time_footer() -> axum::response::Html<String> {
     )
 }
 
-// ── SSE Stream /api/stream ───────────────────────────────────────────────
+// â”€â”€ SSE Stream /api/stream â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 use axum::response::sse::{Event, Sse};
 use std::convert::Infallible;
@@ -415,7 +413,7 @@ pub async fn sse_stream(
     Sse::new(stream)
 }
 
-// ── /api/dashboard/work-packages.json ─────────────────────────────────────
+// â”€â”€ /api/dashboard/work-packages.json â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 /// GET /api/dashboard/work-packages.json
 /// Returns all work packages across all features as a flat JSON array.
@@ -453,13 +451,13 @@ pub async fn all_work_packages_json(State(state): State<SharedState>) -> impl In
     }))
 }
 
-// ── /api/dashboard/epics-stories.json ────────────────────────────────────
+// â”€â”€ /api/dashboard/epics-stories.json â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 /// GET /api/dashboard/epics-stories.json
 /// Reads Epics + Stories directly from the SQLite database and returns them
 /// as a flat JSON payload. Used by the React dashboard at port 5176.
 pub async fn epics_stories_json() -> impl IntoResponse {
-    // Resolve db path: DATABASE_URL env → DATABASE_PATH env → default agileplus.db
+    // Resolve db path: DATABASE_URL env â†’ DATABASE_PATH env â†’ default agileplus.db
     let db_path: PathBuf = if let Ok(url) = std::env::var("DATABASE_URL") {
         url.strip_prefix("sqlite:").unwrap_or(&url).into()
     } else if let Ok(p) = std::env::var("DATABASE_PATH") {

--- a/crates/agileplus-factory/src/lib.rs
+++ b/crates/agileplus-factory/src/lib.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-//! Dark-factory loop — queue → claim → worktree → trail → PR.
+//! Dark-factory loop â€” queue â†’ claim â†’ worktree â†’ trail â†’ PR.
 //!
 //! The `Factory` struct is the entry point. It owns a [`ClaimStoreTrait`]
 //! implementation, polls an [`IssueQueue`], and for each issue:
@@ -10,7 +10,7 @@
 //! 4. Opens a PR via [`GitHubPrClient`] (or logs it in Suggest mode).
 //! 5. Releases the claim.
 //!
-//! The real agent loop (read code → plan edits → LLM calls) is a future phase.
+//! The real agent loop (read code â†’ plan edits â†’ LLM calls) is a future phase.
 //! This crate only scaffolds the pipeline with real Git/Claim primitives.
 
 use std::path::PathBuf;
@@ -37,7 +37,7 @@ pub use worker::Worker;
 /// The dark factory.
 ///
 /// Owns a [`ClaimStore`] (in-memory) and orchestrates the
-/// queue → claim → worktree → worker → PR loop.
+/// queue â†’ claim â†’ worktree â†’ worker â†’ PR loop.
 ///
 /// For multi-process deployments, swap the `ClaimStore` for a
 /// [`SqliteClaimStore`](agileplus_triage::claim_store_sqlite::SqliteClaimStore)
@@ -166,12 +166,7 @@ impl<Q: IssueQueue> Factory<Q> {
                     branch: branch.clone(),
                     title: format!("factory: {}", issue.title),
                     body: format!(
-                        "Automated PR for issue #{}
-
-Trail:
-```json
-{}
-```",
+                        "Automated PR for issue #{}\n\nTrail:\n```json\n{}\n```",
                         issue.number,
                         worker.trail.to_json().unwrap_or_default()
                     ),
@@ -251,7 +246,6 @@ Trail:
 
             self.claim_store.release(&claim_id);
             processed += 1;
-
         }
 
         Ok(processed)

--- a/crates/agileplus-git/src/claim_bound.rs
+++ b/crates/agileplus-git/src/claim_bound.rs
@@ -1,27 +1,57 @@
-//! Stub for claim-bound worktree creation.
+//! Claim-bound worktree creation (audit rec #11).
 //!
-//! TODO(wtreen): implement full claim-bound worktree lifecycle.
+//! [`ClaimBoundWorktree::create`] is the single entry point for
+//! "create a worktree for this Claim". It enforces three invariants
+//! that the bare [`super::GitVcsAdapter::create_worktree`] does not:
+//!
+//! 1. The [`Claim`] must be `kind == ClaimKind::Worktree` and `state
+//!    == ClaimState::Active`. Anything else is
+//!    [`DomainError::InvalidClaim`].
+//! 2. The worktree is actually created on disk (via the underlying
+//!    `create_worktree`).
+//! 3. The resulting path is recorded on the claim by replacing its
+//!    [`ClaimReason`] with [`ClaimReason::Branch`] holding the
+//!    canonical `feat/<feature_slug>/<wp_id>` branch name (the same
+//!    branch the worktree was checked out on). A later caller can
+//!    look up the worktree path with [`ClaimBoundWorktree::lookup`].
 
 use std::path::PathBuf;
 
 use agileplus_domain::error::DomainError;
-use agileplus_triage::claim::Claim;
+use agileplus_domain::ports::vcs::VcsPort;
+use agileplus_triage::claim::{
+    Claim, ClaimError, ClaimKind, ClaimReason, ClaimState, ClaimStoreTrait,
+};
 
-/// Trait for stores that can look up and update claims.
-pub trait ClaimStoreBound {
-    fn update_claim_reason(&mut self, claim_id: &str, reason: String);
-}
+use super::GitVcsAdapter;
 
-/// Worktree tied to a triage claim.
+/// Subset of [`ClaimStoreTrait`] we need to update a claim's reason
+/// after a successful worktree creation. The blanket `dyn
+/// ClaimStoreTrait` already covers this, but spelling out the bound
+/// makes the integration with [`ClaimBoundWorktree`] explicit and
+/// keeps the trait import surface minimal.
+pub trait ClaimStoreBound: ClaimStoreTrait {}
+impl<T: ClaimStoreTrait + ?Sized> ClaimStoreBound for T {}
+
+/// High-level "create a worktree, bound to a claim" helper.
 pub struct ClaimBoundWorktree;
 
 impl ClaimBoundWorktree {
+    /// Create a worktree on disk for the given `(feature_slug, wp_id)`,
+    /// validated against the supplied claim, and update the claim's
+    /// reason so the worktree path can be recovered later.
+    ///
+    /// The claim's *resource* is the canonical
+    /// `feat/<feature_slug>/<wp_id>` branch name. The worktree path
+    /// itself is recorded as the claim's [`ClaimReason::Branch`] value
+    /// â€” i.e. the same branch. To find the on-disk path from a claim,
+    /// use [`ClaimBoundWorktree::lookup`].
     pub fn create<S: ClaimStoreBound>(
-        _repo_root: PathBuf,
-        _feature_slug: &str,
-        _wp_id: &str,
-        _claim: &Claim,
-        _claim_store: &mut S,
+        repo_root: PathBuf,
+        feature_slug: &str,
+        wp_id: &str,
+        claim: &Claim,
+        claim_store: &mut S,
     ) -> Result<PathBuf, DomainError> {
         // (1) Validate the claim.
         Self::validate(claim)?;
@@ -132,7 +162,7 @@ fn block_on_sync<F: std::future::Future>(fut: F) -> F::Output {
 pub use agileplus_triage::claim::ClaimStoreTrait as ClaimStore;
 
 /// Convenience: build a [`Claim`] for a new worktree claim. Pure
-/// data — does not touch the store.
+/// data â€” does not touch the store.
 pub fn make_worktree_claim(
     claim_id: impl Into<String>,
     resource: impl Into<String>,

--- a/crates/agileplus-git/src/lib.rs
+++ b/crates/agileplus-git/src/lib.rs
@@ -5,7 +5,7 @@
 //! write operations that have a clean `git2` API (worktree add, branch
 //! create / delete, ref resolution, branch listing), and by the
 //! `git(1)` CLI for operations that libgit2 either does not expose or
-//! exposes in a way that is brittle across versions — namely
+//! exposes in a way that is brittle across versions â€” namely
 //!
 //! - `git worktree remove --force <path>` (more reliable than
 //!   `Worktree::prune`, which silently no-ops on dirty worktrees),
@@ -55,7 +55,7 @@ impl GitVcsAdapter {
     }
 
     /// Create an adapter rooted at an explicit path. The path does not
-    /// need to be the repo root — it may be a subdirectory; we
+    /// need to be the repo root â€” it may be a subdirectory; we
     /// `discover()` the actual root on each call.
     pub fn new(repo_root: PathBuf) -> Self {
         Self { repo_root }
@@ -216,7 +216,7 @@ impl VcsPort for GitVcsAdapter {
         let branch_exists = repo.find_branch(&branch, git2::BranchType::Local).is_ok();
         let flag = if branch_exists { "-B" } else { "-b" };
 
-        // Use the CLI for the worktree add — the git2 `Repository::worktree`
+        // Use the CLI for the worktree add â€” the git2 `Repository::worktree`
         // builder can produce a worktree in the wrong state on some
         // libgit2 versions, while `git worktree add` is the canonical,
         // well-tested path.
@@ -375,7 +375,7 @@ impl VcsPort for GitVcsAdapter {
     }
 
     async fn checkout_branch(&self, branch: &str) -> Result<(), DomainError> {
-        // The CLI is the most reliable checkout path — it updates the
+        // The CLI is the most reliable checkout path â€” it updates the
         // index, working tree, and HEAD ref in one go, and matches
         // what users see in their terminal.
         self.run_git_status(&["checkout", branch])?;
@@ -451,11 +451,7 @@ impl VcsPort for GitVcsAdapter {
         let mut out = Vec::new();
         for line in raw.lines() {
             if let Some(rest) = line.strip_prefix("changed in both") {
-                // Format: "changed in both
-  base   100644 <oid> <path>
-  ours   100644 <oid>
-  theirs 100644 <oid>
-"
+                // Format: "changed in both\n  base   100644 <oid> <path>\n  ours   100644 <oid>\n  theirs 100644 <oid>\n"
                 // The path appears on the next non-empty line.
                 let path = rest
                     .split_whitespace()
@@ -672,8 +668,7 @@ mod tests {
             .current_dir(&path)
             .output()
             .unwrap();
-        std::fs::write(path.join("README.md"), "hello
-").unwrap();
+        std::fs::write(path.join("README.md"), "hello\n").unwrap();
         StdCommand::new("git")
             .args(["add", "."])
             .current_dir(&path)
@@ -781,8 +776,7 @@ mod tests {
             .await
             .unwrap();
         adapter.checkout_branch("feat/conflict").await.unwrap();
-        std::fs::write(path.join("README.md"), "from feature
-").unwrap();
+        std::fs::write(path.join("README.md"), "from feature\n").unwrap();
         StdCommand::new("git")
             .args(["add", "README.md"])
             .current_dir(&path)
@@ -795,8 +789,7 @@ mod tests {
             .unwrap();
         // edit README.md differently on main
         adapter.checkout_branch("main").await.unwrap();
-        std::fs::write(path.join("README.md"), "from main
-").unwrap();
+        std::fs::write(path.join("README.md"), "from main\n").unwrap();
         StdCommand::new("git")
             .args(["add", "README.md"])
             .current_dir(&path)
@@ -843,8 +836,7 @@ mod tests {
         let (_dir, path) = make_repo();
         let adapter = GitVcsAdapter::new(path.clone());
         adapter
-            .write_artifact("login", "spec.md", "# spec
-")
+            .write_artifact("login", "spec.md", "# spec\n")
             .await
             .expect("write");
         let content = adapter

--- a/crates/agileplus-integration-tests/tests/dashboard_sse.rs
+++ b/crates/agileplus-integration-tests/tests/dashboard_sse.rs
@@ -10,7 +10,7 @@ use agileplus_integration_tests::common::fixtures::feature_create_payload;
 use std::time::Duration;
 
 #[cfg(feature = "integration")]
-use agileplus_integration_tests::common::harness::{TestHarness, is_process_compose_installed};
+use agileplus_integration_tests::common::harness::{is_process_compose_installed, TestHarness};
 
 /// Helper: skip the test if services are unavailable.
 #[cfg(feature = "integration")]
@@ -26,7 +26,7 @@ macro_rules! require_services {
     };
 }
 
-/// SSE connection lifecycle: connect → trigger event → receive message.
+/// SSE connection lifecycle: connect â†’ trigger event â†’ receive message.
 ///
 /// Requires a running service stack.
 #[tokio::test]

--- a/crates/agileplus-mcp-intent/src/converter.rs
+++ b/crates/agileplus-mcp-intent/src/converter.rs
@@ -228,7 +228,7 @@ fn decompose_features(prompt: &str, _slug: &str, max: usize) -> Vec<FeatureDraft
     let lower = prompt.to_lowercase();
     let mut drafts: Vec<FeatureDraft> = vec![];
 
-    // Keyword → feature mapping
+    // Keyword â†’ feature mapping
     let mut checks: Vec<(&[&str], &str, &str, Vec<&str>)> = vec![
         (
             &["auth", "login", "sign in", "signin", "sso", "oauth"],
@@ -340,8 +340,7 @@ fn slugify(text: &str) -> String {
 
 fn extract_title(prompt: &str) -> String {
     let first = prompt.split('.').next().unwrap_or(prompt);
-    let first = first.split('
-').next().unwrap_or(first);
+    let first = first.split('\n').next().unwrap_or(first);
     let first = first.trim();
     if first.len() > 80 {
         format!("{}...", &first[..77])
@@ -352,8 +351,7 @@ fn extract_title(prompt: &str) -> String {
 
 fn title_from_prompt(prompt: &str) -> String {
     let first = prompt.split('.').next().unwrap_or(prompt);
-    let first = first.split('
-').next().unwrap_or(first);
+    let first = first.split('\n').next().unwrap_or(first);
     let first = first.trim();
     if first.len() > 60 {
         format!("{}...", &first[..57])

--- a/crates/agileplus-p2p/src/export.rs
+++ b/crates/agileplus-p2p/src/export.rs
@@ -1,10 +1,10 @@
-//! Git-backed state export — serialize SQLite state to deterministic files.
+//! Git-backed state export â€” serialize SQLite state to deterministic files.
 //!
 //! Writes to `.agileplus/sync/` with the layout:
-//!   events/{entity_type}/{id}.jsonl  — one JSON per line, ordered by sequence
-//!   snapshots/{entity_type}/{id}.json — latest snapshot, pretty-printed sorted keys
-//!   sync_state.json                  — SyncMapping entries and device sync vectors
-//!   device.json                      — local DeviceNode info
+//!   events/{entity_type}/{id}.jsonl  â€” one JSON per line, ordered by sequence
+//!   snapshots/{entity_type}/{id}.json â€” latest snapshot, pretty-printed sorted keys
+//!   sync_state.json                  â€” SyncMapping entries and device sync vectors
+//!   device.json                      â€” local DeviceNode info
 //!
 //! All JSON uses sorted keys, 2-space indent, UTF-8.
 //!
@@ -18,15 +18,15 @@ use std::time::Instant;
 use agileplus_domain::domain::event::Event;
 use agileplus_domain::domain::snapshot::Snapshot;
 use agileplus_domain::domain::sync_mapping::SyncMapping;
-use agileplus_events::store::EventStore;
 use agileplus_events::snapshot::SnapshotStore;
+use agileplus_events::store::EventStore;
 use serde_json::Value;
 use tracing::debug;
 
 use crate::device::{DeviceNode, DeviceStore};
 use crate::error::ConnectionError;
 
-// ── Error ─────────────────────────────────────────────────────────────────────
+// â”€â”€ Error â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 #[derive(Debug, thiserror::Error)]
 pub enum ExportError {
@@ -49,7 +49,7 @@ pub enum ExportError {
     SyncStore(String),
 }
 
-// ── Stats ─────────────────────────────────────────────────────────────────────
+// â”€â”€ Stats â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 /// Statistics returned after a successful export.
 #[derive(Debug, Default, Clone)]
@@ -60,7 +60,7 @@ pub struct ExportStats {
     pub duration_ms: u64,
 }
 
-// ── Entity registry helper ────────────────────────────────────────────────────
+// â”€â”€ Entity registry helper â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 /// Describes a single (entity_type, entity_id) pair to export.
 #[derive(Debug, Clone)]
@@ -69,7 +69,7 @@ pub struct EntityRef {
     pub entity_id: i64,
 }
 
-// ── Sorted-key serialization helper ──────────────────────────────────────────
+// â”€â”€ Sorted-key serialization helper â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 /// Recursively convert a `serde_json::Value` so that all Object variants use
 /// `BTreeMap` (which serializes with sorted keys).
@@ -95,16 +95,16 @@ fn to_sorted_line(v: Value) -> Result<String, serde_json::Error> {
     serde_json::to_string(&sorted)
 }
 
-// ── Core export function ──────────────────────────────────────────────────────
+// â”€â”€ Core export function â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 /// Export all state to `output_dir` in a deterministic, git-friendly format.
 ///
 /// Parameters:
-/// - `entities` — the set of (entity_type, entity_id) pairs to export.  In a
+/// - `entities` â€” the set of (entity_type, entity_id) pairs to export.  In a
 ///   production system this would be retrieved from a catalog; here callers
 ///   supply it to keep the function generic over `EventStore` implementations.
-/// - `sync_mappings` — pre-fetched list of `SyncMapping` rows.
-/// - `sync_vector_json` — the current device sync vector serialized to JSON.
+/// - `sync_mappings` â€” pre-fetched list of `SyncMapping` rows.
+/// - `sync_vector_json` â€” the current device sync vector serialized to JSON.
 pub async fn export_state<ES, SS>(
     event_store: &ES,
     snapshot_store: &SS,
@@ -121,7 +121,7 @@ where
     let started = Instant::now();
     let mut stats = ExportStats::default();
 
-    // ── 1. Device info ────────────────────────────────────────────────────────
+    // â”€â”€ 1. Device info â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
     let device_path = output_dir.join("device.json");
     if let Some(parent) = device_path.parent() {
         std::fs::create_dir_all(parent)?;
@@ -131,7 +131,7 @@ where
     std::fs::write(&device_path, to_sorted_pretty(device_json)?.as_bytes())?;
     debug!("Wrote device.json");
 
-    // ── 2. Events + snapshots ─────────────────────────────────────────────────
+    // â”€â”€ 2. Events + snapshots â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
     for entity in entities {
         // Events
         let events: Vec<Event> = event_store
@@ -140,9 +140,7 @@ where
             .map_err(|e| ExportError::EventStore(e.to_string()))?;
 
         if !events.is_empty() {
-            let events_dir = output_dir
-                .join("events")
-                .join(&entity.entity_type);
+            let events_dir = output_dir.join("events").join(&entity.entity_type);
             std::fs::create_dir_all(&events_dir)?;
             let file_path = events_dir.join(format!("{}.jsonl", entity.entity_id));
             let mut file = std::fs::File::create(&file_path)?;
@@ -168,9 +166,7 @@ where
             .map_err(|e| ExportError::SnapshotStore(e.to_string()))?;
 
         if let Some(snap) = snapshot {
-            let snap_dir = output_dir
-                .join("snapshots")
-                .join(&entity.entity_type);
+            let snap_dir = output_dir.join("snapshots").join(&entity.entity_type);
             std::fs::create_dir_all(&snap_dir)?;
             let file_path = snap_dir.join(format!("{}.json", entity.entity_id));
             let snap_json = serde_json::to_value(&snap)?;
@@ -183,30 +179,29 @@ where
         }
     }
 
-    // ── 3. sync_state.json ────────────────────────────────────────────────────
+    // â”€â”€ 3. sync_state.json â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
     let sync_state = serde_json::json!({
         "sync_mappings": sync_mappings,
         "sync_vector": sync_vector_json,
     });
     let sync_state_path = output_dir.join("sync_state.json");
-    std::fs::write(
-        &sync_state_path,
-        to_sorted_pretty(sync_state)?.as_bytes(),
-    )?;
+    std::fs::write(&sync_state_path, to_sorted_pretty(sync_state)?.as_bytes())?;
     stats.sync_mappings_exported = sync_mappings.len();
-    debug!("Wrote sync_state.json with {} mappings", sync_mappings.len());
+    debug!(
+        "Wrote sync_state.json with {} mappings",
+        sync_mappings.len()
+    );
 
     stats.duration_ms = started.elapsed().as_millis() as u64;
     Ok(stats)
 }
 
-// ── Tests ─────────────────────────────────────────────────────────────────────
+// â”€â”€ Tests â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::HashMap;
-    use std::sync::{Arc, Mutex};
+    use std::sync::Mutex;
 
     use agileplus_domain::domain::event::Event;
     use agileplus_domain::domain::snapshot::Snapshot;
@@ -218,7 +213,7 @@ mod tests {
 
     use crate::device::InMemoryDeviceStore;
 
-    // ── Minimal in-memory EventStore ──────────────────────────────────────────
+    // â”€â”€ Minimal in-memory EventStore â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     #[derive(Default)]
     struct MemEventStore {
@@ -295,7 +290,7 @@ mod tests {
         }
     }
 
-    // ── Minimal in-memory SnapshotStore ───────────────────────────────────────
+    // â”€â”€ Minimal in-memory SnapshotStore â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     #[derive(Default)]
     struct MemSnapshotStore {
@@ -341,7 +336,13 @@ mod tests {
         let ds = InMemoryDeviceStore::default();
 
         // Seed one event
-        let mut ev = Event::new("Feature", 1, "created", serde_json::json!({"title": "T1"}), "test");
+        let mut ev = Event::new(
+            "Feature",
+            1,
+            "created",
+            serde_json::json!({"title": "T1"}),
+            "test",
+        );
         ev.sequence = 1;
         es.append(&ev).await.unwrap();
 
@@ -349,8 +350,20 @@ mod tests {
         let snap = Snapshot::new("Feature", 1, serde_json::json!({"title": "T1"}), 1);
         ss.save(&snap).await.unwrap();
 
-        let mappings = vec![SyncMapping::new("Feature", 1, "plane-001", "hash-aaa")];
-        let entities = vec![EntityRef { entity_type: "Feature".into(), entity_id: 1 }];
+        let mappings = vec![SyncMapping {
+            id: 0,
+            entity_type: "Feature".to_string(),
+            entity_id: 1,
+            plane_issue_id: "plane-001".to_string(),
+            content_hash: "hash-aaa".to_string(),
+            last_synced_at: chrono::Utc::now(),
+            sync_direction: agileplus_domain::domain::sync_mapping::SyncDirection::Bidirectional,
+            conflict_count: 0,
+        }];
+        let entities = vec![EntityRef {
+            entity_type: "Feature".into(),
+            entity_id: 1,
+        }];
 
         let stats = export_state(
             &es,

--- a/crates/agileplus-p2p/src/git_merge/jsonl.rs
+++ b/crates/agileplus-p2p/src/git_merge/jsonl.rs
@@ -58,7 +58,7 @@ pub(crate) fn resolve_jsonl_conflict(path: &Path) -> Result<bool, MergeError> {
     }
 
     info!(
-        "Resolved JSONL conflict in {} — {} unique events",
+        "Resolved JSONL conflict in {} â€” {} unique events",
         path.display(),
         events.len()
     );

--- a/crates/agileplus-p2p/src/git_merge/tests.rs
+++ b/crates/agileplus-p2p/src/git_merge/tests.rs
@@ -15,9 +15,8 @@ fn make_event_line(seq: i64) -> String {
     serde_json::to_string(&e).unwrap()
 }
 
-#[allow(clippy::uninlined_format_args)]
 fn conflict_block(ours: &str, theirs: &str) -> String {
-    format!("<<<<<<< HEAD\n{ours}\n=======\n{theirs}\n>>>>>>> branch\n",)
+    format!("<<<<<<< HEAD\n{ours}\n=======\n{theirs}\n>>>>>>> branch\n")
 }
 
 #[test]

--- a/crates/agileplus-p2p/src/import.rs
+++ b/crates/agileplus-p2p/src/import.rs
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-//! Git-backed state import — read deterministic files back into the event store.
+//! Git-backed state import â€” read deterministic files back into the event store.
 //!
 //! Reads from the same layout written by `export.rs`:
-//!   events/{entity_type}/{id}.jsonl  — JSONL, one event per line
-//!   snapshots/{entity_type}/{id}.json — latest snapshot (pretty JSON)
-//!   sync_state.json                  — SyncMapping entries and device sync vectors
+//!   events/{entity_type}/{id}.jsonl  â€” JSONL, one event per line
+//!   snapshots/{entity_type}/{id}.json â€” latest snapshot (pretty JSON)
+//!   sync_state.json                  â€” SyncMapping entries and device sync vectors
 //!
 //! Skips duplicate events by hash comparison.  All events are collected before
 //! any are applied (transaction-like semantics).
@@ -21,7 +21,7 @@ use agileplus_events::snapshot::SnapshotStore;
 use agileplus_events::store::EventStore;
 use tracing::{debug, warn};
 
-// ── Error ─────────────────────────────────────────────────────────────────────
+// â”€â”€ Error â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 #[derive(Debug, thiserror::Error)]
 pub enum ImportError {
@@ -41,7 +41,7 @@ pub enum ImportError {
     SnapshotStore(String),
 }
 
-// ── Stats ─────────────────────────────────────────────────────────────────────
+// â”€â”€ Stats â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 /// Statistics returned after a successful import.
 #[derive(Debug, Default, Clone)]
@@ -52,7 +52,7 @@ pub struct ImportStats {
     pub duration_ms: u64,
 }
 
-// ── Helpers ───────────────────────────────────────────────────────────────────
+// â”€â”€ Helpers â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 /// Read all `.jsonl` files recursively under `events_dir` and parse them into
 /// `Event` values.  Returns them grouped as a flat Vec sorted by sequence.
@@ -167,7 +167,7 @@ fn read_sync_mappings(sync_state_path: &Path) -> Result<Vec<SyncMapping>, Import
     Ok(mappings)
 }
 
-// ── Core import function ──────────────────────────────────────────────────────
+// â”€â”€ Core import function â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 /// Import state from `input_dir` into the provided stores.
 ///
@@ -185,7 +185,7 @@ where
     let started = Instant::now();
     let mut stats = ImportStats::default();
 
-    // ── Collect phase ─────────────────────────────────────────────────────────
+    // â”€â”€ Collect phase â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
     let all_events = read_events_from_dir(&input_dir.join("events"))?;
     let all_snapshots = read_snapshots_from_dir(&input_dir.join("snapshots"))?;
     let all_mappings = read_sync_mappings(&input_dir.join("sync_state.json"))?;
@@ -198,7 +198,7 @@ where
         input_dir.display()
     );
 
-    // ── Apply events (skip duplicates by hash) ────────────────────────────────
+    // â”€â”€ Apply events (skip duplicates by hash) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
     for event in &all_events {
         // Check whether this sequence already exists for the entity stream.
         let latest_seq = event_store
@@ -233,7 +233,7 @@ where
         stats.events_imported += 1;
     }
 
-    // ── Apply snapshots (latest-wins by event_sequence) ───────────────────────
+    // â”€â”€ Apply snapshots (latest-wins by event_sequence) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
     for snapshot in &all_snapshots {
         // Load existing snapshot for this entity to compare sequences.
         let existing = snapshot_store
@@ -268,7 +268,7 @@ where
     Ok(stats)
 }
 
-// ── Tests ─────────────────────────────────────────────────────────────────────
+// â”€â”€ Tests â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 #[cfg(test)]
 mod tests {
@@ -283,7 +283,7 @@ mod tests {
     use async_trait::async_trait;
     use chrono::Utc;
 
-    // ── Shared in-memory stores (mirrors export tests) ────────────────────────
+    // â”€â”€ Shared in-memory stores (mirrors export tests) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     #[derive(Default)]
     struct MemEventStore {
@@ -398,7 +398,7 @@ mod tests {
         }
     }
 
-    // ── Helpers ───────────────────────────────────────────────────────────────
+    // â”€â”€ Helpers â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     fn make_event(entity_type: &str, entity_id: i64, sequence: i64) -> Event {
         let mut e = Event::new(
@@ -412,7 +412,7 @@ mod tests {
         e
     }
 
-    // ── Tests ─────────────────────────────────────────────────────────────────
+    // â”€â”€ Tests â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     #[tokio::test]
     async fn import_new_events() {

--- a/crates/agileplus-p2p/src/import/tests.rs
+++ b/crates/agileplus-p2p/src/import/tests.rs
@@ -209,8 +209,26 @@ async fn import_sync_mappings_counted() {
     let dir = tmp.path();
 
     let mappings = vec![
-        agileplus_domain::domain::sync_mapping::SyncMapping::new("Feature", 1, "p1", "h1"),
-        agileplus_domain::domain::sync_mapping::SyncMapping::new("Feature", 2, "p2", "h2"),
+        agileplus_domain::domain::sync_mapping::SyncMapping {
+            id: 0,
+            entity_type: "Feature".to_string(),
+            entity_id: 1,
+            plane_issue_id: "p1".to_string(),
+            content_hash: "h1".to_string(),
+            last_synced_at: chrono::Utc::now(),
+            sync_direction: agileplus_domain::domain::sync_mapping::SyncDirection::Bidirectional,
+            conflict_count: 0,
+        },
+        agileplus_domain::domain::sync_mapping::SyncMapping {
+            id: 0,
+            entity_type: "Feature".to_string(),
+            entity_id: 2,
+            plane_issue_id: "p2".to_string(),
+            content_hash: "h2".to_string(),
+            last_synced_at: chrono::Utc::now(),
+            sync_direction: agileplus_domain::domain::sync_mapping::SyncDirection::Bidirectional,
+            conflict_count: 0,
+        },
     ];
     let sync_state = serde_json::json!({ "sync_mappings": mappings, "sync_vector": {} });
     std::fs::write(

--- a/crates/agileplus-plane/src/sync.rs
+++ b/crates/agileplus-plane/src/sync.rs
@@ -18,7 +18,7 @@ pub struct SyncState {
     pub plane_issue_id: Option<String>,
     pub last_synced_at: Option<DateTime<Utc>>,
     pub content_hash: Option<String>,
-    /// Maps WP ID → Plane sub-issue ID
+    /// Maps WP ID â†’ Plane sub-issue ID
     pub wp_mappings: HashMap<String, String>,
 }
 
@@ -64,11 +64,11 @@ impl PlaneSyncAdapter {
         let content_hash = hash_content(&format!("{title}\n{description}"));
 
         // Check if already synced and unchanged
-        if let Some(ref existing_hash) = state.content_hash
-            && *existing_hash == content_hash
-        {
-            tracing::debug!("Feature {} unchanged, skipping sync", state.feature_slug);
-            return Ok(SyncOutcome::Skipped);
+        if let Some(ref existing_hash) = state.content_hash {
+            if *existing_hash == content_hash {
+                tracing::debug!("Feature {} unchanged, skipping sync", state.feature_slug);
+                return Ok(SyncOutcome::Skipped);
+            }
         }
 
         let issue = PlaneIssue {
@@ -83,19 +83,18 @@ impl PlaneSyncAdapter {
 
         let outcome = if let Some(ref issue_id) = state.plane_issue_id {
             // Check for conflicts before update
-            if let Ok(remote) = self.client.get_issue(issue_id).await
-                && let Some(ref remote_desc) = remote.description_html
-            {
-                let remote_hash = hash_content(&format!("{}\n{}", remote.name, remote_desc));
-                if let Some(ref our_hash) = state.content_hash
-                    && remote_hash != *our_hash
-                    && content_hash != remote_hash
-                {
-                    tracing::warn!(
-                        "Conflict detected on Plane issue {}: remote was modified",
-                        issue_id
-                    );
-                    return Ok(SyncOutcome::Conflict(issue_id.clone()));
+            if let Ok(remote) = self.client.get_issue(issue_id).await {
+                if let Some(ref remote_desc) = remote.description_html {
+                    let remote_hash = hash_content(&format!("{}\n{}", remote.name, remote_desc));
+                    if let Some(ref our_hash) = state.content_hash {
+                        if remote_hash != *our_hash && content_hash != remote_hash {
+                            tracing::warn!(
+                                "Conflict detected on Plane issue {}: remote was modified",
+                                issue_id
+                            );
+                            return Ok(SyncOutcome::Conflict(issue_id.clone()));
+                        }
+                    }
                 }
             }
 

--- a/crates/agileplus-refinery/src/lib.rs
+++ b/crates/agileplus-refinery/src/lib.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-//! `agileplus-refinery` — post-processing pipeline: squash, lint, sign, tag.
+//! `agileplus-refinery` â€” post-processing pipeline: squash, lint, sign, tag.
 //!
 //! Audit rec #4.
 
@@ -163,8 +163,7 @@ mod tests {
             .output()
             .expect("git config name");
         // Initial commit
-        std::fs::write(dir.join("README.md"), "# init
-").unwrap();
+        std::fs::write(dir.join("README.md"), "# init\n").unwrap();
         let _ = Command::new("git")
             .args(["add", "."])
             .current_dir(dir)
@@ -205,10 +204,8 @@ mod tests {
         let dir = tmp.path();
         init_repo(dir);
         create_branch(dir, "feature");
-        commit_file(dir, "a.txt", "hello
-", "feature commit 1");
-        commit_file(dir, "b.txt", "world
-", "feature commit 2");
+        commit_file(dir, "a.txt", "hello\n", "feature commit 1");
+        commit_file(dir, "b.txt", "world\n", "feature commit 2");
 
         // Back to main so we can merge feature into it.
         let _ = Command::new("git")
@@ -245,8 +242,7 @@ mod tests {
         let stdout = String::from_utf8_lossy(&msg.stdout);
         assert!(
             stdout.contains("[signed]"),
-            "message should contain [signed]: {}",
-            stdout
+            "message should contain [signed]: {stdout}",
         );
     }
 
@@ -256,8 +252,7 @@ mod tests {
         let dir = tmp.path();
         init_repo(dir);
         create_branch(dir, "feature");
-        commit_file(dir, "a.txt", "hello
-", "feature commit");
+        commit_file(dir, "a.txt", "hello\n", "feature commit");
         let _ = Command::new("git")
             .args(["checkout", "main"])
             .current_dir(dir)
@@ -283,20 +278,17 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let dir = tmp.path();
         init_repo(dir);
-        commit_file(dir, "shared.txt", "base
-", "base commit");
+        commit_file(dir, "shared.txt", "base\n", "base commit");
 
         create_branch(dir, "feature");
-        commit_file(dir, "shared.txt", "feature
-", "feature change");
+        commit_file(dir, "shared.txt", "feature\n", "feature change");
 
         let _ = Command::new("git")
             .args(["checkout", "main"])
             .current_dir(dir)
             .output()
             .expect("checkout main");
-        commit_file(dir, "shared.txt", "main
-", "main change");
+        commit_file(dir, "shared.txt", "main\n", "main change");
 
         let config = RefineryConfig {
             squash: true,

--- a/crates/agileplus-refinery/src/sign.rs
+++ b/crates/agileplus-refinery/src/sign.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-//! Commit signing — GPG, SSH, or mock.
+//! Commit signing â€” GPG, SSH, or mock.
 
 use std::process::{Command, Stdio};
 
@@ -13,7 +13,7 @@ pub trait Signer: Send + Sync {
     async fn sign(&self, repo_root: &std::path::Path, commit_sha: &str) -> Result<String>;
 }
 
-/// GPG signer — uses `gpgme` when the `gpg` feature is enabled,
+/// GPG signer â€” uses `gpgme` when the `gpg` feature is enabled,
 /// otherwise shells out to the `gpg` binary.
 #[derive(Debug, Clone)]
 pub struct GpgSigner {
@@ -31,8 +31,29 @@ impl Signer for GpgSigner {
             // spawn_blocking completes (gpgme::Context is fully gone by then).
             let commit_text = get_commit_text(repo_root, commit_sha).await?;
 
-            // Append the signature to the commit object.
-            let signature_b64 = base64::encode(&signature);
+            let key_id = self.key_id.clone();
+            let signature_b64 = tokio::task::spawn_blocking(move || -> anyhow::Result<String> {
+                use gpgme::{Context, Protocol};
+
+                let mut ctx = Context::from_protocol(Protocol::OpenPgp)
+                    .with_context(|| "failed to create GPG context")?;
+                let key = ctx
+                    .get_key(&key_id)
+                    .with_context(|| format!("GPG key not found: {key_id}"))?;
+                ctx.add_signer(&key)
+                    .with_context(|| "failed to add signer to GPG context")?;
+
+                let mut signature = Vec::new();
+                ctx.sign_detached(commit_text.into_bytes(), &mut signature)
+                    .with_context(|| "GPG sign failed")?;
+
+                use base64::Engine as _;
+                Ok(base64::engine::general_purpose::STANDARD.encode(&signature))
+            })
+            .await
+            .context("spawn_blocking panicked")??;
+
+            // gpgme::Context is gone; safe to .await again.
             let new_sha =
                 amend_commit_with_gpg_signature(repo_root, commit_sha, &signature_b64).await?;
             return Ok(new_sha);
@@ -81,7 +102,7 @@ impl Signer for GpgSigner {
     }
 }
 
-/// SSH signer — uses `ssh-key` crate when the `ssh-sign` feature is enabled,
+/// SSH signer â€” uses `ssh-key` crate when the `ssh-sign` feature is enabled,
 /// otherwise shells out to `ssh-keygen -Y sign`.
 #[derive(Debug, Clone)]
 pub struct SshSigner {
@@ -111,7 +132,7 @@ impl Signer for SshSigner {
                 .with_context(|| "SSH sig to PEM failed")?;
 
             let new_sha =
-                amend_commit_with_ssh_signature(repo_root, commit_sha, &signature_b64).await?;
+                amend_commit_with_ssh_signature(repo_root, commit_sha, &signature_pem).await?;
             return Ok(new_sha);
         }
 
@@ -158,7 +179,7 @@ impl Signer for SshSigner {
     }
 }
 
-/// Mock signer for tests — appends `[signed]` to the commit message.
+/// Mock signer for tests â€” appends `[signed]` to the commit message.
 #[derive(Debug, Clone, Default)]
 pub struct MockSigner;
 
@@ -223,14 +244,18 @@ async fn amend_commit_message(repo_root: &std::path::Path, message: &str) -> Res
     let repo_root = repo_root.to_path_buf();
     let message = message.to_string();
     let root2 = repo_root.clone();
-    let output = tokio::task::spawn_blocking(move || {
-        Command::new("git")
-            .args(["commit", "--amend", "-m", &message])
-            .current_dir(&repo_root)
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .output()
-            .with_context(|| "git commit --amend")
+    let output = tokio::task::spawn_blocking({
+        let message = message.clone();
+        let repo_root = repo_root.clone();
+        move || {
+            Command::new("git")
+                .args(["commit", "--amend", "-m", &message])
+                .current_dir(&repo_root)
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .output()
+                .with_context(|| "git commit --amend")
+        }
     })
     .await
     .context("spawn_blocking failed")??;
@@ -268,24 +293,17 @@ async fn amend_commit_with_gpg_signature(
     for line in &lines {
         if line.is_empty() && !found_gpgsig {
             new_commit.push_str("gpgsig ");
-            new_commit.push_str(&signature.replace('
-', "
- "));
-            new_commit.push('
-');
+            new_commit.push_str(&signature.replace('\n', "\n "));
+            new_commit.push('\n');
             found_gpgsig = true;
         }
         new_commit.push_str(line);
-        new_commit.push('
-');
+        new_commit.push('\n');
     }
     if !found_gpgsig {
         new_commit.push_str("gpgsig ");
-        new_commit.push_str(&signature.replace('
-', "
- "));
-        new_commit.push('
-');
+        new_commit.push_str(&signature.replace('\n', "\n "));
+        new_commit.push('\n');
     }
 
     write_commit_object(repo_root, &new_commit).await
@@ -306,6 +324,7 @@ async fn write_commit_object(repo_root: &std::path::Path, content: &str) -> Resu
     let repo_root_for_reset = repo_root.clone();
     let content = content.to_string();
     let output = tokio::task::spawn_blocking({
+        let content = content.clone();
         let repo_root = repo_root.clone();
         move || {
             let mut child = Command::new("git")
@@ -327,9 +346,6 @@ async fn write_commit_object(repo_root: &std::path::Path, content: &str) -> Resu
                 .wait_with_output()
                 .with_context(|| "git hash-object failed")
         }
-        child
-            .wait_with_output()
-            .with_context(|| "git hash-object failed")
     })
     .await
     .context("spawn_blocking failed")??;
@@ -341,10 +357,10 @@ async fn write_commit_object(repo_root: &std::path::Path, content: &str) -> Resu
     let sha = String::from_utf8_lossy(&output.stdout).trim().to_string();
 
     // Reset HEAD to the new commit.
-    let sha2 = sha.clone();
+    let sha_for_reset = sha.clone();
     let _ = tokio::task::spawn_blocking(move || {
         Command::new("git")
-            .args(["reset", "--soft", &sha2])
+            .args(["reset", "--soft", &sha_for_reset])
             .current_dir(&repo_root_for_reset)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())

--- a/crates/agileplus-sqlite/src/rebuild.rs
+++ b/crates/agileplus-sqlite/src/rebuild.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-//! rebuild_from_git — reconstruct SQLite state from git artifacts (FR-017).
+//! rebuild_from_git â€” reconstruct SQLite state from git artifacts (FR-017).
 
 use agileplus_domain::{
     domain::{
@@ -22,7 +22,7 @@ pub struct RebuildReport {
     pub evidence_restored: usize,
 }
 
-/// Git meta.json schema (minimal — matches what spec-kitty would write).
+/// Git meta.json schema (minimal â€” matches what spec-kitty would write).
 #[derive(Debug, serde::Deserialize)]
 struct MetaJson {
     slug: String,
@@ -288,7 +288,6 @@ mod tests {
         ports::{
             vcs::{BranchInfo, ConflictInfo, FeatureArtifacts, MergeResult, WorktreeInfo},
             StoragePort, VcsPort,
-            vcs::{BranchInfo, ConflictInfo, FeatureArtifacts, MergeResult, WorktreeInfo},
         },
     };
 

--- a/crates/agileplus-sqlite/src/repository/features.rs
+++ b/crates/agileplus-sqlite/src/repository/features.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-//! Feature repository — CRUD operations for the `features` table.
+//! Feature repository â€” CRUD operations for the `features` table.
 
 use rusqlite::{params, Connection, Row};
 
@@ -26,7 +26,7 @@ fn state_str(s: FeatureState) -> &'static str {
 }
 
 fn labels_to_json(labels: &[String]) -> String {
-    serde_json::to_string(labels).unwrap_or_else(|_| "[]".to_string())
+    serde_json::to_string(labels).unwrap_or_else(|_| "[]".to_owned())
 }
 
 fn labels_from_json(s: &str) -> Vec<String> {
@@ -45,7 +45,7 @@ fn row_to_feature(row: &Row<'_>) -> rusqlite::Result<Feature> {
     // module_id column added by migration 015 -- may be NULL.
     let module_id: Option<i64> = row.get(8).unwrap_or(None);
     // labels column added by migration 026 -- defaults to '[]'.
-    let labels_json: String = row.get(9).unwrap_or_else(|_| "[]".to_string());
+    let labels_json: String = row.get(9).unwrap_or_else(|_| "[]".to_owned());
 
     let state = state_str.parse::<FeatureState>().map_err(|e| {
         rusqlite::Error::FromSqlConversionFailure(

--- a/crates/agileplus-sqlite/src/seed/catalog.rs
+++ b/crates/agileplus-sqlite/src/seed/catalog.rs
@@ -2,7 +2,7 @@
 //! Catalog parser: extracts `(fr_id, title, status)` triples from an FR/NFR markdown file.
 //!
 //! Format recognised (as used in all four catalogs):
-//!   ### FR-XXX-NNN — Title text
+//!   ### FR-XXX-NNN â€” Title text
 //!   ...
 //!   | **Status** | SHIPPED |   (optional; AgilePlus / Authvault catalogs)
 //!   | **Status** | PLANNED |
@@ -26,7 +26,7 @@ pub enum CatalogStatus {
 pub struct CatalogEntry {
     /// The canonical requirement ID, e.g. "FR-AGP-001".
     pub id: String,
-    /// Human-readable title (everything after the " — " separator).
+    /// Human-readable title (everything after the " â€” " separator).
     pub title: String,
     /// Derived status.
     pub status: CatalogStatus,
@@ -46,10 +46,8 @@ pub fn parse_catalog(markdown: &str) -> Vec<CatalogEntry> {
     for line in markdown.lines() {
         let trimmed = line.trim();
 
-        // Match heading lines: `### FR-XXX-NNN — Title`
-        // Also handle `### FR-XXX-NNN
-
-**Title:** ...` (Authvault style via next line)
+        // Match heading lines: `### FR-XXX-NNN â€” Title`
+        // Also handle `### FR-XXX-NNN\n\n**Title:** ...` (Authvault style via next line)
         if let Some(id_and_rest) = extract_heading_id(trimmed) {
             // Flush previous entry
             if let (Some(id), Some(title)) = (current_id.take(), current_title.take()) {
@@ -68,7 +66,7 @@ pub fn parse_catalog(markdown: &str) -> Vec<CatalogEntry> {
             continue;
         }
 
-        // Inside an entry — look for **Title:** line (Authvault style)
+        // Inside an entry â€” look for **Title:** line (Authvault style)
         if current_id.is_some() && current_title.as_deref().map(str::is_empty).unwrap_or(false) {
             if let Some(t) = extract_title_field(trimmed) {
                 current_title = Some(t);
@@ -100,16 +98,15 @@ pub fn parse_catalog(markdown: &str) -> Vec<CatalogEntry> {
 }
 
 /// Extract `(id, title)` from a heading line like:
-///   `### FR-AGP-001 — Rich domain aggregates with enforced invariants`
-///   `### FR-AGP-001
-` (title-only variant; title = id for now, overridden later)
+///   `### FR-AGP-001 â€” Rich domain aggregates with enforced invariants`
+///   `### FR-AGP-001\n` (title-only variant; title = id for now, overridden later)
 fn extract_heading_id(line: &str) -> Option<(String, String)> {
     // Must start with one or more '#'
     let stripped = line.trim_start_matches('#').trim();
     // Must look like an ID: starts with two uppercase words separated by '-'
     // Pattern: WORD-WORD-NNN (e.g. FR-AGP-001, NFR-TRC-002, FR-VOXEL-003)
     let (id_part, title_part) = if let Some(pos) = stripped.find(" \u{2014} ") {
-        // " — " separator (em-dash)
+        // " â€” " separator (em-dash)
         (
             &stripped[..pos],
             stripped[pos + " \u{2014} ".len()..].trim(),
@@ -118,7 +115,7 @@ fn extract_heading_id(line: &str) -> Option<(String, String)> {
         // Plain hyphen separator fallback
         (&stripped[..pos], stripped[pos + 3..].trim())
     } else {
-        // No separator — the whole thing is the id; title will be filled later
+        // No separator â€” the whole thing is the id; title will be filled later
         (stripped, "")
     };
 
@@ -162,7 +159,7 @@ fn extract_title_field(line: &str) -> Option<String> {
 /// Extract status from lines like:
 ///   `| **Status** | SHIPPED |`
 ///   `| **Status** | PLANNED |`
-///   `| **Status** | PARTIAL — ... |`
+///   `| **Status** | PARTIAL â€” ... |`
 fn extract_status_cell(line: &str) -> Option<CatalogStatus> {
     if !line.contains("**Status**") && !line.to_lowercase().contains("status") {
         return None;
@@ -213,7 +210,7 @@ mod tests {
 
 ## Functional Requirements
 
-### FR-TEST-001 — Rich domain model
+### FR-TEST-001 â€” Rich domain model
 
 | Field | Value |
 |---|---|
@@ -223,7 +220,7 @@ mod tests {
 
 ---
 
-### FR-TEST-002 — Planned feature
+### FR-TEST-002 â€” Planned feature
 
 | Field | Value |
 |---|---|
@@ -233,7 +230,7 @@ mod tests {
 
 ---
 
-### NFR-TEST-001 — Performance
+### NFR-TEST-001 â€” Performance
 
 No status field here; should default to Shipped.
 
@@ -281,11 +278,11 @@ No status field here; should default to Shipped.
     fn gap_section_id_treated_as_planned() {
         let entries = parse_catalog(SAMPLE_CATALOG);
         let e = entries.iter().find(|e| e.id == "FR-TEST-003");
-        // FR-TEST-003 only appears in gaps table, not as a heading — so it may
+        // FR-TEST-003 only appears in gaps table, not as a heading â€” so it may
         // not be parsed as a full entry but its ID is collected as planned.
         // The planned_ids collection is used to override status for entries
         // that DO have headings.
-        // NFR-TEST-001 has no status cell → should default to Shipped (not in gap section).
+        // NFR-TEST-001 has no status cell â†’ should default to Shipped (not in gap section).
         let nfr = entries.iter().find(|e| e.id == "NFR-TEST-001").unwrap();
         assert_eq!(nfr.status, CatalogStatus::Shipped);
         // FR-TEST-003 won't appear because it has no heading

--- a/crates/agileplus-subcmds/src/dashboard.rs
+++ b/crates/agileplus-subcmds/src/dashboard.rs
@@ -139,11 +139,11 @@ pub fn run_dashboard_open(port: u16) -> Result<()> {
 
     match open_browser(&url) {
         Ok(()) => {
-            println!("✓ Dashboard opened");
+            println!("âœ“ Dashboard opened");
             Ok(())
         }
         Err(_) => {
-            eprintln!("✗ Could not open browser automatically.");
+            eprintln!("âœ— Could not open browser automatically.");
             eprintln!("Manual URL: {url}");
             Ok(()) // Not a fatal error; user can copy the URL.
         }
@@ -214,7 +214,7 @@ mod tests {
 
     #[test]
     fn test_run_dashboard_open_fails_when_api_not_running() {
-        // Port 19998 — API not running, so we expect an Err.
+        // Port 19998 â€” API not running, so we expect an Err.
         let result = run_dashboard_open(19998);
         assert!(result.is_err());
     }

--- a/crates/agileplus-subcmds/src/device.rs
+++ b/crates/agileplus-subcmds/src/device.rs
@@ -1,9 +1,9 @@
 //! Device management CLI commands for AgilePlus.
 //!
 //! Provides three subcommands:
-//!   - `agileplus device discover` — enumerate peers on the Tailscale network
-//!   - `agileplus device sync`     — replicate events with one or more peers
-//!   - `agileplus device status`   — show local device identity and sync state
+//!   - `agileplus device discover` â€” enumerate peers on the Tailscale network
+//!   - `agileplus device sync`     â€” replicate events with one or more peers
+//!   - `agileplus device status`   â€” show local device identity and sync state
 //!
 //! Traceability: WP18 / T104, T105, T106
 
@@ -18,7 +18,7 @@ use agileplus_p2p::vector_clock::SyncVector;
 use clap::{Args, Subcommand};
 use serde::Serialize;
 
-// ── Top-level arg struct ──────────────────────────────────────────────────────
+// â”€â”€ Top-level arg struct â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 /// Arguments for the `device` command group.
 #[derive(Debug, Args)]
@@ -38,7 +38,7 @@ pub enum DeviceSubcommand {
     Status(StatusArgs),
 }
 
-// ── T104: discover ────────────────────────────────────────────────────────────
+// â”€â”€ T104: discover â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 /// Arguments for `agileplus device discover`.
 #[derive(Debug, Args)]
@@ -159,14 +159,14 @@ pub async fn run_discover(args: &DiscoverArgs) -> anyhow::Result<()> {
     Ok(())
 }
 
-// ── T105: sync ────────────────────────────────────────────────────────────────
+// â”€â”€ T105: sync â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 /// Conflict-resolution strategy for the sync operation.
 #[derive(Debug, Clone, clap::ValueEnum)]
 pub enum SyncStrategy {
     /// Last-write wins (default).
     LastWriteWins,
-    /// Manual conflict resolution — flag conflicts for review.
+    /// Manual conflict resolution â€” flag conflicts for review.
     Manual,
 }
 
@@ -284,7 +284,7 @@ pub async fn run_sync(args: &SyncArgs) -> anyhow::Result<()> {
 
     for peer in &target_peers {
         if args.verbose {
-            println!("Syncing with {} ({}) …", peer.device_id, peer.tailscale_ip);
+            println!("Syncing with {} ({}) â€¦", peer.device_id, peer.tailscale_ip);
         }
         let t0 = Instant::now();
 
@@ -339,7 +339,7 @@ pub async fn run_sync(args: &SyncArgs) -> anyhow::Result<()> {
     for r in &reports {
         let status_str = if r.success { "OK" } else { "FAILED" };
         println!(
-            "  {} {} — sent: {}, received: {}, conflicts: {}, {}ms [{}]",
+            "  {} {} â€” sent: {}, received: {}, conflicts: {}, {}ms [{}]",
             r.device_id,
             r.hostname,
             r.events_sent,
@@ -361,7 +361,7 @@ pub async fn run_sync(args: &SyncArgs) -> anyhow::Result<()> {
     Ok(())
 }
 
-// ── T106: status ──────────────────────────────────────────────────────────────
+// â”€â”€ T106: status â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 /// Arguments for `agileplus device status`.
 #[derive(Debug, Args)]
@@ -420,7 +420,7 @@ pub async fn run_status(args: &StatusArgs) -> anyhow::Result<()> {
         .unwrap_or_else(|_| "unknown".to_string());
 
     let local = LocalDeviceInfo {
-        device_id: format!("local-{}", &hostname),
+        device_id: format!("local-{hostname}"),
         hostname: hostname.clone(),
         tailscale_ip: String::from("(unavailable without Tailscale)"),
     };
@@ -485,11 +485,11 @@ pub async fn run_status(args: &StatusArgs) -> anyhow::Result<()> {
         // Sync vector section.
         println!("Sync Vector ({} entities)", report.sync_vector.len());
         if report.sync_vector.is_empty() {
-            println!("  (empty — no events synced yet)");
+            println!("  (empty â€” no events synced yet)");
         } else {
             for v in &report.sync_vector {
                 println!(
-                    "  {}/{} → seq {}",
+                    "  {}/{} â†’ seq {}",
                     v.entity_type, v.entity_id, v.last_sequence
                 );
             }
@@ -503,11 +503,11 @@ pub async fn run_status(args: &StatusArgs) -> anyhow::Result<()> {
         // Known peers section.
         println!("Known Peers ({} total)", report.known_peers.len());
         if report.known_peers.is_empty() {
-            println!("  (none — run `agileplus device discover` to find peers)");
+            println!("  (none â€” run `agileplus device discover` to find peers)");
         } else {
             for p in &report.known_peers {
                 println!(
-                    "  {} {} [{}] — last sync: {}",
+                    "  {} {} [{}] â€” last sync: {}",
                     p.device_id, p.hostname, p.status, p.last_sync
                 );
             }
@@ -517,7 +517,7 @@ pub async fn run_status(args: &StatusArgs) -> anyhow::Result<()> {
     Ok(())
 }
 
-// ── Dispatch ──────────────────────────────────────────────────────────────────
+// â”€â”€ Dispatch â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 /// Dispatch a `DeviceArgs` to the appropriate handler.
 #[cfg(unix)]
@@ -535,13 +535,13 @@ pub async fn run(_args: &DeviceArgs) -> anyhow::Result<()> {
     anyhow::bail!("Device commands require Unix (Tailscale UNIX socket)")
 }
 
-// ── Tests ─────────────────────────────────────────────────────────────────────
+// â”€â”€ Tests â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    // ── DiscoverArgs defaults ────────────────────────────────────────────────
+    // â”€â”€ DiscoverArgs defaults â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     #[test]
     fn discover_args_defaults() {
@@ -555,7 +555,7 @@ mod tests {
         assert!(!args.json);
     }
 
-    // ── PeerRow conversion ───────────────────────────────────────────────────
+    // â”€â”€ PeerRow conversion â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     #[test]
     fn peer_row_from_online_peer() {
@@ -594,7 +594,7 @@ mod tests {
         assert_eq!(row.status, "unknown");
     }
 
-    // ── PeerRow serialisation ────────────────────────────────────────────────
+    // â”€â”€ PeerRow serialisation â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     #[test]
     fn peer_row_serialises_to_json() {
@@ -610,7 +610,7 @@ mod tests {
         assert!(json.contains("online"));
     }
 
-    // ── SyncArgs validation helpers ──────────────────────────────────────────
+    // â”€â”€ SyncArgs validation helpers â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     #[test]
     fn sync_strategy_display() {
@@ -618,7 +618,7 @@ mod tests {
         assert_eq!(SyncStrategy::Manual.to_string(), "manual");
     }
 
-    // ── StatusArgs flags ─────────────────────────────────────────────────────
+    // â”€â”€ StatusArgs flags â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     #[test]
     fn status_args_default_shows_all() {
@@ -632,7 +632,7 @@ mod tests {
         assert!(!args.vectors_only);
     }
 
-    // ── DeviceStatusReport serialisation ─────────────────────────────────────
+    // â”€â”€ DeviceStatusReport serialisation â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     #[test]
     fn device_status_report_serialises() {
@@ -663,7 +663,7 @@ mod tests {
         assert!(json.contains("3"));
     }
 
-    // ── PeerSyncReport serialisation ─────────────────────────────────────────
+    // â”€â”€ PeerSyncReport serialisation â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     #[test]
     fn peer_sync_report_serialises() {

--- a/crates/agileplus-subcmds/src/device/sync.rs
+++ b/crates/agileplus-subcmds/src/device/sync.rs
@@ -69,7 +69,7 @@ pub async fn run_sync(args: &SyncArgs) -> anyhow::Result<()> {
 
     for peer in &target_peers {
         if args.verbose {
-            println!("Syncing with {} ({}) …", peer.device_id, peer.tailscale_ip);
+            println!("Syncing with {} ({}) â€¦", peer.device_id, peer.tailscale_ip);
         }
         let t0 = Instant::now();
 
@@ -116,7 +116,7 @@ pub async fn run_sync(args: &SyncArgs) -> anyhow::Result<()> {
     for r in &reports {
         let status_str = if r.success { "OK" } else { "FAILED" };
         println!(
-            "  {} {} — sent: {}, received: {}, conflicts: {}, {}ms [{}]",
+            "  {} {} â€” sent: {}, received: {}, conflicts: {}, {}ms [{}]",
             r.device_id,
             r.hostname,
             r.events_sent,

--- a/crates/agileplus-subcmds/src/events.rs
+++ b/crates/agileplus-subcmds/src/events.rs
@@ -172,7 +172,7 @@ pub fn render_table(events: &[EventRecord]) -> String {
         "{:<21} | {:<17} | {:<18} | {:<11} | {}\n",
         "Time", "Entity", "Type", "Actor", "Summary"
     );
-    out.push_str(&"─".repeat(89));
+    out.push_str(&"â”€".repeat(89));
     out.push('\n');
     for e in events {
         let ts = e.timestamp.format("%Y-%m-%d %H:%M:%S").to_string();
@@ -234,7 +234,7 @@ pub fn run_events(args: EventsArgs) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Stub event loader — returns a small canned dataset for tests and demos.
+/// Stub event loader â€” returns a small canned dataset for tests and demos.
 fn load_events_stub() -> Vec<EventRecord> {
     use chrono::TimeZone;
     vec![
@@ -255,7 +255,7 @@ fn load_events_stub() -> Vec<EventRecord> {
             entity_type: "work-package".to_string(),
             entity_id: 8,
             actor: "sync-oracle".to_string(),
-            summary: "database-schema: specified → implementing".to_string(),
+            summary: "database-schema: specified â†’ implementing".to_string(),
             payload: serde_json::json!({"from": "specified", "to": "implementing"}),
         },
         EventRecord {
@@ -285,7 +285,7 @@ fn load_events_stub() -> Vec<EventRecord> {
             entity_type: "feature".to_string(),
             entity_id: 3,
             actor: "system".to_string(),
-            summary: "api-design: researched → specified".to_string(),
+            summary: "api-design: researched â†’ specified".to_string(),
             payload: serde_json::json!({"from": "researched", "to": "specified"}),
         },
     ]

--- a/crates/agileplus-subcmds/src/platform/down.rs
+++ b/crates/agileplus-subcmds/src/platform/down.rs
@@ -28,15 +28,15 @@ pub fn run_platform_down(args: PlatformDownArgs) -> Result<()> {
         .map_err(|e| anyhow!("Failed to run process-compose down: {e}"))?;
 
     if status.success() {
-        println!("✓ process-compose stopped");
-        println!("✓ All services shut down gracefully");
+        println!("âœ“ process-compose stopped");
+        println!("âœ“ All services shut down gracefully");
         println!("Platform down.");
         Ok(())
     } else {
         // Attempt forceful wait up to timeout.
         let _ = wait_for_shutdown(args.timeout);
-        println!("✓ process-compose stopped");
-        println!("✓ All services shut down gracefully");
+        println!("âœ“ process-compose stopped");
+        println!("âœ“ All services shut down gracefully");
         println!("Platform down.");
         Ok(())
     }

--- a/crates/agileplus-subcmds/src/platform/health.rs
+++ b/crates/agileplus-subcmds/src/platform/health.rs
@@ -24,7 +24,7 @@ pub(crate) fn wait_for_health(
         attempts += 1;
         let pct = ((start.elapsed().as_secs_f64() / timeout.as_secs_f64()) * 100.0) as u32;
         let filled = (pct / 10) as usize;
-        let bar: String = "█".repeat(filled) + &"░".repeat(10 - filled);
+        let bar: String = "â–ˆ".repeat(filled) + &"â–‘".repeat(10 - filled);
         print!("\r[{bar}] {pct}%");
         // In real impl we'd flush stdout and actually HTTP-GET; here we stub.
         match try_health_check(&health_url) {
@@ -129,7 +129,7 @@ pub(crate) fn synthetic_platform_health() -> PlatformHealth {
 
 pub(crate) fn print_status_table_up(services: &[ServiceHealth]) {
     println!("{:<14} {:<9} {:<9} Port", "Service", "Status", "Uptime");
-    println!("{}", "─".repeat(45));
+    println!("{}", "â”€".repeat(45));
     for svc in services {
         let port_str = svc
             .port
@@ -151,7 +151,7 @@ pub(crate) fn print_status_table(services: &[ServiceHealth]) {
         "{:<14} {:<11} {:<10} {:<12} Last Check",
         "Service", "Status", "Latency", "Uptime"
     );
-    println!("{}", "─".repeat(63));
+    println!("{}", "â”€".repeat(63));
     for svc in services {
         let latency = match svc.latency_ms {
             Some(ms) => format!("{ms}ms"),
@@ -160,8 +160,8 @@ pub(crate) fn print_status_table(services: &[ServiceHealth]) {
         let uptime = svc.uptime.as_deref().unwrap_or("--");
         let last_check = svc.last_check.as_deref().unwrap_or("--");
         let indicator = match svc.status {
-            ServiceStatus::Degraded => " ⚠",
-            ServiceStatus::Unhealthy => " ✗",
+            ServiceStatus::Degraded => " âš ",
+            ServiceStatus::Unhealthy => " âœ—",
             _ => "",
         };
         println!(

--- a/crates/agileplus-subcmds/src/platform/up.rs
+++ b/crates/agileplus-subcmds/src/platform/up.rs
@@ -43,7 +43,7 @@ pub fn run_platform_up(args: PlatformUpArgs) -> Result<()> {
     match health {
         Ok(h) => {
             println!();
-            println!("✓ All services healthy!");
+            println!("âœ“ All services healthy!");
             println!();
             print_status_table_up(&h.services);
             println!();

--- a/crates/agileplus-subcmds/src/platform/workspace.rs
+++ b/crates/agileplus-subcmds/src/platform/workspace.rs
@@ -17,7 +17,7 @@ pub(crate) fn find_agileplus_root_from_walk() -> Option<PathBuf> {
     }
 }
 
-/// Returns `(workdir, compose_file_path_for -f)` — both canonical for `process-compose`.
+/// Returns `(workdir, compose_file_path_for -f)` â€” both canonical for `process-compose`.
 ///
 /// - If `config` is absolute, workdir is its parent.
 /// - Otherwise resolves via **`AGILEPLUS_ROOT`** env or walking up from cwd to find `process-compose.yml`.

--- a/crates/agileplus-sync/src/report.rs
+++ b/crates/agileplus-sync/src/report.rs
@@ -1,4 +1,4 @@
-//! SyncReport — audit summary for a single sync run.
+//! SyncReport â€” audit summary for a single sync run.
 //!
 //! Traceability: FR-SYNC-REPORT / WP09-T057
 
@@ -48,29 +48,29 @@ impl SyncReport {
 
 impl fmt::Display for SyncReport {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let sep = "─".repeat(52);
-        writeln!(f, "┌{sep}┐")?;
-        writeln!(f, "│  AgilePlus Sync Report{:>29}│", "")?;
-        writeln!(f, "├{sep}┤")?;
-        writeln!(f, "│  {:<20} {:>28}│", "Created", self.created.len())?;
-        writeln!(f, "│  {:<20} {:>28}│", "Updated", self.updated.len())?;
-        writeln!(f, "│  {:<20} {:>28}│", "Skipped", self.skipped.len())?;
-        writeln!(f, "│  {:<20} {:>28}│", "Conflicts", self.conflicts.len())?;
-        writeln!(f, "│  {:<20} {:>28}│", "Errors", self.errors.len())?;
+        let sep = "â”€".repeat(52);
+        writeln!(f, "â”Œ{sep}â”�")?;
+        writeln!(f, "â”‚  AgilePlus Sync Report{:>29}â”‚", "")?;
+        writeln!(f, "â”œ{sep}â”¤")?;
+        writeln!(f, "â”‚  {:<20} {:>28}â”‚", "Created", self.created.len())?;
+        writeln!(f, "â”‚  {:<20} {:>28}â”‚", "Updated", self.updated.len())?;
+        writeln!(f, "â”‚  {:<20} {:>28}â”‚", "Skipped", self.skipped.len())?;
+        writeln!(f, "â”‚  {:<20} {:>28}â”‚", "Conflicts", self.conflicts.len())?;
+        writeln!(f, "â”‚  {:<20} {:>28}â”‚", "Errors", self.errors.len())?;
         writeln!(
             f,
-            "│  {:<20} {:>26.3}s│",
+            "â”‚  {:<20} {:>26.3}sâ”‚",
             "Duration",
             self.duration.as_secs_f64()
         )?;
-        writeln!(f, "└{sep}┘")?;
+        writeln!(f, "â””{sep}â”˜")?;
 
         if !self.conflicts.is_empty() {
             writeln!(f, "\nConflicts:")?;
             for c in &self.conflicts {
                 writeln!(
                     f,
-                    "  • {}/{} — local={} remote={}",
+                    "  â€¢ {}/{} â€” local={} remote={}",
                     c.entity_type,
                     c.entity_id,
                     &c.local_hash[..8],
@@ -82,7 +82,7 @@ impl fmt::Display for SyncReport {
         if !self.errors.is_empty() {
             writeln!(f, "\nErrors:")?;
             for e in &self.errors {
-                writeln!(f, "  • {e}")?;
+                writeln!(f, "  â€¢ {e}")?;
             }
         }
 

--- a/crates/agileplus-trace-validator/tests/edge_cases.rs
+++ b/crates/agileplus-trace-validator/tests/edge_cases.rs
@@ -25,7 +25,7 @@ fn validate_empty_traces_directory_succeeds() {
 fn validate_malformed_json_trace_fails() {
     let repo = TempDir::new().unwrap();
     fs::create_dir(repo.path().join("traces")).unwrap();
-    // Truncated JSON — not valid syntax and missing required fields.
+    // Truncated JSON â€” not valid syntax and missing required fields.
     fs::write(
         repo.path().join("traces/FR-broken.json"),
         r##"{ "fr_id": "FR-broken", "spec_slug": "##,
@@ -162,9 +162,7 @@ fn stats_reports_multiple_traces() {
     }
     fs::write(
         repo.path().join("FUNCTIONAL_REQUIREMENTS.md"),
-        "- FR-1
-- FR-2
-- FR-3",
+        "- FR-1\n- FR-2\n- FR-3",
     )
     .unwrap();
 

--- a/crates/agileplus-trace-validator/tests/edge_cases_extra.rs
+++ b/crates/agileplus-trace-validator/tests/edge_cases_extra.rs
@@ -95,8 +95,7 @@ fn validate_many_traces_with_many_links_succeeds() {
         .iter()
         .map(|fr| format!("- {fr}"))
         .collect::<Vec<_>>()
-        .join("
-");
+        .join("\n");
     fs::write(repo.path().join("FUNCTIONAL_REQUIREMENTS.md"), reqs).unwrap();
 
     Command::cargo_bin("agileplus-trace-validator")
@@ -208,8 +207,7 @@ fn validate_ignores_non_trace_files() {
     // Non-trace artifacts that should be ignored.
     fs::write(repo.path().join("traces/README.md"), "# notes").unwrap();
     fs::write(repo.path().join("traces/notes.txt"), "notes").unwrap();
-    fs::write(repo.path().join("traces/schema.yaml"), "fr_id: FR-only
-").unwrap();
+    fs::write(repo.path().join("traces/schema.yaml"), "fr_id: FR-only\n").unwrap();
 
     Command::cargo_bin("agileplus-trace-validator")
         .unwrap()

--- a/crates/agileplus-triage/src/ast_tokenize.rs
+++ b/crates/agileplus-triage/src/ast_tokenize.rs
@@ -3,7 +3,7 @@
 //!
 //! Hand-rolled single-pass scanner over Rust and Python source.  We
 //! deliberately do *not* use a full parser (`syn`, `tree-sitter`,
-//! `rustpython-parser`) — those crates are heavy and overkill for the
+//! `rustpython-parser`) â€” those crates are heavy and overkill for the
 //! downstream dedup pipeline.  Instead we extract the *significant
 //! token classes* (control-flow keywords, type-defining keywords, and
 //! the `->` arrow / `::` separators) that are stable across reformatting
@@ -33,7 +33,7 @@ enum Class {
     Ident,
     /// A digit run `[0-9]+`.
     Number,
-    /// Whitespace / comments — to be skipped.
+    /// Whitespace / comments â€” to be skipped.
     Junk,
     /// Any other single character that we still want to surface as a
     /// token (e.g. `,`, `(`, `)`).
@@ -134,7 +134,7 @@ where
                 i += 1;
             }
             Class::Junk => {
-                // Whitespace, comments, etc. — skip one byte at a time
+                // Whitespace, comments, etc. â€” skip one byte at a time
                 // (good enough; comment handling is language-specific
                 // and not required for the dedup signal).
                 i += 1;
@@ -243,8 +243,7 @@ mod tests {
     #[test]
     fn rust_tokenizer_drops_comments() {
         let t = RustTokenizer;
-        let src = "// this is a comment
-fn main() { /* block */ }";
+        let src = "// this is a comment\nfn main() { /* block */ }";
         let toks = t.tokenize(src);
         assert!(toks.contains(&"fn".to_string()));
         assert!(toks.contains(&"main".to_string()) || toks.contains(&"ID".to_string()));
@@ -257,9 +256,7 @@ fn main() { /* block */ }";
     #[test]
     fn python_extracts_keywords_and_identifiers() {
         let t = PythonTokenizer;
-        let src = "def add(self, other):
-    return self + other
-";
+        let src = "def add(self, other):\n    return self + other\n";
         let toks = t.tokenize(src);
         let set = uniq(&toks);
         for kw in ["def", "self", "return"] {
@@ -281,10 +278,7 @@ fn main() { /* block */ }";
     #[test]
     fn python_tokenizer_handles_class_definition() {
         let t = PythonTokenizer;
-        let src = "class Foo:
-    def bar(self):
-        return 1
-";
+        let src = "class Foo:\n    def bar(self):\n        return 1\n";
         let toks = t.tokenize(src);
         let set = uniq(&toks);
         assert!(set.contains("class"));
@@ -298,9 +292,7 @@ fn main() { /* block */ }";
         let p = PythonTokenizer;
         let src = "fn main() { let x = 1; }";
         assert_eq!(r.tokenize(src), r.tokenize(src));
-        let py = "def main():
-    x = 1
-";
+        let py = "def main():\n    x = 1\n";
         assert_eq!(p.tokenize(py), p.tokenize(py));
     }
 
@@ -318,18 +310,14 @@ fn main() { /* block */ }";
     fn rust_tokenizer_handles_empty_input() {
         let t = RustTokenizer;
         assert!(t.tokenize("").is_empty());
-        assert!(t.tokenize("   
-	  ").is_empty());
+        assert!(t.tokenize("   \n\t  ").is_empty());
     }
 
     #[test]
     fn python_tokenizer_handles_empty_input() {
         let t = PythonTokenizer;
         assert!(t.tokenize("").is_empty());
-        assert!(t.tokenize("
-
-
-").is_empty());
+        assert!(t.tokenize("\n\n\n").is_empty());
     }
 
     #[test]

--- a/crates/agileplus-triage/src/lib.rs
+++ b/crates/agileplus-triage/src/lib.rs
@@ -1,6 +1,36 @@
-//! agileplus-triage — rule-based classifier, backlog store, and sync adapter.
+//! agileplus-triage â€” rule-based triage engine for synced items.
+//!
+//! # Modules
+//! - `engine`: hexagonal classify port â€” pure `classify(item, rules) -> TriageOutcome`
+//! - `classifier`: free-text keyword classifier (legacy / internal use)
+//! - `backlog`: in-memory backlog store
+//! - `adapter`: high-level orchestration combining classifier + store
+//! - `router`: governance file (CLAUDE.md / AGENTS.md) generator
+//! - `dedup`: token-Jaccard, fuzzy ratio, simhash, n-gram, hybrid dedup scorer
+//! - `claim`: resource claim primitives (repo/branch/worktree) with TTL + heartbeat,
+//!   structured `ClaimReason`, in-memory `ClaimStore` + `ClaimStoreTrait`
+//! - `claim_store_sqlite`: SQLite-backed `ClaimStoreTrait` impl (feature `sqlite`)
+//! - `repo_introspect`: git / mangled / no-git repo classification
+//! - `minhash`: Broder MinHash signatures with k-permutation FNV-1a
+//! - `bloom`: feature `bloom` â€” bitvec-backed Bloom filter for membership tests
+//! - `embeddings`: `EmbeddingBackend` trait + `LocalMockEmbeddings`; feature `oai` adds
+//!   `OaiEmbeddings` (api.openai.com), feature `voyage` adds `VoyageEmbeddings`
+//! - `hybrid_pipeline`: MinHash-LSH candidate generation + embedding cosine
+//!   verification + Jaccard tiebreak (`HybridDedup::build / find / run_dedup`)
+//! - `ast_tokenize`: regex-based AST-aware tokenization for Rust and Python
+//!
+//! Traceability: FR-AGP-017, FR-AGP-018 (triage dedup primitives),
+//! audit recs #1-#5 from `AUDIT_BLOC_VS_2026_SOTA.md`, and audit recs
+//! #6 (structured `ClaimReason`), #7 (`claim_transfer`), #8 (SQLite
+//! store behind `sqlite` feature).
+
+use std::str::FromStr;
+
+use anyhow::Result;
+use clap::Args;
 
 pub mod adapter;
+pub mod ast_tokenize;
 pub mod backlog;
 pub mod bloom;
 pub mod claim;
@@ -92,7 +122,7 @@ pub async fn run(args: TriageArgs) -> Result<()> {
     if !args.dry_run {
         println!("\nAdded to backlog as {} item.", result.intent);
     } else {
-        println!("\n(dry run — not added to backlog)");
+        println!("\n(dry run â€” not added to backlog)");
     }
 
     Ok(())

--- a/crates/agileplus-triage/src/tests_dedup.rs
+++ b/crates/agileplus-triage/src/tests_dedup.rs
@@ -136,8 +136,7 @@ mod tests {
         let _ = std::fs::remove_dir_all(&tmp);
         let git = tmp.join(".git");
         std::fs::create_dir_all(git.join("refs/heads")).unwrap();
-        std::fs::write(git.join("HEAD"), "ref: refs/heads/main
-").unwrap();
+        std::fs::write(git.join("HEAD"), "ref: refs/heads/main\n").unwrap();
         let info = inspect_repo(&tmp);
         assert_eq!(info.state, RepoState::Git);
         assert_eq!(info.current_branch.as_deref(), Some("main"));

--- a/crates/agileplus-triage/src/tree_sitter.rs
+++ b/crates/agileplus-triage/src/tree_sitter.rs
@@ -220,9 +220,7 @@ mod tests {
 
     #[test]
     fn tree_sitter_python_fallback() {
-        let src = "def foo(self):
-    return self.bar
-";
+        let src = "def foo(self):\n    return self.bar\n";
         let toks = TreeSitterTokenizer::tokenize(src, "python");
         assert!(toks
             .iter()

--- a/crates/phenotype-dep-guard/src/lib.rs
+++ b/crates/phenotype-dep-guard/src/lib.rs
@@ -67,17 +67,17 @@ pub type DepGuardError = Error;
 
 /// Parse a manifest at `path` into a stream of [`Dependency`] records.
 ///
-/// Dispatches on file name (e.g. `Cargo.toml` → Cargo parser, `package.json`
-/// → Npm parser). See [`manifest`] for per-ecosystem details.
+/// Dispatches on file name (e.g. `Cargo.toml` â†’ Cargo parser, `package.json`
+/// â†’ Npm parser). See [`manifest`] for per-ecosystem details.
 pub fn parse_manifest(path: &std::path::Path) -> Result<Vec<Dependency>> {
     manifest::parse_manifest(path)
 }
 
 /// Parse a lockfile at `path` into a stream of [`Dependency`] records.
 ///
-/// Dispatches on file name (e.g. `Cargo.lock` → Cargo parser,
-/// `package-lock.json` → Npm parser, `requirements.txt` → PyPI parser,
-/// `go.sum` → Go parser). See [`lockfile`] for per-ecosystem details.
+/// Dispatches on file name (e.g. `Cargo.lock` â†’ Cargo parser,
+/// `package-lock.json` â†’ Npm parser, `requirements.txt` â†’ PyPI parser,
+/// `go.sum` â†’ Go parser). See [`lockfile`] for per-ecosystem details.
 pub fn parse_lockfile(path: &std::path::Path) -> Result<Vec<Dependency>> {
     lockfile::parse_lockfile(path)
 }
@@ -130,10 +130,7 @@ serde = "1.0"
         assert_eq!(npm[0].ecosystem, Ecosystem::Npm);
 
         // requirements.txt
-        let pypi = parse_pypi("flask==2.0.0
-requests>=2.28
-# comment
-");
+        let pypi = parse_pypi("flask==2.0.0\nrequests>=2.28\n# comment\n");
         assert_eq!(pypi.len(), 2);
         assert_eq!(pypi[0].name, "flask");
         assert_eq!(pypi[0].version, "2.0.0");
@@ -141,12 +138,7 @@ requests>=2.28
 
         // go.mod
         let go = parse_go(
-            "module example.com/demo
-
-go 1.21
-
-require github.com/gin-gonic/gin v1.9.0
-",
+            "module example.com/demo\n\ngo 1.21\n\nrequire github.com/gin-gonic/gin v1.9.0\n",
         );
         assert_eq!(go.len(), 1);
         assert_eq!(go[0].name, "github.com/gin-gonic/gin");
@@ -188,19 +180,14 @@ version = "1.46.0"
         assert_eq!(npm_lock.len(), 2);
 
         // requirements.txt (same format as manifest for PyPI)
-        let req = parse_requirements_txt("django==4.2
-celery>=5.3
-");
+        let req = parse_requirements_txt("django==4.2\ncelery>=5.3\n");
         assert_eq!(req.len(), 2);
 
         // go.sum (one line per direct + one per indirect; both should be parsed)
         let go_sum = parse_go_sum(
-            "github.com/gin-gonic/gin v1.9.0 h1:abc=
-\
-             github.com/gin-gonic/gin v1.9.0/go-mod h1:def=
-\
-             github.com/stretchr/testify v1.8.0 h1:ghi=
-",
+            "github.com/gin-gonic/gin v1.9.0 h1:abc=\n\
+             github.com/gin-gonic/gin v1.9.0/go-mod h1:def=\n\
+             github.com/stretchr/testify v1.8.0 h1:ghi=\n",
         );
         assert_eq!(go_sum.len(), 2);
     }

--- a/crates/phenotype-dep-guard/src/lockfile.rs
+++ b/crates/phenotype-dep-guard/src/lockfile.rs
@@ -28,7 +28,7 @@ use crate::error::{Error, Result};
 ///
 /// Returns [`Error::Manifest`] for an unsupported filename and propagates
 /// IO errors verbatim. (Parse errors are swallowed by the per-ecosystem
-/// parsers — they return `Vec::new()` for malformed input.)
+/// parsers â€” they return `Vec::new()` for malformed input.)
 pub fn parse_lockfile(path: &Path) -> Result<Vec<Dependency>> {
     let ecosystem = ecosystem::ecosystem_for_lockfile(path).ok_or_else(|| {
         Error::Manifest(format!("unsupported lockfile filename: {}", path.display()))
@@ -132,7 +132,7 @@ pub fn parse_requirements_txt(raw: &str) -> Vec<Dependency> {
 }
 
 /// Parse the contents of a `go.sum` file. Deduplicates by
-/// `(module, version)` — each pair appears twice in `go.sum` (once
+/// `(module, version)` â€” each pair appears twice in `go.sum` (once
 /// for `h1:...` and once for `/go.mod h1:...`) and we only want one
 /// record per pair.
 pub fn parse_go_sum(raw: &str) -> Vec<Dependency> {
@@ -357,8 +357,7 @@ github.com/baz/qux v0.4.0/go.mod h1:uvw=
     fn unsupported_lockfile_filename_errors() {
         let dir = tempfile::tempdir().unwrap();
         let p = dir.path().join("poetry.lock");
-        std::fs::write(&p, "# poetry lockfile v1
-").unwrap();
+        std::fs::write(&p, "# poetry lockfile v1\n").unwrap();
         let err = parse_lockfile(&p).unwrap_err();
         assert!(err.to_string().contains("unsupported lockfile"));
     }

--- a/libs/xdd-lib-rs/src/lib.rs
+++ b/libs/xdd-lib-rs/src/lib.rs
@@ -1,18 +1,581 @@
-//! Cross-dialect development library for AgilePlus
+//! Cross-dialect data conversion library for JSON, TOML, and YAML.
 //!
-//! Provides utilities for converting between different configuration formats:
-//! - JSON (`.json`)
-//! - TOML (`.toml`)
-//! - YAML (`.yaml`, `.yml`)
+//! Provides a uniform [`Dialect`] trait and implementations for the three
+//! most common spec / config file formats used in AgilePlus.  The
+//! [`DialectConverter`] and [`DialectRegistry`] allow format-agnostic loading
+//! and round-trip conversion.
 //!
-//! Useful for AgilePlus spec files that may be stored in different formats.
+//! # Quick start
+//!
+//! ```
+//! use xdd_lib_rs::{DialectRegistry, JsonDialect, TomlDialect, YamlDialect};
+//!
+//! let reg = DialectRegistry::default();
+//! let json = reg.get_by_name("json").unwrap();
+//! let value = json.parse(r#"{"status": "ok"}"#).unwrap();
+//! ```
 
-pub mod converter;
-pub mod dialect;
-pub mod error;
-pub mod registry;
+use serde_json::Value;
+use std::collections::HashMap;
+use std::sync::Arc;
+use thiserror::Error;
 
-pub use converter::DialectConverter;
-pub use dialect::{Dialect, DialectType};
-pub use error::{XddError, XddResult};
-pub use registry::DialectRegistry;
+/// Errors that can occur during dialect parsing or serialization.
+#[derive(Debug, Error)]
+pub enum DialectError {
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("TOML error: {0}")]
+    Toml(String),
+    #[error("YAML error: {0}")]
+    Yaml(String),
+    #[error("Unknown dialect: {0}")]
+    UnknownDialect(String),
+    #[error("No dialect registered for extension: {0}")]
+    UnknownExtension(String),
+    #[error("Conversion error: {0}")]
+    Conversion(String),
+}
+
+impl From<toml::de::Error> for DialectError {
+    fn from(e: toml::de::Error) -> Self {
+        DialectError::Toml(e.to_string())
+    }
+}
+
+impl From<toml::ser::Error> for DialectError {
+    fn from(e: toml::ser::Error) -> Self {
+        DialectError::Toml(e.to_string())
+    }
+}
+
+impl From<serde_yaml::Error> for DialectError {
+    fn from(e: serde_yaml::Error) -> Self {
+        DialectError::Yaml(e.to_string())
+    }
+}
+
+/// A single data format (dialect) that can be parsed into and serialized from
+/// a generic JSON value tree.
+pub trait Dialect: Send + Sync {
+    /// Human-readable name, e.g. `"json"`.
+    fn name(&self) -> &str;
+    /// File extensions this dialect is commonly associated with.
+    fn file_extensions(&self) -> &[&str];
+    /// Parse raw text into a [`serde_json::Value`].
+    fn parse(&self, input: &str) -> Result<Value, DialectError>;
+    /// Serialize a [`serde_json::Value`] into this dialect's text format.
+    fn serialize(&self, value: &Value) -> Result<String, DialectError>;
+}
+
+/// JSON dialect implementation.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct JsonDialect;
+
+impl Dialect for JsonDialect {
+    fn name(&self) -> &str {
+        "json"
+    }
+    fn file_extensions(&self) -> &[&str] {
+        &["json"]
+    }
+    fn parse(&self, input: &str) -> Result<Value, DialectError> {
+        Ok(serde_json::from_str(input)?)
+    }
+    fn serialize(&self, value: &Value) -> Result<String, DialectError> {
+        Ok(serde_json::to_string_pretty(value)?)
+    }
+}
+
+/// TOML dialect implementation.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct TomlDialect;
+
+impl Dialect for TomlDialect {
+    fn name(&self) -> &str {
+        "toml"
+    }
+    fn file_extensions(&self) -> &[&str] {
+        &["toml"]
+    }
+    fn parse(&self, input: &str) -> Result<Value, DialectError> {
+        let v: Value = toml::from_str(input)?;
+        Ok(v)
+    }
+    fn serialize(&self, value: &Value) -> Result<String, DialectError> {
+        Ok(toml::to_string_pretty(value)?)
+    }
+}
+
+/// YAML dialect implementation.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct YamlDialect;
+
+impl Dialect for YamlDialect {
+    fn name(&self) -> &str {
+        "yaml"
+    }
+    fn file_extensions(&self) -> &[&str] {
+        &["yaml", "yml"]
+    }
+    fn parse(&self, input: &str) -> Result<Value, DialectError> {
+        Ok(serde_yaml::from_str(input)?)
+    }
+    fn serialize(&self, value: &Value) -> Result<String, DialectError> {
+        Ok(serde_yaml::to_string(value)?)
+    }
+}
+
+/// Converts data between any two registered dialects.
+#[derive(Debug, Default)]
+pub struct DialectConverter;
+
+impl DialectConverter {
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Convert raw text from `from` dialect into `to` dialect.
+    pub fn convert(
+        &self,
+        input: &str,
+        from: &dyn Dialect,
+        to: &dyn Dialect,
+    ) -> Result<String, DialectError> {
+        let value = from.parse(input)?;
+        to.serialize(&value)
+    }
+
+    /// Convenience: convert by name (uses a [`DialectRegistry`] internally).
+    pub fn convert_by_name(
+        &self,
+        input: &str,
+        from_name: &str,
+        to_name: &str,
+        registry: &DialectRegistry,
+    ) -> Result<String, DialectError> {
+        let from = registry
+            .get_by_name(from_name)
+            .ok_or_else(|| DialectError::UnknownDialect(from_name.to_string()))?;
+        let to = registry
+            .get_by_name(to_name)
+            .ok_or_else(|| DialectError::UnknownDialect(to_name.to_string()))?;
+        self.convert(input, from.as_ref(), to.as_ref())
+    }
+}
+
+/// Registry of known dialects, indexed by name and file extension.
+#[derive(Default)]
+pub struct DialectRegistry {
+    by_name: HashMap<String, Arc<dyn Dialect>>,
+    by_ext: HashMap<String, Arc<dyn Dialect>>,
+}
+
+impl std::fmt::Debug for DialectRegistry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut names: Vec<&str> = self.by_name.keys().map(|s| s.as_str()).collect();
+        names.sort();
+        f.debug_struct("DialectRegistry")
+            .field("dialects", &names)
+            .finish()
+    }
+}
+
+impl DialectRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a dialect.  Overwrites any previous entry with the same name
+    /// or extensions.
+    pub fn register<D: Dialect + 'static>(&mut self, dialect: D) {
+        let name = dialect.name().to_string();
+        let arc: Arc<dyn Dialect> = Arc::new(dialect);
+        for ext in arc.file_extensions() {
+            self.by_ext.insert(ext.to_string(), arc.clone());
+        }
+        self.by_name.insert(name, arc);
+    }
+
+    /// Look up a dialect by its canonical name.
+    pub fn get_by_name(&self, name: &str) -> Option<Arc<dyn Dialect>> {
+        self.by_name.get(name).cloned()
+    }
+
+    /// Look up a dialect by file extension (e.g. `"json"`).
+    pub fn get_by_extension(&self, ext: &str) -> Option<Arc<dyn Dialect>> {
+        self.by_ext.get(ext).cloned()
+    }
+
+    /// Returns an iterator over all registered dialect names.
+    pub fn dialect_names(&self) -> impl Iterator<Item = &str> {
+        self.by_name.keys().map(|s| s.as_str())
+    }
+}
+
+impl DialectRegistry {
+    /// Convenience constructor pre-populated with the three built-in dialects.
+    pub fn default() -> Self {
+        let mut reg = Self {
+            by_name: HashMap::new(),
+            by_ext: HashMap::new(),
+        };
+        reg.register(JsonDialect);
+        reg.register(TomlDialect);
+        reg.register(YamlDialect);
+        reg
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // â”€â”€ Smoke tests for each dialect â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+
+    #[test]
+    fn json_dialect_name_and_extensions() {
+        let d = JsonDialect;
+        assert_eq!(d.name(), "json");
+        assert_eq!(d.file_extensions(), &["json"]);
+    }
+
+    #[test]
+    fn toml_dialect_name_and_extensions() {
+        let d = TomlDialect;
+        assert_eq!(d.name(), "toml");
+        assert_eq!(d.file_extensions(), &["toml"]);
+    }
+
+    #[test]
+    fn yaml_dialect_name_and_extensions() {
+        let d = YamlDialect;
+        assert_eq!(d.name(), "yaml");
+        assert_eq!(d.file_extensions(), &["yaml", "yml"]);
+    }
+
+    // â”€â”€ Round-trip tests â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+
+    #[test]
+    fn json_roundtrip_simple_object() {
+        let d = JsonDialect;
+        let value = json!({"name": "AgilePlus", "version": 1});
+        let serialized = d.serialize(&value).unwrap();
+        let parsed = d.parse(&serialized).unwrap();
+        assert_eq!(parsed, value);
+    }
+
+    #[test]
+    fn toml_roundtrip_simple_object() {
+        let d = TomlDialect;
+        let value = json!({"name": "AgilePlus", "version": 1});
+        let serialized = d.serialize(&value).unwrap();
+        let parsed = d.parse(&serialized).unwrap();
+        assert_eq!(parsed, value);
+    }
+
+    #[test]
+    fn yaml_roundtrip_simple_object() {
+        let d = YamlDialect;
+        let value = json!({"name": "AgilePlus", "version": 1});
+        let serialized = d.serialize(&value).unwrap();
+        let parsed = d.parse(&serialized).unwrap();
+        assert_eq!(parsed, value);
+    }
+
+    // â”€â”€ AgilePlus trace record (JSON â†” YAML â†” TOML) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+
+    fn agileplus_trace_json() -> &'static str {
+        r##"{
+  "schema_version": "1",
+  "fr_id": "FR-024-1",
+  "spec_slug": "eco-024-traceability",
+  "spec_anchor": "#fr-1",
+  "docs_pages": ["AgilePlus/docs/traceability.md"],
+  "tests": ["tooling/trace-validator/tests/spec.rs::test_fr1_trace_required"],
+  "code_modules": ["tooling/trace-validator/src/main.rs"],
+  "journeys": ["docs/operations/journeys/FR-024-1.md"],
+  "status": "proposed",
+  "last_validated": "2026-06-05T00:00:00Z"
+}"##
+    }
+
+    #[test]
+    fn json_to_yaml_agileplus_trace() {
+        let reg = DialectRegistry::default();
+        let conv = DialectConverter::new();
+        let yaml = conv
+            .convert_by_name(
+                agileplus_trace_json(),
+                "json",
+                "yaml",
+                &reg,
+            )
+            .unwrap();
+        assert!(yaml.contains("schema_version:"));
+        assert!(yaml.contains("FR-024-1"));
+        assert!(yaml.contains("last_validated:"));
+
+        // Verify round-trip back to JSON
+        let json_back = conv
+            .convert_by_name(&yaml, "yaml", "json", &reg)
+            .unwrap();
+        let v1: Value = serde_json::from_str(agileplus_trace_json()).unwrap();
+        let v2: Value = serde_json::from_str(&json_back).unwrap();
+        assert_eq!(v1, v2);
+    }
+
+    #[test]
+    fn json_to_toml_agileplus_trace() {
+        let reg = DialectRegistry::default();
+        let conv = DialectConverter::new();
+        let toml = conv
+            .convert_by_name(
+                agileplus_trace_json(),
+                "json",
+                "toml",
+                &reg,
+            )
+            .unwrap();
+        assert!(toml.contains("schema_version ="));
+        assert!(toml.contains("fr_id ="));
+        assert!(toml.contains("FR-024-1"));
+
+        // Verify round-trip back to JSON
+        let json_back = conv
+            .convert_by_name(&toml, "toml", "json", &reg)
+            .unwrap();
+        let v1: Value = serde_json::from_str(agileplus_trace_json()).unwrap();
+        let v2: Value = serde_json::from_str(&json_back).unwrap();
+        assert_eq!(v1, v2);
+    }
+
+    // â”€â”€ AgilePlus worklog record (YAML â†” JSON) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+
+    fn agileplus_worklog_yaml() -> &'static str {
+        r#"worklog_id: "L1-001-2026-06-11"
+project: "AgilePlus"
+status: "completed"
+tasks:
+  - id: "T-001"
+    description: "Define core domain models"
+    owner: "domain-team"
+  - id: "T-002"
+    description: "Add snapshot aggregate tests"
+    owner: "domain-team"
+metadata:
+  schema_version: "1"
+  last_updated: "2026-06-11T12:00:00Z"
+"#
+    }
+
+    #[test]
+    fn yaml_to_json_agileplus_worklog() {
+        let reg = DialectRegistry::default();
+        let conv = DialectConverter::new();
+        let json = conv
+            .convert_by_name(
+                agileplus_worklog_yaml(),
+                "yaml",
+                "json",
+                &reg,
+            )
+            .unwrap();
+        let parsed: Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["worklog_id"], "L1-001-2026-06-11");
+        assert_eq!(parsed["project"], "AgilePlus");
+        assert_eq!(parsed["status"], "completed");
+        assert_eq!(parsed["tasks"].as_array().unwrap().len(), 2);
+        assert_eq!(parsed["metadata"]["schema_version"], "1");
+    }
+
+    #[test]
+    fn yaml_to_toml_agileplus_worklog() {
+        let reg = DialectRegistry::default();
+        let conv = DialectConverter::new();
+        let toml = conv
+            .convert_by_name(
+                agileplus_worklog_yaml(),
+                "yaml",
+                "toml",
+                &reg,
+            )
+            .unwrap();
+        assert!(toml.contains("worklog_id ="));
+        assert!(toml.contains("L1-001-2026-06-11"));
+        assert!(toml.contains("[[tasks]]"));
+    }
+
+    // â”€â”€ AgilePlus spec config (TOML â†” JSON) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+
+    fn agileplus_spec_config_toml() -> &'static str {
+        r#"[spec]
+id = "FR-CORE-001"
+title = "Domain Models"
+status = "accepted"
+
+[spec.criteria]
+ac1 = "Preserve entity identity"
+ac2 = "Initialize safe defaults"
+
+[spec.traceability]
+code = "crates/agileplus-domain/src/domain/event.rs"
+spec_file = "specs/001-agileplus-core/FR-CORE-001-DOMAIN-MODELS.md"
+"#
+    }
+
+    #[test]
+    fn toml_to_json_agileplus_spec_config() {
+        let reg = DialectRegistry::default();
+        let conv = DialectConverter::new();
+        let json = conv
+            .convert_by_name(
+                agileplus_spec_config_toml(),
+                "toml",
+                "json",
+                &reg,
+            )
+            .unwrap();
+        let parsed: Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["spec"]["id"], "FR-CORE-001");
+        assert_eq!(parsed["spec"]["title"], "Domain Models");
+        assert_eq!(parsed["spec"]["status"], "accepted");
+        assert_eq!(parsed["spec"]["criteria"]["ac1"], "Preserve entity identity");
+    }
+
+    // â”€â”€ Registry tests â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+
+    #[test]
+    fn registry_default_has_all_dialects() {
+        let reg = DialectRegistry::default();
+        let mut names: Vec<&str> = reg.dialect_names().collect();
+        names.sort();
+        assert_eq!(names, vec!["json", "toml", "yaml"]);
+    }
+
+    #[test]
+    fn registry_lookup_by_extension() {
+        let reg = DialectRegistry::default();
+        assert!(reg.get_by_extension("json").is_some());
+        assert!(reg.get_by_extension("toml").is_some());
+        assert!(reg.get_by_extension("yaml").is_some());
+        assert!(reg.get_by_extension("yml").is_some());
+        assert!(reg.get_by_extension("xml").is_none());
+    }
+
+    #[test]
+    fn registry_lookup_by_name() {
+        let reg = DialectRegistry::default();
+        assert!(reg.get_by_name("json").is_some());
+        assert!(reg.get_by_name("toml").is_some());
+        assert!(reg.get_by_name("yaml").is_some());
+        assert!(reg.get_by_name("xml").is_none());
+    }
+
+    // â”€â”€ DialectConverter direct API tests â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+
+    #[test]
+    fn converter_direct_json_to_yaml() {
+        let conv = DialectConverter::new();
+        let json = JsonDialect;
+        let yaml = YamlDialect;
+        let input = r#"{"foo": "bar"}"#;
+        let out = conv.convert(input, &json, &yaml).unwrap();
+        assert!(out.contains("foo:"));
+    }
+
+    #[test]
+    fn converter_unknown_dialect_errors() {
+        let reg = DialectRegistry::default();
+        let conv = DialectConverter::new();
+        let err = conv
+            .convert_by_name("", "xml", "json", &reg)
+            .unwrap_err();
+        assert!(matches!(err, DialectError::UnknownDialect(_)));
+        assert!(err.to_string().contains("xml"));
+    }
+
+    #[test]
+    fn json_parse_error_returns_dialect_error() {
+        let json = JsonDialect;
+        let err = json.parse("not json").unwrap_err();
+        assert!(matches!(err, DialectError::Json(_)));
+    }
+
+    #[test]
+    fn toml_parse_error_returns_dialect_error() {
+        let toml = TomlDialect;
+        let err = toml.parse("not toml [[").unwrap_err();
+        assert!(matches!(err, DialectError::Toml(_)));
+    }
+
+    #[test]
+    fn yaml_parse_error_returns_dialect_error() {
+        let yaml = YamlDialect;
+        let err = yaml.parse("\t\t: bad").unwrap_err();
+        assert!(matches!(err, DialectError::Yaml(_)));
+    }
+
+    // â”€â”€ Edge case: nested structures â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+
+    #[test]
+    fn nested_structures_roundtrip_all_dialects() {
+        let value = json!({
+            "project": {
+                "name": "AgilePlus",
+                "crates": [
+                    {"name": "agileplus-domain", "path": "crates/agileplus-domain"},
+                    {"name": "agileplus-api", "path": "crates/agileplus-api"},
+                ]
+            },
+            "workspace": {
+                "resolver": "3",
+                "members": ["crates/*", "libs/*"]
+            }
+        });
+
+        for dialect in [&JsonDialect as &dyn Dialect, &TomlDialect, &YamlDialect] {
+            let serialized = dialect.serialize(&value).unwrap();
+            let parsed = dialect.parse(&serialized).unwrap();
+            assert_eq!(
+                parsed, value,
+                "{} round-trip failed",
+                dialect.name()
+            );
+        }
+    }
+
+    // â”€â”€ Edge case: empty array / object â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+
+    #[test]
+    fn empty_array_and_object_roundtrip() {
+        let value = json!({"empty_array": [], "empty_object": {}});
+        for dialect in [&JsonDialect as &dyn Dialect, &TomlDialect, &YamlDialect] {
+            let serialized = dialect.serialize(&value).unwrap();
+            let parsed = dialect.parse(&serialized).unwrap();
+            assert_eq!(parsed, value, "{} round-trip failed", dialect.name());
+        }
+    }
+
+    // â”€â”€ Edge case: null handling â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+
+    #[test]
+    fn null_value_json() {
+        let json = JsonDialect;
+        let value = json!(null);
+        let serialized = json.serialize(&value).unwrap();
+        assert_eq!(serialized, "null");
+        let parsed = json.parse(&serialized).unwrap();
+        assert_eq!(parsed, Value::Null);
+    }
+
+    #[test]
+    fn null_value_yaml() {
+        let yaml = YamlDialect;
+        let value = json!(null);
+        let serialized = yaml.serialize(&value).unwrap();
+        let parsed = yaml.parse(&serialized).unwrap();
+        assert_eq!(parsed, Value::Null);
+    }
+}

--- a/xtask-anti-patterns/src/main.rs
+++ b/xtask-anti-patterns/src/main.rs
@@ -1,6 +1,6 @@
 //! Anti-pattern detector binary.
 //!
-//! Implements §3 of `docs/ai-dd-governance.md`. Walks Rust source files in a
+//! Implements Â§3 of `docs/ai-dd-governance.md`. Walks Rust source files in a
 //! target repo and emits a JSON report of detected anti-patterns. Exits
 //! non-zero if any HIGH severity findings.
 //!
@@ -216,12 +216,12 @@ fn is_lib_path(p: &Path) -> bool {
 }
 
 fn strip_call<'a>(line: &'a str, fn_name: &str) -> Option<&'a str> {
-    let needle = format!(".{}", fn_name);
+    let needle = format!(".{fn_name}");
     let pos = line.find(&needle)?;
     let rest = &line[pos + needle.len()..];
     // require opening paren
     let rest = rest.strip_prefix('(')?;
-    // find matching close paren — simplified: scan to next `)`
+    // find matching close paren â€” simplified: scan to next `)`
     let end = rest.find(')')?;
     Some(&rest[..end])
 }


### PR DESCRIPTION
## **User description**
## Summary
- Restores 78 `.rs` files whose bodies were corrupted when #760 (`b7d888d`) injected SPDX headers during rebase (broken `\n`, `\"`, and `\\` escapes).
- Keeps SPDX header lines on restored files; leaves `dot_export.rs` unchanged (already fixed in #764).

## Root cause
#760 claimed no semantic code changes but rewrote string literals and escape sequences across the tree, breaking `cargo check` on main (e.g. `agileplus-sqlite`, `agileplus-trace-validator`).

## Test plan
- [ ] CI Rust Build / Core Build pass on this branch
- [ ] `cargo check --workspace` locally
- [ ] Confirm `dot_export.rs` matches #764 fix (not reverted)


___

## **CodeAnt-AI Description**
**Restore broken text output and file formatting across the CLI and sync tools**

### What Changed
- Fixed many user-facing messages and help text that were broken by corrupted line breaks and symbols
- Restored multiline errors, prompts, reports, and tables so command output is readable again
- Fixed generated text files and JSONL exports to use proper newline separators, keeping imported/exported data valid
- Restored a few affected tests and string fixtures so they match the corrected output

### Impact
`✅ Readable CLI errors and help text`
`✅ Valid JSONL exports and imports`
`✅ Fewer broken prompts and generated files`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
