### PR TITLE
fix(ci): domain zero-dep lint + config lint taplo path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,7 +311,7 @@ jobs:
       - name: Install taplo
         run: cargo install taplo-cli
       - name: TOML format check
-        run: taplo format --check Cargo.toml rust/Cargo.toml python/pyproject.toml
+        run: taplo format --check Cargo.toml rust/Cargo.toml pyproject.toml
       - name: actionlint
         uses: reviewdog/action-actionlint@v1
 

--- a/crates/agileplus-domain/Cargo.toml
+++ b/crates/agileplus-domain/Cargo.toml
@@ -14,8 +14,6 @@ chrono.workspace = true
 sha2.workspace = true
 agileplus-validate.workspace = true
 uuid.workspace = true
-phenotype-error-core = { path = "../../../phenoShared/crates/phenotype-error-core" }
-regex = "1"
 
 [dev-dependencies]
 tokio.workspace = true

--- a/crates/agileplus-domain/src/builder.rs
+++ b/crates/agileplus-domain/src/builder.rs
@@ -287,10 +287,14 @@ fn new_edge_id() -> String {
 
 /// Validate a node id matches `^[A-Z][a-z]+#[a-z0-9-]+$` without a regex engine.
 fn is_valid_node_id(id: &str) -> bool {
-    use regex::Regex;
-    static RE: std::sync::OnceLock<Regex> = std::sync::OnceLock::new();
-    let re = RE.get_or_init(|| Regex::new(r"^[A-Z][a-z]+#[a-z0-9\-]+$").expect("domain operation"));
-    re.is_match(id)
+    let parts: Vec<&str> = id.split('#').collect();
+    if parts.len() != 2 { return false; }
+    let (prefix, suffix) = (parts[0], parts[1]);
+    if prefix.is_empty() || suffix.is_empty() { return false; }
+    if !prefix.chars().next().map_or(false, |c| c.is_ascii_uppercase()) { return false; }
+    if prefix.len() == 1 { return false; }
+    if !prefix[1..].chars().all(|c| c.is_ascii_lowercase()) { return false; }
+    suffix.chars().all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## **User description**
fix(ci): domain zero-dep lint + config lint taplo path

## Summary
- Replace regex-based is_valid_node_id with pure-Rust char iteration (no external crate)
- Remove regex and phenotype-error-core from agileplus-domain Cargo.toml
- Fix Config Lint taplo path: python/pyproject.toml -> pyproject.toml

## Test plan
- [ ] Domain Zero-Dep Lint job passes
- [ ] Config Lint job passes
- [ ] builder.rs unit tests pass


___

## **CodeAnt-AI Description**
**Fix domain ID validation and CI config lint paths**

### What Changed
- Node IDs are now checked without relying on a regex engine, while keeping the same allowed name format
- The domain crate no longer depends on unused validation and error crates
- Config lint now checks the correct root `pyproject.toml` file instead of the Python subfolder path

### Impact
`✅ Fewer CI failures`
`✅ Cleaner domain dependency checks`
`✅ Reliable config linting`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
