### PR TITLE
fix(domain): remove disallowed deps (async-trait, uuid) from agileplus-domain

### DIFF
--- a/.github/workflows/sast-full.yml
+++ b/.github/workflows/sast-full.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        language: [python, cpp, javascript]
+        language: [python, javascript]        # cpp removed: not in repo
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -62,7 +62,7 @@ jobs:
       security-events: write
     strategy:
       matrix:
-        language: [cpp, python]
+        language: [python]        # cpp removed: not in repo
     steps:
       - uses: actions/checkout@v7
       - uses: github/codeql-action/init@v4

--- a/crates/agileplus-domain/Cargo.toml
+++ b/crates/agileplus-domain/Cargo.toml
@@ -9,11 +9,9 @@ rust-version.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-async-trait.workspace = true
 chrono.workspace = true
 sha2.workspace = true
 agileplus-validate.workspace = true
-uuid.workspace = true
 
 [dev-dependencies]
 tokio.workspace = true

--- a/crates/agileplus-domain/src/adapters/noop_trace_adapter.rs
+++ b/crates/agileplus-domain/src/adapters/noop_trace_adapter.rs
@@ -4,7 +4,6 @@
 //! system is connected, in integration tests, or as a default/fallback implementation.
 
 use async_trait::async_trait;
-use uuid::Uuid;
 
 use crate::error::DomainError;
 use crate::ports::traceability_port::TraceabilityPort;
@@ -19,11 +18,10 @@ use crate::traceability::TraceRef;
 /// use agileplus_domain::ports::traceability_port::TraceabilityPort;
 /// use agileplus_domain::traceability::TraceRef;
 /// use chrono::Utc;
-/// use uuid::Uuid;
 ///
 /// # tokio_test::block_on(async {
 /// let adapter = NoopTraceAdapter;
-/// let entity_id = Uuid::new_v4();
+/// let entity_id = format!("trace-{}", chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0));
 /// let trace_ref = TraceRef {
 ///     trace_id: "FR-001".into(),
 ///     artifact_type: "requirement".into(),
@@ -42,11 +40,11 @@ pub struct NoopTraceAdapter;
 
 #[async_trait]
 impl TraceabilityPort for NoopTraceAdapter {
-    async fn link_trace(&self, _entity_id: Uuid, _trace_ref: TraceRef) -> Result<(), DomainError> {
+    async fn link_trace(&self, _entity_id: String, _trace_ref: TraceRef) -> Result<(), DomainError> {
         Ok(())
     }
 
-    async fn get_traces(&self, _entity_id: Uuid) -> Result<Vec<TraceRef>, DomainError> {
+    async fn get_traces(&self, _entity_id: String) -> Result<Vec<TraceRef>, DomainError> {
         Ok(vec![])
     }
 }

--- a/crates/agileplus-domain/src/ports/epic.rs
+++ b/crates/agileplus-domain/src/ports/epic.rs
@@ -1,16 +1,13 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 //! Epic repository port.
 
-use async_trait::async_trait;
-
 use crate::domain::epic::{Epic, EpicStatus};
 use crate::error::DomainError;
 
 /// Repository port for Epic aggregates.
-#[async_trait]
 pub trait EpicRepository: Send + Sync {
-    async fn create(&self, epic: &Epic) -> Result<i64, DomainError>;
-    async fn get_by_id(&self, id: i64) -> Result<Option<Epic>, DomainError>;
-    async fn update_status(&self, id: i64, status: EpicStatus) -> Result<(), DomainError>;
-    async fn list_by_project(&self, project_id: i64) -> Result<Vec<Epic>, DomainError>;
+    fn create(&self, epic: &Epic) -> Result<i64, DomainError>;
+    fn get_by_id(&self, id: i64) -> Result<Option<Epic>, DomainError>;
+    fn update_status(&self, id: i64, status: EpicStatus) -> Result<(), DomainError>;
+    fn list_by_project(&self, project_id: i64) -> Result<Vec<Epic>, DomainError>;
 }

--- a/crates/agileplus-domain/src/ports/events.rs
+++ b/crates/agileplus-domain/src/ports/events.rs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 //! Domain event publisher port.
 
-use async_trait::async_trait;
-
 use crate::error::DomainError;
 
 /// Application-level domain events emitted AFTER persistence.
@@ -35,7 +33,6 @@ pub enum DomainEvent {
 }
 
 /// Output port for publishing domain events to an event bus / message broker.
-#[async_trait]
 pub trait DomainEventPublisher: Send + Sync {
-    async fn publish(&self, event: DomainEvent) -> Result<(), DomainError>;
+    fn publish(&self, event: DomainEvent) -> Result<(), DomainError>;
 }

--- a/crates/agileplus-domain/src/ports/plane_sync.rs
+++ b/crates/agileplus-domain/src/ports/plane_sync.rs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 //! Plane.so sync port.
 
-use async_trait::async_trait;
-
 use crate::domain::story::{Story, StoryStatus};
 use crate::error::DomainError;
 
@@ -43,17 +41,16 @@ impl PlaneIssue {
 }
 
 /// Hexagonal port for Plane.so synchronization.
-#[async_trait]
 pub trait PlaneSyncPort: Send + Sync {
-    async fn list_projects(&self) -> Result<Vec<PlaneProject>, DomainError>;
+    fn list_projects(&self) -> Result<Vec<PlaneProject>, DomainError>;
 
-    async fn sync_story_to_plane(
+    fn sync_story_to_plane(
         &self,
         project_identifier: &str,
         story: &Story,
     ) -> Result<PlaneIssue, DomainError>;
 
-    async fn sync_from_plane(
+    fn sync_from_plane(
         &self,
         project_id: i64,
         epic_id: i64,

--- a/crates/agileplus-domain/src/ports/story.rs
+++ b/crates/agileplus-domain/src/ports/story.rs
@@ -1,18 +1,15 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 //! Story repository port.
 
-use async_trait::async_trait;
-
 use crate::domain::story::{Story, StoryStatus};
 use crate::error::DomainError;
 
 /// Repository port for Story aggregates.
-#[async_trait]
 pub trait StoryRepository: Send + Sync {
-    async fn create(&self, story: &Story) -> Result<i64, DomainError>;
-    async fn get_by_id(&self, id: i64) -> Result<Option<Story>, DomainError>;
-    async fn update_status(&self, id: i64, status: StoryStatus) -> Result<(), DomainError>;
-    async fn list_by_epic(&self, epic_id: i64) -> Result<Vec<Story>, DomainError>;
+    fn create(&self, story: &Story) -> Result<i64, DomainError>;
+    fn get_by_id(&self, id: i64) -> Result<Option<Story>, DomainError>;
+    fn update_status(&self, id: i64, status: StoryStatus) -> Result<(), DomainError>;
+    fn list_by_epic(&self, epic_id: i64) -> Result<Vec<Story>, DomainError>;
 
     /// Upsert a story keyed by `story.requirement_id`.
     ///
@@ -27,7 +24,7 @@ pub trait StoryRepository: Send + Sync {
     /// The default implementation performs a get-then-insert/update using
     /// the base `create` / `get_by_id` methods.  Adapters with native
     /// SQL UPSERT support should override this for efficiency.
-    async fn upsert_by_requirement_id(&self, story: &Story) -> Result<i64, DomainError> {
+    fn upsert_by_requirement_id(&self, story: &Story) -> Result<i64, DomainError> {
         let req_id = story.requirement_id.as_deref().ok_or_else(|| {
             DomainError::Validation(
                 "upsert_by_requirement_id requires story.requirement_id to be set".to_string(),
@@ -37,16 +34,16 @@ pub trait StoryRepository: Send + Sync {
         // Walk all stories for this epic and check for a match.
         // This default impl is O(n) per epic and intended only as a
         // portable fallback; adapters should override with an indexed query.
-        let candidates = self.list_by_epic(story.epic_id).await?;
+        let candidates = self.list_by_epic(story.epic_id)?;
         if let Some(existing) = candidates
             .iter()
             .find(|s| s.requirement_id.as_deref() == Some(req_id))
         {
             // Update status to reflect latest GitHub state.
-            self.update_status(existing.id, story.status).await?;
+            self.update_status(existing.id, story.status)?;
             Ok(existing.id)
         } else {
-            self.create(story).await
+            self.create(story)
         }
     }
 }

--- a/crates/agileplus-domain/src/ports/traceability_port.rs
+++ b/crates/agileplus-domain/src/ports/traceability_port.rs
@@ -2,7 +2,6 @@
 //! external traceability systems (e.g. Tracera).
 
 use async_trait::async_trait;
-use uuid::Uuid;
 
 use crate::error::DomainError;
 use crate::traceability::TraceRef;
@@ -14,9 +13,9 @@ use crate::traceability::TraceRef;
 #[async_trait]
 pub trait TraceabilityPort: Send + Sync {
     /// Create or update a link from a domain entity to a traced artifact.
-    async fn link_trace(&self, entity_id: Uuid, trace_ref: TraceRef) -> Result<(), DomainError>;
+    async fn link_trace(&self, entity_id: String, trace_ref: TraceRef) -> Result<(), DomainError>;
 
     /// Retrieve all trace links for a given domain entity.
     /// Returns an empty `Vec` when no traces exist (not an error).
-    async fn get_traces(&self, entity_id: Uuid) -> Result<Vec<TraceRef>, DomainError>;
+    async fn get_traces(&self, entity_id: String) -> Result<Vec<TraceRef>, DomainError>;
 }


### PR DESCRIPTION
## **User description**
Fixes domain zero-dep lint. Removes async-trait and uuid from Cargo.toml. Makes async trait methods sync. Replaces Uuid types with String.


___

## **CodeAnt-AI Description**
**Remove unused dependencies and switch domain ports to plain string IDs**

### What Changed
- Domain repository and sync ports now use regular synchronous calls instead of async trait-based definitions.
- Trace links now use string-based entity IDs instead of UUIDs, and the no-op trace adapter was updated to match.
- The default story upsert flow now runs synchronously while keeping the same find-or-create behavior.
- Security scans no longer include C/C++ checks in repositories that do not contain C++ code.

### Impact
`✅ Fewer domain build failures`
`✅ Simpler trace linking across adapters`
`✅ Cleaner security scans in non-C++ repos`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
