### PR TITLE
ci(gitleaks): baseline allowlist

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,6 @@
+[extend]
+useDefault = true
+
+[[rules.allowlist]]
+description = "Cargo.lock"
+paths = ["Cargo.lock"]


### PR DESCRIPTION
## Summary

Adds .gitleaks.toml baseline allowlist to prevent false positives on secret scanning.

## Stack Topology

- **Head branch**: `fix/agileplus-gitleaks`
- **Base branch**: `main`
- **Lane**: automated composer/forge lane (layered-pr-exception)
- **Kitty-spec**: `kitty-specs/eco-045-gitleaks-baseline/`

spec: eco-045-gitleaks-baseline

## Validation

- [x] Governance template sections present (Summary, Stack Topology, Validation, Governance, CI Exception)
- [x] Kitty-spec registered on main via governance compliance PR (eco-035..047)
- [ ] Local tests (deferred to lane author; no billed CI per policy)
- [ ] Rebase on main after governance compliance merge for spec-first directory presence

## Governance

- [x] Conventional Commit PR title (lowercase subject)
- [x] `spec: eco-045-gitleaks-baseline` traceability line
- [x] `layered-pr-exception` label for direct-to-main automated lanes
- [x] policy-gate / pr-governance-gate / spec-first alignment (metadata-only; gates not weakened)

## CI Exception

`layered-pr-exception`: automated lane targets `main` directly per stack rollout policy. No `ci-billing-exception`. Rebase on main after kitty-spec registration lands to satisfy spec-first on branch head.
