### PR TITLE
spec: agileplus adr expansion

### DIFF
--- a/docs/adr/0007-governance-contract-model.md
+++ b/docs/adr/0007-governance-contract-model.md
@@ -1,0 +1,41 @@
+# ADR-0007: Governance Contract Model
+
+## Status
+
+Accepted
+
+## Context
+
+AgilePlus gates feature lifecycle transitions (spec → ship) with versioned rules and
+evidence requirements. That vocabulary was duplicated in `agileplus-domain` while Tracera
+and other Phenotype consumers need the same semantics. ADR-0005 moved shared types to
+[`traceability-core`](https://github.com/KooshaPari/phenotype-pm-core) (PM-core spine).
+
+## Decision
+
+1. **Canonical types** live in `traceability-core::governance`:
+   `GovernanceContract`, `GovernanceRule`, `EvidenceRequirement`, `EvidenceType`,
+   `PolicyRule`, and `BuiltinPolicy`.
+2. **Contracts are immutable** once bound to a feature (`bound_at` set). Policy changes
+   create a new contract version; prior versions remain auditable.
+3. **Rules are transition-scoped**: each `GovernanceRule` names a lifecycle transition
+   (e.g. `Review → Approved`) and lists required evidence (`fr_id` + `EvidenceType`) and
+   optional `policy_refs`.
+4. **AgilePlus owns authoring and persistence** (`agileplus-domain` re-exports,
+   `agileplus-sqlite` stores). **Tracera reads** contracts for gate evaluation but does
+   not author them.
+5. **CLI/API surface**: `governance:check:gates`, `governance:evaluate:policy`, and
+   `GetGovernanceContract` operate on spine types, not local duplicates.
+
+## Consequences
+
+- Single governance vocabulary across AgilePlus, Tracera, and future PM consumers.
+- Feature promotion fails closed when required evidence or policies are missing.
+- Contract versioning adds storage overhead but preserves audit trail for compliance.
+- Local policy extensions stay in `PolicyRule` registry; contracts reference by id only.
+
+## References
+
+- ADR-0005: traceability-core git dependency
+- `crates/traceability-core/src/governance.rs`
+- `docs/specs/NFR-AP-001-traceability-requirements.md`

--- a/docs/adr/0008-intent-graph-ontology.md
+++ b/docs/adr/0008-intent-graph-ontology.md
@@ -1,0 +1,40 @@
+# ADR-0008: Intent Graph Ontology
+
+## Status
+
+Accepted
+
+## Context
+
+User intent must trace from prompt → spec → code → test → PR without ad-hoc link tables.
+AgilePlus and `agileplus-mcp-intent` need a shared, validated graph model. The PM-core
+spine (`traceability-core::intent_graph`) is the org-wide source for node types, DAG
+stages, and relationship semantics.
+
+## Decision
+
+1. **Canonical model**: `IntentGraph` with typed `Node` (`NodeType`: Intent, Plan, Feature,
+   Story, Task, Spec, Commit, Test, PR, Bug, Artifact), `Edge` (`RelationshipType`), and
+   `DagStage` ordering.
+2. **Human source, machine derivative**: Markdown intent artifacts and kitty-specs are the
+   human-readable source of truth; JSON intent graphs are validated derivatives (see
+   `convert_prompt_to_intent_graph` in agileplus-mcp-intent).
+3. **Validation at ingest**: `IntentGraph::validate()` enforces acyclic DAG constraints,
+   allowed node/edge combinations, and canonical link types before persistence or MCP export.
+4. **Traceability bridge**: Intent-graph nodes link to spine artifacts (`ArtifactRef`,
+   `RequirementId`) and coverage-matrix rows; they do not replace Tracera trace links.
+5. **AgilePlus re-exports** spine types from `agileplus-domain`; no parallel ontology.
+
+## Consequences
+
+- Agents and CLI tools share one intent vocabulary across repos.
+- Invalid graphs are rejected at authoring time, not at ship gate.
+- Graph validation logic is centralized in PM-core; AgilePlus consumes updates via
+  `cargo update -p traceability-core`.
+- MCP intent tooling and kitty-specs must align node ids with graph validation rules.
+
+## References
+
+- ADR-0005: traceability-core git dependency
+- `crates/traceability-core/src/intent_graph.rs`
+- `docs/superpowers/specs/2026-06-14-intent-artifact-design.md`

--- a/docs/adr/0009-claim-engine.md
+++ b/docs/adr/0009-claim-engine.md
@@ -1,0 +1,43 @@
+# ADR-0009: Claim Engine
+
+## Status
+
+Accepted
+
+## Context
+
+Two claim domains overlap in AgilePlus: (a) **traceability claims** — assertions that a
+layer or transition is satisfied (evidence present, acceptance met, implementation linked);
+(b) **resource claims** — exclusive agent ownership of repo/branch/worktree during execution.
+Without a unified evaluation model, gates and triage drift apart.
+
+## Decision
+
+1. **Spine claim evaluation** (traceability): `ProgressionGate` in
+   `traceability-core::contract` is the claim engine for layer advancement. It evaluates
+   `GatePredicate` values (`not_approved`, `missing_acceptance`, `missing_evidence`,
+   `missing_implementation`, `missing_test`) against a `GateContext` built from spine
+   types (`Requirement`, `AcceptanceContract`, `CoverageMatrix`, `Evidence`).
+2. **Governance claims** compose with progression: lifecycle transitions consult
+   `GovernanceContract` rules first; progression gates enforce artifact-level claims second.
+3. **Resource claims** (orchestration): `agileplus-triage::ClaimStore` handles TTL/heartbeat
+   resource locks (`ClaimKind`: Repo, Branch, Worktree, Subproject). Structured `ClaimReason`
+   ties locks to work-package ids — not free-form strings.
+4. **Fail closed**: any failing predicate or expired resource claim blocks the requested
+   action; no silent downgrade to ungated paths.
+5. **Tracera** evaluates progression/governance claims read-only; resource claims stay
+   local to AgilePlus CLI/agent runtime.
+
+## Consequences
+
+- One predicate vocabulary for "why was this blocked?" across API, CLI, and BDD fixtures.
+- Agent coordination and traceability gates share FR/WP identifiers in claim reasons.
+- Claim evaluation is deterministic and testable without I/O (pure spine functions + in-memory store).
+- New predicates require a spine change and semver bump in `traceability-core`.
+
+## References
+
+- ADR-0007: governance contract model
+- ADR-0010: acceptance contract and progression gates
+- `crates/traceability-core/src/contract.rs` (`ProgressionGate`, `GateContext`)
+- `crates/agileplus-triage/src/claim.rs`

--- a/docs/adr/0010-acceptance-contract-progression-gates.md
+++ b/docs/adr/0010-acceptance-contract-progression-gates.md
@@ -1,0 +1,44 @@
+# ADR-0010: Acceptance Contract and Progression Gates
+
+## Status
+
+Accepted
+
+## Context
+
+Stories and features cannot reach terminal states without testable acceptance criteria linked
+to evidence. Tracera owns coverage matrices; AgilePlus owns authoring. NFR-AP-001 requires
+verified acceptance before `Done`. The PM-core spine adds `AcceptanceContract` and
+matrix-backed satisfaction checks so both sides share one contract shape.
+
+## Decision
+
+1. **AcceptanceContract** (`traceability-core::contract`) binds to an `ArtifactRef` and
+   holds `Criterion` entries (`id`, `test_ref`, `evidence_ref`), optional `GherkinRef`
+   scenarios, and a `VerificationMethod`.
+2. **Satisfaction is matrix-derived**: `AcceptanceContract::is_satisfied(matrix)` returns
+   true only when every criterion maps to a `CoverageState::Covered` cell in the supplied
+   `CoverageMatrix` — no ad-hoc boolean flags.
+3. **Layer stack**: `Layer` enum orders Intent → IntentDoc → SpecAdr → PlanWbs → Execution
+   → Evidence. `ProgressionGate` pairs `(from_layer, to_layer)` with predicates; advancement
+   requires prior layer claims to pass (ADR-0009).
+4. **Ship gate**: AgilePlus domain/CLI reject transitions to terminal states when acceptance
+   is unsatisfied or criteria list is empty.
+5. **BDD linkage**: Gherkin refs are advisory metadata; matrix coverage remains the
+   authoritative satisfaction signal for automation.
+
+## Consequences
+
+- FR/NFR traceability and acceptance criteria share one coverage matrix (Tracera builds,
+  AgilePlus consumes).
+- Unsatisfied criteria are enumerable via `unsatisfied_criteria()` for agent remediation loops.
+- Empty criteria contracts are always rejected — prevents "Done" without testable bar.
+- Contract schema changes propagate via PM-core; AgilePlus avoids local acceptance DTOs.
+
+## References
+
+- ADR-0005: traceability-core git dependency
+- ADR-0009: claim engine
+- `crates/traceability-core/src/contract.rs`
+- `docs/specs/FR-AP-001-domain-entities.md` (§ AcceptanceContract)
+- `docs/specs/NFR-AP-001-traceability-requirements.md`


### PR DESCRIPTION
## Summary

Adds ADRs for shared claim, intent, governance, and acceptance rules with fail-closed blocking behavior.

## Stack Topology

- **Head branch**: `spec/agileplus-adr-expansion`
- **Base branch**: `main`
- **Lane**: automated composer/forge lane (layered-pr-exception)
- **Kitty-spec**: `kitty-specs/eco-036-adr-expansion/`

spec: eco-036-adr-expansion

## Validation

- [x] Governance template sections present (Summary, Stack Topology, Validation, Governance, CI Exception)
- [x] Kitty-spec registered on main via governance compliance PR (eco-035..047)
- [ ] Local tests (deferred to lane author; no billed CI per policy)
- [ ] Rebase on main after governance compliance merge for spec-first directory presence

## Governance

- [x] Conventional Commit PR title (lowercase subject)
- [x] `spec: eco-036-adr-expansion` traceability line
- [x] `layered-pr-exception` label for direct-to-main automated lanes
- [x] policy-gate / pr-governance-gate / spec-first alignment (metadata-only; gates not weakened)

## CI Exception

`layered-pr-exception`: automated lane targets `main` directly per stack rollout policy. No `ci-billing-exception`. Rebase on main after kitty-spec registration lands to satisfy spec-first on branch head.
