### PR TITLE
feat(rust): wire dashboard web frontend to agileplus-api

### DIFF
--- a/.github/workflows/security-guard.yml
+++ b/.github/workflows/security-guard.yml
@@ -34,4 +34,4 @@ jobs:
         env:
           SKIP: legacy-tooling-scan
         with:
-          extra_args: --hook-stage pre-commit --config .pre-commit-config.yaml --show-diff-on-failure --skip legacy-tooling-scan
+          extra_args: --hook-stage pre-commit --config .pre-commit-config.yaml --show-diff-on-failure

--- a/crates/agileplus-dashboard/web/.env.development
+++ b/crates/agileplus-dashboard/web/.env.development
@@ -1,20 +1,6 @@
 # AgilePlus Dashboard — Development Environment
-# This file is used by Vite during development (npm run dev)
+# Used by Vite during `npm run dev`
 
-# API Configuration
-VITE_API_URL=http://localhost:3000
+# agileplus-api base URL (no trailing slash)
+VITE_API_BASE=http://localhost:3000
 VITE_API_TIMEOUT=30000
-
-# Development Mode
-VITE_DEV_MODE=true
-
-# Logging
-VITE_LOG_LEVEL=debug
-
-# Feature Flags (development)
-VITE_ENABLE_MOCK_DATA=false
-VITE_ENABLE_REACT_DEVTOOLS=true
-
-# Sentry (optional, disabled in dev)
-VITE_SENTRY_DSN=
-VITE_SENTRY_ENVIRONMENT=development

--- a/crates/agileplus-dashboard/web/.env.example
+++ b/crates/agileplus-dashboard/web/.env.example
@@ -1,0 +1,4 @@
+# Copy to .env.development for local dev (not committed).
+# agileplus-api base URL — no trailing slash
+VITE_API_BASE=http://localhost:3000
+VITE_API_TIMEOUT=30000

--- a/crates/agileplus-dashboard/web/package.json
+++ b/crates/agileplus-dashboard/web/package.json
@@ -5,33 +5,36 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
+    "axios": "^1.14.1",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "zustand": "^5.0.12",
-    "axios": "^1.14.1",
-    "clsx": "^2.1.1",
     "tailwind-merge": "^3.3.1",
-    "class-variance-authority": "^0.7.1"
+    "zustand": "^5.0.12"
   },
   "devDependencies": {
-    "@vitejs/plugin-react": "^5.1.0",
-    "typescript": "^5.9.3",
-    "vite": "^8.0.1",
-    "@types/react": "^19.2.0",
-    "@types/react-dom": "^19.2.0",
-    "tailwindcss": "^3.4.17",
-    "autoprefixer": "^10.4.21",
-    "postcss": "^8.5.6",
+    "@playwright/test": "^1.52.0",
     "@tailwindcss/vite": "^4.1.10",
-    "vitest": "^3.2.4",
-    "@vitest/coverage-v8": "^3.2.4",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
-    "@testing-library/jest-dom": "^6.6.3",
+    "@types/react": "^19.2.0",
+    "@types/react-dom": "^19.2.0",
+    "@vitejs/plugin-react": "^5.1.0",
+    "@vitest/coverage-v8": "^3.2.4",
+    "autoprefixer": "^10.4.21",
     "jsdom": "^26.1.0",
-    "@playwright/test": "^1.52.0"
+    "postcss": "^8.5.6",
+    "tailwindcss": "^3.4.17",
+    "typescript": "^5.9.3",
+    "vite": "^8.0.1",
+    "vitest": "^3.2.4"
   }
 }

--- a/crates/agileplus-dashboard/web/postcss.config.js
+++ b/crates/agileplus-dashboard/web/postcss.config.js
@@ -1,6 +1,6 @@
 export default {
   plugins: {
-    '@tailwindcss/postcss': {},
+    tailwindcss: {},
     autoprefixer: {},
   },
 }

--- a/crates/agileplus-dashboard/web/src/App.tsx
+++ b/crates/agileplus-dashboard/web/src/App.tsx
@@ -1,25 +1,9 @@
 import React, { useEffect, useState } from 'react';
-import axios from 'axios';
-import { useAgilePlusStore } from './stores/agileplus';
+import { useDashboardData } from './hooks/useDashboardData';
+import { useWorkPackages } from './hooks/useWorkPackages';
 import { Button, Badge, Card, Pill, Modal, Toast } from './components';
+import type { ApiEpic, ApiStory } from './types/api';
 import './styles/globals.css';
-
-// ─── Types ────────────────────────────────────────────────────────────────────
-
-interface Epic {
-  id: number;
-  title: string;
-  status: string;
-  requirement_id: string | null;
-}
-
-interface Story {
-  id: number;
-  epic_id: number | null;
-  title: string;
-  status: string;
-  requirement_id: string | null;
-}
 
 type View = 'dashboard' | 'epics' | 'stories' | 'evidence';
 
@@ -39,7 +23,7 @@ function epicBadgeVariant(status: string): 'success' | 'warning' | 'error' | 'in
 
 // ─── Seed / demo data (used when API is unreachable) ─────────────────────────
 
-const SEED_EPICS: Epic[] = [
+const SEED_EPICS: ApiEpic[] = [
   { id: 1, title: 'Core domain entities', status: 'Done', requirement_id: 'FR-AGP-001' },
   { id: 2, title: 'SQLite persistence layer', status: 'Done', requirement_id: 'FR-AGP-002' },
   { id: 3, title: 'Axum REST API', status: 'In Progress', requirement_id: 'FR-AGP-003' },
@@ -48,7 +32,7 @@ const SEED_EPICS: Epic[] = [
   { id: 6, title: 'Plane.so integration', status: 'Planned', requirement_id: 'FR-AGP-018' },
 ];
 
-const SEED_STORIES: Story[] = [
+const SEED_STORIES: ApiStory[] = [
   { id: 1, epic_id: 1, title: 'Define Epic/Story/WorkPackage value objects', status: 'Done', requirement_id: null },
   { id: 2, epic_id: 1, title: 'Add requirement traceability links', status: 'Done', requirement_id: null },
   { id: 3, epic_id: 2, title: 'SQLite migrations for all domain tables', status: 'Done', requirement_id: null },
@@ -98,7 +82,7 @@ function Nav({ activeView, onNav }: NavProps) {
 
 // ─── Dashboard view ────────────────────────────────────────────────────────────
 
-function DashboardView({ epics, stories }: { epics: Epic[]; stories: Story[] }) {
+function DashboardView({ epics, stories }: { epics: ApiEpic[]; stories: ApiStory[] }) {
   const done = epics.filter((e) => e.status.toLowerCase() === 'done').length;
   const inProgress = epics.filter((e) => ['in_progress', 'in progress'].includes(e.status.toLowerCase())).length;
   const planned = epics.filter((e) => e.status.toLowerCase() === 'planned').length;
@@ -153,8 +137,8 @@ function DashboardView({ epics, stories }: { epics: Epic[]; stories: Story[] }) 
 
 // ─── Epics view ────────────────────────────────────────────────────────────────
 
-function EpicsView({ epics, stories }: { epics: Epic[]; stories: Story[] }) {
-  const [selectedEpic, setSelectedEpic] = useState<Epic | null>(null);
+function EpicsView({ epics, stories }: { epics: ApiEpic[]; stories: ApiStory[] }) {
+  const [selectedEpic, setSelectedEpic] = useState<ApiEpic | null>(null);
 
   return (
     <div>
@@ -241,7 +225,7 @@ function EpicsView({ epics, stories }: { epics: Epic[]; stories: Story[] }) {
 
 // ─── Stories view ──────────────────────────────────────────────────────────────
 
-function StoriesView({ epics, stories }: { epics: Epic[]; stories: Story[] }) {
+function StoriesView({ epics, stories }: { epics: ApiEpic[]; stories: ApiStory[] }) {
   const [filterEpic, setFilterEpic] = useState<number | 'all'>('all');
   const [filterStatus, setFilterStatus] = useState<string>('all');
 
@@ -347,57 +331,21 @@ function EvidenceGalleryView() {
 // ─── Root App ─────────────────────────────────────────────────────────────────
 
 export function App() {
-  const setWorkPackages = useAgilePlusStore((state) => state.setWorkPackages);
-  const setLoading = useAgilePlusStore((state) => state.setLoading);
+  const { epics: apiEpics, stories: apiStories, loading, error } = useDashboardData();
+  useWorkPackages();
 
   const [view, setView] = useState<View>('dashboard');
-  const [epics, setEpics] = useState<Epic[]>([]);
-  const [stories, setStories] = useState<Story[]>([]);
-  const [dataReady, setDataReady] = useState(false);
   const [toastMsg, setToastMsg] = useState<string | null>(null);
 
-  // Try live API, fall back to seed data
-  useEffect(() => {
-    setLoading(true);
-    axios
-      .get('/api/dashboard/epics-stories.json', { timeout: 3000 })
-      .then((res) => {
-        const data = res.data as { epics: Epic[]; stories: Story[] };
-        if (data.epics?.length) {
-          setEpics(data.epics);
-          setStories(data.stories ?? []);
-        } else {
-          setEpics(SEED_EPICS);
-          setStories(SEED_STORIES);
-        }
-      })
-      .catch(() => {
-        setEpics(SEED_EPICS);
-        setStories(SEED_STORIES);
-        setToastMsg('API offline — showing seed data');
-      })
-      .finally(() => {
-        setLoading(false);
-        setDataReady(true);
-      });
+  const epics = apiEpics.length > 0 ? apiEpics : loading ? [] : SEED_EPICS;
+  const stories = apiStories.length > 0 ? apiStories : loading ? [] : SEED_STORIES;
+  const dataReady = !loading;
 
-    // Also try the work-packages endpoint for the Zustand store
-    axios
-      .get('/api/dashboard/work-packages.json', { timeout: 3000 })
-      .then((res) => {
-        const data = res.data as { work_packages: any[] };
-        setWorkPackages(
-          (data.work_packages ?? []).map((wp: any) => ({
-            id: String(wp.id),
-            title: wp.title ?? '(untitled)',
-            status: wp.status ?? 'planned',
-            priority: wp.priority ?? 'medium',
-            assignee: wp.assignee ?? undefined,
-          }))
-        );
-      })
-      .catch(() => {/* no-op */});
-  }, [setWorkPackages, setLoading]);
+  useEffect(() => {
+    if (!loading && error && apiEpics.length === 0) {
+      setToastMsg('API offline — showing seed data');
+    }
+  }, [loading, error, apiEpics.length]);
 
   return (
     <div className="min-h-screen bg-gray-50">

--- a/crates/agileplus-dashboard/web/src/components/foundation/Button.test.tsx
+++ b/crates/agileplus-dashboard/web/src/components/foundation/Button.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
 import { Button } from './Button';
 
 /**
@@ -86,7 +87,7 @@ describe('Button Component', () => {
   });
 
   it('does not trigger onClick when disabled', async () => {
-    const onClick = jest.fn();
+    const onClick = vi.fn();
     render(
       <Button disabled onClick={onClick}>
         Disabled
@@ -101,14 +102,14 @@ describe('Button Component', () => {
   // ============================================================================
 
   it('calls onClick handler on click', async () => {
-    const onClick = jest.fn();
+    const onClick = vi.fn();
     render(<Button onClick={onClick}>Click</Button>);
     await userEvent.click(screen.getByRole('button'));
     expect(onClick).toHaveBeenCalledTimes(1);
   });
 
   it('triggers on keyboard enter', async () => {
-    const onClick = jest.fn();
+    const onClick = vi.fn();
     render(<Button onClick={onClick}>Click</Button>);
     const button = screen.getByRole('button');
     button.focus();

--- a/crates/agileplus-dashboard/web/src/components/foundation/Input.test.tsx
+++ b/crates/agileplus-dashboard/web/src/components/foundation/Input.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
 import { Input } from './Input';
 
 /**
@@ -43,13 +44,13 @@ describe('Input Component', () => {
   });
 
   it('renders password input type', () => {
-    render(<Input type="password" />);
-    expect(screen.getByRole('textbox')).toHaveAttribute('type', 'password');
+    const { container } = render(<Input type="password" />);
+    expect(container.querySelector('input[type="password"]')).toBeInTheDocument();
   });
 
   it('renders number input type', () => {
     render(<Input type="number" />);
-    expect(screen.getByRole('textbox')).toHaveAttribute('type', 'number');
+    expect(screen.getByRole('spinbutton')).toHaveAttribute('type', 'number');
   });
 
   // ============================================================================
@@ -57,7 +58,7 @@ describe('Input Component', () => {
   // ============================================================================
 
   it('handles onChange event', async () => {
-    const onChange = jest.fn();
+    const onChange = vi.fn();
     render(<Input onChange={onChange} />);
     const input = screen.getByRole('textbox');
 

--- a/crates/agileplus-dashboard/web/src/hooks/useDashboardData.ts
+++ b/crates/agileplus-dashboard/web/src/hooks/useDashboardData.ts
@@ -1,0 +1,56 @@
+import { useEffect, useState } from 'react';
+import { fetchDashboardEpicsStories } from '../lib/api/client';
+import type { ApiEpic, ApiStory } from '../types/api';
+
+interface UseDashboardDataResult {
+  epics: ApiEpic[];
+  stories: ApiStory[];
+  loading: boolean;
+  error: string | null;
+}
+
+/**
+ * Fetches main dashboard epics/stories from agileplus-api.
+ */
+export function useDashboardData(): UseDashboardDataResult {
+  const [epics, setEpics] = useState<ApiEpic[]>([]);
+  const [stories, setStories] = useState<ApiStory[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const data = await fetchDashboardEpicsStories();
+        if (cancelled) return;
+        if (data.error) setError(data.error);
+        setEpics(data.epics ?? []);
+        setStories(data.stories ?? []);
+      } catch (err) {
+        if (cancelled) return;
+        const message =
+          err instanceof Error ? err.message : 'Failed to load dashboard data';
+        setError(
+          `API unavailable: ${message}. Start agileplus-api (default :3000).`,
+        );
+        setEpics([]);
+        setStories([]);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return { epics, stories, loading, error };
+}
+
+export default useDashboardData;

--- a/crates/agileplus-dashboard/web/src/hooks/useWorkPackages.ts
+++ b/crates/agileplus-dashboard/web/src/hooks/useWorkPackages.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import axios from 'axios';
+import { fetchDashboardWorkPackages } from '../lib/api/client';
 import { useAgilePlusStore } from '../stores/agileplus';
 import type { WorkPackage } from '../types';
 
@@ -10,6 +10,22 @@ import type { WorkPackage } from '../types';
 
 interface UseWorkPackagesOptions {
   skip?: boolean;
+}
+
+function toWorkPackage(wp: {
+  id: string;
+  title?: string;
+  status?: string;
+  priority?: string;
+  assignee?: string | null;
+}): WorkPackage {
+  return {
+    id: String(wp.id),
+    title: wp.title ?? '(untitled)',
+    status: (wp.status ?? 'planned') as WorkPackage['status'],
+    priority: (wp.priority ?? 'medium') as WorkPackage['priority'],
+    assignee: wp.assignee ?? undefined,
+  };
 }
 
 /**
@@ -26,19 +42,27 @@ export function useWorkPackages(options: UseWorkPackagesOptions = {}) {
   useEffect(() => {
     if (skip) return;
 
-    const fetchWorkPackages = async () => {
+    let cancelled = false;
+
+    const load = async () => {
       setLoading(true);
       try {
-        const response = await axios.get<WorkPackage[]>('/api/work-packages');
-        setWorkPackages(response.data);
+        const data = await fetchDashboardWorkPackages();
+        if (cancelled) return;
+        setWorkPackages((data.work_packages ?? []).map(toWorkPackage));
       } catch (error) {
-        console.error('Failed to fetch work packages:', error);
+        if (!cancelled) {
+          console.error('Failed to fetch work packages:', error);
+        }
       } finally {
-        setLoading(false);
+        if (!cancelled) setLoading(false);
       }
     };
 
-    fetchWorkPackages();
+    void load();
+    return () => {
+      cancelled = true;
+    };
   }, [skip, setWorkPackages, setLoading]);
 
   return {

--- a/crates/agileplus-dashboard/web/src/lib/api/client.ts
+++ b/crates/agileplus-dashboard/web/src/lib/api/client.ts
@@ -1,0 +1,36 @@
+import axios, { type AxiosInstance } from 'axios';
+import type {
+  EpicsStoriesResponse,
+  WorkPackagesResponse,
+} from '../../types/api';
+import { API_TIMEOUT_MS, getApiBase } from './config';
+
+let client: AxiosInstance | null = null;
+
+/** Shared axios instance targeting agileplus-api. */
+export function getApiClient(): AxiosInstance {
+  if (!client) {
+    client = axios.create({
+      baseURL: getApiBase(),
+      timeout: API_TIMEOUT_MS,
+      headers: { Accept: 'application/json' },
+    });
+  }
+  return client;
+}
+
+/** Dashboard epics + stories (GET /api/dashboard/epics-stories.json). */
+export async function fetchDashboardEpicsStories(): Promise<EpicsStoriesResponse> {
+  const { data } = await getApiClient().get<EpicsStoriesResponse>(
+    '/api/dashboard/epics-stories.json',
+  );
+  return data;
+}
+
+/** All work packages (GET /api/dashboard/work-packages.json). */
+export async function fetchDashboardWorkPackages(): Promise<WorkPackagesResponse> {
+  const { data } = await getApiClient().get<WorkPackagesResponse>(
+    '/api/dashboard/work-packages.json',
+  );
+  return data;
+}

--- a/crates/agileplus-dashboard/web/src/lib/api/config.ts
+++ b/crates/agileplus-dashboard/web/src/lib/api/config.ts
@@ -1,0 +1,10 @@
+const DEFAULT_API_BASE = 'http://localhost:3000';
+
+/** agileplus-api base URL (no trailing slash). */
+export function getApiBase(): string {
+  const raw = import.meta.env.VITE_API_BASE?.trim();
+  const base = raw && raw.length > 0 ? raw : DEFAULT_API_BASE;
+  return base.replace(/\/$/, '');
+}
+
+export const API_TIMEOUT_MS = Number(import.meta.env.VITE_API_TIMEOUT) || 30_000;

--- a/crates/agileplus-dashboard/web/src/main.tsx
+++ b/crates/agileplus-dashboard/web/src/main.tsx
@@ -1,25 +1,9 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import ReactDOM from 'react-dom/client';
-import axios from 'axios';
-import { useAgilePlusStore } from './stores/agileplus';
+import { useDashboardData } from './hooks/useDashboardData';
+import { useWorkPackages } from './hooks/useWorkPackages';
+import type { ApiEpic, ApiStory } from './types/api';
 import './styles/globals.css';
-
-// ── Types ──────────────────────────────────────────────────────────────────
-
-interface Epic {
-  id: number;
-  title: string;
-  status: string;
-  requirement_id: string | null;
-}
-
-interface Story {
-  id: number;
-  epic_id: number | null;
-  title: string;
-  status: string;
-  requirement_id: string | null;
-}
 
 // ── Styles ─────────────────────────────────────────────────────────────────
 
@@ -113,8 +97,8 @@ function DashboardView({
   workPackageCount,
   loading,
 }: {
-  epics: Epic[];
-  stories: Story[];
+  epics: ApiEpic[];
+  stories: ApiStory[];
   workPackageCount: number;
   loading: boolean;
 }) {
@@ -173,7 +157,7 @@ function DashboardView({
   );
 }
 
-function EpicsView({ epics, stories, loading }: { epics: Epic[]; stories: Story[]; loading: boolean }) {
+function EpicsView({ epics, stories, loading }: { epics: ApiEpic[]; stories: ApiStory[]; loading: boolean }) {
   if (loading) return <p style={{ color: '#64748b' }}>Loading epics…</p>;
   return (
     <div>
@@ -182,7 +166,7 @@ function EpicsView({ epics, stories, loading }: { epics: Epic[]; stories: Story[
       </h2>
       {epics.length === 0 && (
         <div style={CARD}>
-          <p style={{ margin: 0, color: '#94a3b8' }}>No epics found. Make sure the backend API is running on :4000.</p>
+          <p style={{ margin: 0, color: '#94a3b8' }}>No epics found. Make sure agileplus-api is running (default :3000).</p>
         </div>
       )}
       {epics.map((epic) => {
@@ -212,7 +196,7 @@ function EpicsView({ epics, stories, loading }: { epics: Epic[]; stories: Story[
   );
 }
 
-function StoriesView({ epics, stories, loading }: { epics: Epic[]; stories: Story[]; loading: boolean }) {
+function StoriesView({ epics, stories, loading }: { epics: ApiEpic[]; stories: ApiStory[]; loading: boolean }) {
   const [filterEpic, setFilterEpic] = useState<number | null>(null);
   const [filterStatus, setFilterStatus] = useState<string>('');
 
@@ -285,7 +269,7 @@ function StoriesView({ epics, stories, loading }: { epics: Epic[]; stories: Stor
   );
 }
 
-function EvidenceView({ epics, stories }: { epics: Epic[]; stories: Story[] }) {
+function EvidenceView({ epics, stories }: { epics: ApiEpic[]; stories: ApiStory[] }) {
   const tracedEpics = epics.filter((e) => e.requirement_id);
   const tracedStories = stories.filter((s) => s.requirement_id);
   const coverage = stories.length > 0 ? Math.round((tracedStories.length / stories.length) * 100) : 0;
@@ -337,55 +321,9 @@ function EvidenceView({ epics, stories }: { epics: Epic[]; stories: Story[] }) {
 type View = 'dashboard' | 'epics' | 'stories' | 'evidence';
 
 function App() {
-  const workPackages = useAgilePlusStore((state) => state.workPackages);
-  const loading = useAgilePlusStore((state) => state.loading);
-  const setWorkPackages = useAgilePlusStore((state) => state.setWorkPackages);
-  const setLoading = useAgilePlusStore((state) => state.setLoading);
-
-  const [epics, setEpics] = useState<Epic[]>([]);
-  const [stories, setStories] = useState<Story[]>([]);
-  const [epicStoriesLoading, setEpicStoriesLoading] = useState(true);
+  const { workPackages } = useWorkPackages();
+  const { epics, stories, loading: epicStoriesLoading, error: apiError } = useDashboardData();
   const [view, setView] = useState<View>('dashboard');
-  const [apiError, setApiError] = useState<string | null>(null);
-
-  // Fetch work packages
-  useEffect(() => {
-    setLoading(true);
-    axios
-      .get('/api/dashboard/work-packages.json')
-      .then((res) => {
-        const data = res.data as { work_packages: any[] };
-        setWorkPackages(
-          (data.work_packages ?? []).map((wp: any) => ({
-            id: String(wp.id),
-            title: wp.title ?? '(untitled)',
-            status: wp.status ?? 'planned',
-            priority: wp.priority ?? 'medium',
-            assignee: wp.assignee ?? undefined,
-          })),
-        );
-      })
-      .catch(() => {})
-      .finally(() => setLoading(false));
-  }, [setWorkPackages, setLoading]);
-
-  // Fetch epics + stories
-  useEffect(() => {
-    setEpicStoriesLoading(true);
-    setApiError(null);
-    axios
-      .get('/api/dashboard/epics-stories.json')
-      .then((res) => {
-        const data = res.data as { epics: Epic[]; stories: Story[]; error?: string };
-        if (data.error) setApiError(data.error);
-        setEpics(data.epics ?? []);
-        setStories(data.stories ?? []);
-      })
-      .catch((err) => {
-        setApiError(`API unavailable: ${err.message}. Start backend with API_PORT=4000 DATABASE_PATH=agileplus.db`);
-      })
-      .finally(() => setEpicStoriesLoading(false));
-  }, []);
 
   const views: { id: View; label: string }[] = [
     { id: 'dashboard', label: 'Dashboard' },

--- a/crates/agileplus-dashboard/web/src/types/api.ts
+++ b/crates/agileplus-dashboard/web/src/types/api.ts
@@ -1,0 +1,42 @@
+/**
+ * API response types matching agileplus-api dashboard JSON endpoints.
+ */
+
+export interface ApiEpic {
+  id: number;
+  title: string;
+  status: string;
+  requirement_id: string | null;
+}
+
+export interface ApiStory {
+  id: number;
+  epic_id: number | null;
+  title: string;
+  status: string;
+  requirement_id: string | null;
+}
+
+export interface EpicsStoriesResponse {
+  epics: ApiEpic[];
+  stories: ApiStory[];
+  epic_count?: number;
+  story_count?: number;
+  timestamp?: string;
+  error?: string;
+}
+
+export interface ApiWorkPackage {
+  id: string;
+  feature_id?: number;
+  title: string;
+  status: string;
+  priority: string;
+  assignee?: string | null;
+}
+
+export interface WorkPackagesResponse {
+  work_packages: ApiWorkPackage[];
+  count?: number;
+  timestamp?: string;
+}

--- a/crates/agileplus-dashboard/web/src/vite-env.d.ts
+++ b/crates/agileplus-dashboard/web/src/vite-env.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_BASE?: string;
+  readonly VITE_API_TIMEOUT?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/crates/agileplus-dashboard/web/tsconfig.json
+++ b/crates/agileplus-dashboard/web/tsconfig.json
@@ -18,5 +18,5 @@
     "types": ["vite/client"]
   },
   "include": ["src"],
-  "references": [{ "path": "./tsconfig.node.json" }]
+  "exclude": ["src/**/*.test.tsx", "src/**/*.stories.tsx", "src/test/**"]
 }

--- a/crates/agileplus-dashboard/web/vite.config.ts
+++ b/crates/agileplus-dashboard/web/vite.config.ts
@@ -1,24 +1,29 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'path'
 
-export default defineConfig({
-  plugins: [react()],
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src'),
-      '@/components': path.resolve(__dirname, './src/components'),
-      '@/lib': path.resolve(__dirname, './src/lib'),
-      '@/pages': path.resolve(__dirname, './src/pages'),
-    },
-  },
-  server: {
-    port: 5173,
-    proxy: {
-      '/api': {
-        target: 'http://localhost:3000',
-        changeOrigin: true,
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+  const apiBase = (env.VITE_API_BASE || 'http://localhost:3000').replace(/\/$/, '')
+
+  return {
+    plugins: [react()],
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, './src'),
+        '@/components': path.resolve(__dirname, './src/components'),
+        '@/lib': path.resolve(__dirname, './src/lib'),
+        '@/pages': path.resolve(__dirname, './src/pages'),
       },
     },
-  },
+    server: {
+      port: 5173,
+      proxy: {
+        '/api': {
+          target: apiBase,
+          changeOrigin: true,
+        },
+      },
+    },
+  }
 })

--- a/kitty-specs/eco-048-dashboard-web-api-wire/meta.json
+++ b/kitty-specs/eco-048-dashboard-web-api-wire/meta.json
@@ -1,0 +1,8 @@
+{
+  "spec_id": "eco-048",
+  "slug": "eco-048-dashboard-web-api-wire",
+  "title": "Dashboard Web API Wire",
+  "status": "active",
+  "created_at": "2026-06-26T00:00:00Z",
+  "type": "feature"
+}

--- a/kitty-specs/eco-048-dashboard-web-api-wire/plan.md
+++ b/kitty-specs/eco-048-dashboard-web-api-wire/plan.md
@@ -1,0 +1,7 @@
+# Plan: Dashboard Web API Wire
+
+1. Add typed axios client (`src/lib/api/`) with `VITE_API_BASE` config
+2. Add `useDashboardData` hook for epics/stories fetch
+3. Update `useWorkPackages` to use the shared client
+4. Fix PostCSS/vitest deps so web quality gates pass locally
+5. Register kitty-spec and satisfy PR governance metadata

--- a/kitty-specs/eco-048-dashboard-web-api-wire/spec.md
+++ b/kitty-specs/eco-048-dashboard-web-api-wire/spec.md
@@ -1,0 +1,12 @@
+# eco-048: Dashboard Web API Wire
+
+## Goal
+Wire the Vite+React dashboard at `crates/agileplus-dashboard/web/` to agileplus-api
+using a typed client and live dashboard endpoints.
+
+## Acceptance Criteria
+- Typed API client uses `VITE_API_BASE` (default `http://localhost:3000`)
+- Main dashboard fetch uses `GET /api/dashboard/epics-stories.json`
+- Work packages use `GET /api/dashboard/work-packages.json`
+- `npm install --legacy-peer-deps`, `npm run dev`, and `npm run build` succeed
+- Linked PR references `spec: eco-048-dashboard-web-api-wire`

--- a/kitty-specs/eco-048-dashboard-web-api-wire/tasks.md
+++ b/kitty-specs/eco-048-dashboard-web-api-wire/tasks.md
@@ -1,0 +1,7 @@
+# Tasks: eco-048-dashboard-web-api-wire
+
+- [x] Add typed API client and response types
+- [x] Wire dashboard epics/stories and work-package fetches
+- [x] Verify `npm run typecheck`, `npm run test`, `npm run build`
+- [x] Register kitty-spec directory and meta.json
+- [ ] Merge PR to main


### PR DESCRIPTION
## Summary
- Add typed axios API client with configurable `VITE_API_BASE` (default `http://localhost:3000`)
- Wire main dashboard data fetch (`useDashboardData`) to `GET /api/dashboard/epics-stories.json`
- Wire work-package store (`useWorkPackages`) to `GET /api/dashboard/work-packages.json`
- Fix PostCSS/Tailwind build config and vitest deps for install/dev/build

## Stack Topology
- **Frontend:** `crates/agileplus-dashboard/web/` (Vite + React, port 5173)
- **API:** agileplus-api (Axum, default port 3000) serves dashboard JSON routes
- **Data flow:** React hooks → typed client → `/api/dashboard/*.json` on agileplus-api

## Validation
- [x] `npm install --legacy-peer-deps`
- [x] `npm run typecheck`
- [x] `npm run test` (34 tests)
- [x] `npm run build`
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace`
- [x] `cargo build --release`

## Governance
spec: eco-048-dashboard-web-api-wire
- [x] kitty-spec registered (`spec.md`, `plan.md`, `tasks.md`, `meta.json`)
- [x] security-guard pre-commit `--skip` arg removed (uses `SKIP` env only)

## CI Exception
layered-pr-exception

## Test plan
- [ ] Start agileplus-api on :3000
- [ ] `cd crates/agileplus-dashboard/web && npm install --legacy-peer-deps && npm run dev`
- [ ] Confirm dashboard loads epics/stories from API
- [ ] `npm run build` produces `dist/` without errors
