### PR TITLE
feat: gh-release binaries (downloadable agileplus cli)

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -1,0 +1,88 @@
+name: Binaries
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+        description: "Release version"
+      dry_run:
+        required: false
+        type: boolean
+        default: false
+        description: "Run without publishing"
+    secrets:
+      GITHUB_TOKEN:
+        required: false
+
+permissions:
+  contents: write
+
+jobs:
+  binaries:
+    name: Build and publish (${{ matrix.target }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: linux-x86_64
+            archive: tar.gz
+            binary: agileplus
+            package: agileplus-linux-x86_64
+          - os: macos-latest
+            target: macos-arm64
+            archive: tar.gz
+            binary: agileplus
+            package: agileplus-macos-arm64
+          - os: windows-latest
+            target: windows-x86_64
+            archive: zip
+            binary: agileplus.exe
+            package: agileplus-windows-x86_64
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Build release binary
+        run: cargo build --release -p agileplus-cli
+
+      - name: Package binary
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          version="${{ inputs.version }}"
+          release_dir="release-assets"
+          package_dir="${release_dir}/${{ matrix.package }}"
+          archive_name="agileplus-${version}-${{ matrix.target }}.${{ matrix.archive }}"
+          binary_path="target/release/${{ matrix.binary }}"
+
+          mkdir -p "$package_dir"
+          cp "$binary_path" "$package_dir/"
+
+          if [ "${{ matrix.archive }}" = "zip" ]; then
+            (cd "$release_dir" && zip -r "../$archive_name" "${{ matrix.package }}")
+          else
+            tar -C "$release_dir" -czf "$archive_name" "${{ matrix.package }}"
+          fi
+
+          ls -la "$archive_name"
+
+      - name: Upload GitHub Release asset
+        if: ${{ !inputs.dry_run }}
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ inputs.version }}
+          files: agileplus-${{ inputs.version }}-${{ matrix.target }}.${{ matrix.archive }}
+          generate_release_notes: true
+          draft: false
+          prerelease: ${{ contains(inputs.version, '-') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,3 +60,10 @@ jobs:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
       CARGO_TOKEN: ${{ secrets.CARGO_TOKEN }}
+
+  binaries:
+    needs: gate-check
+    uses: ./.github/workflows/binaries.yml
+    with:
+      version: ${{ inputs.version }}
+      dry_run: ${{ inputs.dry_run }}


### PR DESCRIPTION
## **User description**
## Summary
- Added a reusable release workflow that builds `agileplus-cli` binaries for Linux x86_64, macOS arm64, and Windows x86_64.
- Packages each binary as `agileplus-${version}-${target}` and uploads it to the GitHub release via `softprops/action-gh-release@v2`.
- Wired the binary job into the main release orchestrator so the GH release is created alongside the existing publish flow.

## Validation
- `python -c "import yaml,sys; yaml.safe_load(open('.github/workflows/release.yml')); print('release.yml VALID')"`
- `python -c "import yaml,sys; yaml.safe_load(open('.github/workflows/binaries.yml')); print('binaries.yml VALID')"`

## Governance
- Spec: `eco-044-gate-triage`
- Scope is limited to release workflow automation for downloadable CLI artifacts.

## CI Exception
- No Cargo build or test commands were run, per request.


___

## **CodeAnt-AI Description**
**Add downloadable CLI binaries to the release flow**

### What Changed
- Release runs now build `agileplus-cli` binaries for Linux, macOS, and Windows
- Each build is packaged as a versioned release asset and attached to the GitHub release
- Pre-release versions are marked as prereleases, and dry runs skip publishing the assets

### Impact
`✅ Downloadable CLI releases`
`✅ One-step release packaging`
`✅ Clearer prerelease publishing`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
