### PR TITLE
Fix VitePress base path for phenotype.space

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,11 +1,9 @@
 import { createPhenotypeConfig } from '@phenotype/docs/config'
-
-const isPagesBuild = process.env.GITHUB_ACTIONS === 'true' || process.env.GITHUB_PAGES === 'true'
-const repoName = process.env.GITHUB_REPOSITORY?.split('/')[1] || 'AgilePlus'
-const docsBase = isPagesBuild ? `/${repoName}/` : '/'
-
 import { createSiteMeta } from './site-meta.mjs'
+import { resolveDocsBase } from './resolve-base.mjs'
 
+const repoName = process.env.GITHUB_REPOSITORY?.split('/')[1] || 'AgilePlus'
+const docsBase = resolveDocsBase(repoName)
 const siteMeta = createSiteMeta({ base: docsBase, repoName })
 
 export default createPhenotypeConfig(siteMeta)

--- a/docs/.vitepress/resolve-base.mjs
+++ b/docs/.vitepress/resolve-base.mjs
@@ -1,0 +1,9 @@
+export function resolveDocsBase(repoName) {
+  const explicit = process.env.DOCS_BASE ?? process.env.VITEPRESS_BASE;
+  if (explicit) {
+    return explicit.endsWith('/') ? explicit : `${explicit}/`;
+  }
+  if (process.env.PHENOTYPE_CUSTOM_DOMAIN === 'true') return '/';
+  if (process.env.GITHUB_PAGES === 'true') return `/${repoName}/`;
+  return '/';
+}


### PR DESCRIPTION
## **User description**
## Summary
- Add `docs/.vitepress/resolve-base.mjs` shared resolver
- Remove `GITHUB_ACTIONS`-based subpath detection from VitePress config

## Root cause
Builds set `base: '/AgilePlus/'` while `agileplus.phenotype.space` serves at `/`, so CSS loaded from `/AgilePlus/assets/...` 404s.

## Test plan
- [ ] Redeploy `agileplus.phenotype.space`
- [ ] Confirm homepage stylesheet uses `/assets/...` and returns 200

Made with [Cursor](https://cursor.com)


___

## **CodeAnt-AI Description**
**Fix docs asset URLs on custom-domain and GitHub Pages builds**

### What Changed
- Docs now choose the correct base path for the site instead of relying on GitHub Actions detection
- Custom-domain deployments serve assets from the site root, so styles and other files load from `/assets/...`
- GitHub Pages deployments still use the repository subpath, and explicit base settings are respected when provided

### Impact
`✅ Fewer broken styles on custom-domain docs sites`
`✅ Fewer 404s for docs assets`
`✅ Correct asset loading on GitHub Pages and local builds`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
