### PR TITLE
feat(release): cargo-dist installers (rebased)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ version = "0.1.0"
 edition = "2024"
 license = "MIT"
 rust-version = "1.88"
+repository = "https://github.com/KooshaPari/AgilePlus"
+homepage = "https://phenotype.space/agileplus"
+description = "AgilePlus — spec-first project management CLI (FR/NFR traceability)"
 
 [workspace.lints.rust]
 unsafe_code = "forbid"
@@ -19,6 +22,14 @@ unsafe_code = "forbid"
 [workspace.lints.clippy]
 all = "warn"
 pedantic = "warn"
+
+[workspace.metadata.dist]
+cargo-dist-version = "0.28.0"
+ci = ["github"]
+installers = ["shell", "powershell", "msi"]
+targets = ["x86_64-pc-windows-msvc", "x86_64-unknown-linux-gnu", "aarch64-apple-darwin", "x86_64-apple-darwin"]
+install-path = "CARGO_HOME"
+pr-run-mode = "plan"
 
 [workspace.dependencies]
 # Serialization

--- a/crates/agileplus-cli/Cargo.toml
+++ b/crates/agileplus-cli/Cargo.toml
@@ -4,11 +4,12 @@ version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/KooshaPari/AgilePlus"
-description = "agileplus cli — Phenotype infrastructure crate (AgilePlus)"
+repository.workspace = true
+homepage.workspace = true
+description.workspace = true
 documentation = "https://docs.rs/agileplus-cli"
-keywords = ["phenotype", "agileplus", "cli"]
-categories = ["command-line-utilities"]
+keywords = ["project-management", "traceability", "agile", "spec-first"]
+categories = ["command-line-utilities", "development-tools"]
 authors = ["kooshapari"]
 
 [[bin]]


### PR DESCRIPTION
Rebased clean version of #841.

This PR adds cargo-dist 0.28.0 configuration for automated releases on Windows (MSI), Linux, and macOS with shell/PowerShell installers. Updates workspace metadata with official repository, homepage, and description for crates.io.