### PR TITLE
feat(deploy): AgilePlus self-host stack

### DIFF
--- a/deploy/selfhost/Caddyfile
+++ b/deploy/selfhost/Caddyfile
@@ -1,0 +1,41 @@
+{$HOSTNAME} {
+	header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+	header X-Content-Type-Options "nosniff"
+	header X-Frame-Options "DENY"
+	header X-XSS-Protection "1; mode=block"
+	header Referrer-Policy "strict-origin-when-cross-origin"
+	header Permissions-Policy "geolocation=(), microphone=(), camera=()"
+	header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' https:; frame-ancestors 'none'"
+
+	handle /status {
+		respond "AgilePlus CLI self-hosted instance running. No HTTP API available. Use CLI directly." 200
+	}
+
+	handle /health {
+		respond "ok" 200
+	}
+
+	handle {
+		respond `<!DOCTYPE html>
+<html>
+<head><title>AgilePlus Self-Hosted</title></head>
+<body>
+<h1>AgilePlus Self-Hosted Instance</h1>
+<p><strong>AgilePlus is a CLI tool</strong> with no built-in HTTP server. This instance serves as a database container.</p>
+<p><strong>Database location:</strong> /data/agileplus.db</p>
+<p>Mount the agileplus-data volume or run: docker compose exec agileplus-cli agileplus --help</p>
+</body>
+</html>` 200 {
+			header Content-Type text/html
+		}
+	}
+
+	log {
+		output stdout
+		format json
+	}
+}
+
+localhost:8081 {
+	respond `AgilePlus CLI instance (local). No HTTP API.` 200
+}

--- a/deploy/selfhost/README.md
+++ b/deploy/selfhost/README.md
@@ -1,0 +1,168 @@
+# AgilePlus Self-Hosted Deployment
+
+Docker Compose stack for self-hosting AgilePlus CLI with data persistence and optional Cloudflare Tunnel support.
+
+## Important: AgilePlus is a CLI Tool
+
+**AgilePlus is not a web service.** It is a command-line tool for project management. This stack:
+
+- Provides a **containerized CLI environment** with a persistent SQLite database
+- **Does not expose an HTTP API** by default
+- Includes **Caddy** as a placeholder reverse proxy (serves a status page only)
+- Supports **data volume mounting** for local CLI access
+- Optionally integrates with **Cloudflare Tunnel** for external connectivity
+
+If you need HTTP endpoints, build a separate web service wrapper (REST API or GraphQL layer) that mounts the AgilePlus database volume.
+
+## Architecture
+
+```
+┌─────────────────────────────────────┐
+│ Your CLI / Local Container          │
+│ (mounts agileplus-data volume)      │
+│ Runs: agileplus --db /data/...      │
+└─────────────────────────────────────┘
+        │
+        ▼
+┌─────────────────────────────────────┐
+│ AgilePlus CLI Container             │
+│ - SQLite database at /data/          │
+│ - No HTTP server                     │
+└─────────────────────────────────────┘
+        │
+        ▼
+  [agileplus.db]
+```
+
+## Quick Start
+
+### 1. Build the AgilePlus Image
+
+```bash
+cd /path/to/agileplus
+docker build -t agileplus:latest .
+```
+
+### 2. Create `.env.selfhost`
+
+```bash
+cat > .env.selfhost << 'EOF'
+HOSTNAME=agileplus.pheno.studio
+CF_TUNNEL_TOKEN=
+EOF
+```
+
+Add to `.gitignore`:
+```
+.env.selfhost
+.env.*.local
+```
+
+### 3. Start the Stack
+
+```bash
+docker compose -f deploy/selfhost/docker-compose.selfhost.yml \
+  --env-file .env.selfhost up -d
+```
+
+### 4. Access the Database
+
+```bash
+# Run CLI commands against the container
+docker compose -f deploy/selfhost/docker-compose.selfhost.yml \
+  exec agileplus-cli agileplus list-projects
+
+# Or mount the volume locally
+docker run -it --rm -v agileplus-data:/data \
+  agileplus:latest agileplus --db /data/agileplus.db list-projects
+```
+
+## Using the CLI
+
+```bash
+# List all projects
+docker compose exec agileplus-cli agileplus list-projects
+
+# List epics
+docker compose exec agileplus-cli agileplus list-epics --project-id 1
+
+# List stories
+docker compose exec agileplus-cli agileplus list-stories --epic-id 2
+
+# View full help
+docker compose exec agileplus-cli agileplus --help
+```
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `HOSTNAME` | Domain for Caddy status page (no API) |
+| `CF_TUNNEL_TOKEN` | Cloudflare Tunnel token (optional) |
+
+## Managing the Stack
+
+```bash
+# Stop
+docker compose -f deploy/selfhost/docker-compose.selfhost.yml down
+
+# View logs
+docker compose -f deploy/selfhost/docker-compose.selfhost.yml logs -f
+
+# Backup database
+docker run --rm -v agileplus-data:/data -v $(pwd):/backup \
+  ubuntu tar czf /backup/agileplus-backup.tar.gz -C /data .
+```
+
+## Building an HTTP Wrapper (Optional)
+
+Create a lightweight REST API service that mounts the `agileplus-data` volume and calls AgilePlus CLI commands or directly queries SQLite.
+
+## Troubleshooting
+
+```bash
+# Check container status
+docker compose ps
+
+# View detailed logs
+docker compose logs agileplus-cli
+
+# Test CLI directly
+docker compose exec agileplus-cli agileplus --help
+
+# Verify database exists
+docker compose exec agileplus-cli ls -la /data/
+```
+
+## Security
+
+- Never commit `.env.selfhost` to version control
+- Use strong `GITHUB_PAT` if integrating with GitHub
+- Restrict database file permissions (600 or 640)
+- Use Tailscale for private access instead of exposing on public internet
+
+## Updates
+
+```bash
+# Update AgilePlus image
+docker pull agileplus:latest
+docker compose -f deploy/selfhost/docker-compose.selfhost.yml up -d agileplus-cli
+
+# Update Caddy
+docker compose -f deploy/selfhost/docker-compose.selfhost.yml pull caddy
+docker compose -f deploy/selfhost/docker-compose.selfhost.yml up -d caddy
+```
+
+## Production Checklist
+
+- [ ] Database backups automated and tested
+- [ ] `.env.selfhost` is in `.gitignore`
+- [ ] Caddy status page accessible
+- [ ] HTTP wrapper service built (if needed)
+- [ ] Cloudflare Tunnel configured (if external access needed)
+- [ ] Regular Docker image updates scheduled
+
+---
+
+**Version:** 1.0  
+**Status:** CLI-only (no HTTP server)

--- a/deploy/selfhost/docker-compose.selfhost.yml
+++ b/deploy/selfhost/docker-compose.selfhost.yml
@@ -1,0 +1,59 @@
+version: '3.8'
+
+services:
+  agileplus-cli:
+    image: agileplus:latest
+    container_name: agileplus-cli
+    restart: unless-stopped
+    command: agileplus --db /data/agileplus.db list-projects
+    environment:
+      AGILEPLUS_DB: /data/agileplus.db
+      LOG_LEVEL: "info"
+    volumes:
+      - agileplus-data:/data
+    networks:
+      - agileplus-net
+
+  caddy:
+    image: caddy:latest
+    container_name: agileplus-caddy
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile
+      - caddy-data:/data
+      - caddy-config:/config
+    environment:
+      HOSTNAME: ${HOSTNAME:-agileplus.pheno.studio}
+    networks:
+      - agileplus-net
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  cloudflared:
+    image: cloudflare/cloudflared:latest
+    container_name: agileplus-cloudflared
+    restart: unless-stopped
+    command: tunnel --no-autoupdate run
+    environment:
+      TUNNEL_TOKEN: ${CF_TUNNEL_TOKEN:-}
+    networks:
+      - agileplus-net
+    depends_on:
+      - caddy
+    profiles:
+      - cloudflare
+
+volumes:
+  agileplus-data:
+  caddy-data:
+  caddy-config:
+
+networks:
+  agileplus-net:
+    driver: bridge


### PR DESCRIPTION
Replicate Tracera self-host pattern for AgilePlus.

## Summary
- Docker Compose stack: agileplus-cli, Caddy, cloudflared
- AgilePlus is CLI-only (no HTTP server); Caddy serves status page
- Full README with deployment, CLI usage, and optional HTTP wrapper guidance

## Changes
- deploy/selfhost/docker-compose.selfhost.yml: Services definition
- deploy/selfhost/Caddyfile: Security headers, health, status page
- deploy/selfhost/README.md: Comprehensive deployment guide