### PR TITLE
fix(config): taplo format and anyhow security update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "async-trait"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,12 @@ pedantic = "warn"
 cargo-dist-version = "0.28.0"
 ci = ["github"]
 installers = ["shell", "powershell", "msi"]
-targets = ["x86_64-pc-windows-msvc", "x86_64-unknown-linux-gnu", "aarch64-apple-darwin", "x86_64-apple-darwin"]
+targets = [
+  "x86_64-pc-windows-msvc",
+  "x86_64-unknown-linux-gnu",
+  "aarch64-apple-darwin",
+  "x86_64-apple-darwin",
+]
 install-path = "CARGO_HOME"
 pr-run-mode = "plan"
 


### PR DESCRIPTION
## Summary
Fixes Config Lint and Rust Security Audit reds.

- Format Cargo.toml with taplo per Config Lint check
- Update anyhow from 1.0.102 to 1.0.103 to resolve RUSTSEC-2026-0190 (borrow rule UB)

## Root Causes
1. **Config Lint**: Cargo.toml targets array not properly formatted
2. **RUSTSEC-2026-0190**: anyhow 1.0.102 has UB in Error::context + Error::downcast_mut

## Verification
- taplo fmt applied to Cargo.toml
- cargo update bumped anyhow to v1.0.103

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>