### PR TITLE
fix: update Vercel deploy workflow

### DIFF
--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -24,10 +24,25 @@ jobs:
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID || '' }}
         run: |
           if [ "${{ github.event_name }}" == "pull_request" ]; then
-            npx vercel deploy --token ${{ secrets.VERCEL_TOKEN }}
+            bunx vercel deploy --token ${{ secrets.VERCEL_TOKEN }}
           else
-            npx vercel deploy --prod --token ${{ secrets.VERCEL_TOKEN }}
+            bunx vercel deploy --prod --token ${{ secrets.VERCEL_TOKEN }}
+          fi
+
+      - name: Extract and set VERCEL_PROJECT_ID
+        if: success() && env.VERCEL_PROJECT_ID == ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Check if .vercel/project.json was created
+          if [ -f ".vercel/project.json" ]; then
+            PROJECT_ID=$(grep -o '"projectId":"[^"]*"' .vercel/project.json | cut -d'"' -f4)
+            if [ ! -z "$PROJECT_ID" ]; then
+              echo "Found project ID: $PROJECT_ID"
+              gh secret set VERCEL_PROJECT_ID --body "$PROJECT_ID" --repo ${{ github.repository }}
+              echo "VERCEL_PROJECT_ID set successfully"
+            fi
           fi


### PR DESCRIPTION
## Summary
- Replace npx with bunx in Vercel deploy workflow (we have Bun in CI)
- Add automatic VERCEL_PROJECT_ID extraction and setup after first deploy
- This enables the workflow to auto-create the Vercel project and store its ID for subsequent runs

## Test plan
- The workflow should now successfully deploy to Vercel on push to main
- After first successful deploy, VERCEL_PROJECT_ID will be automatically set
- Subsequent deploys will use the cached project ID for faster, production deployments

🤖 Generated with Claude Code