### PR TITLE
feat: integrate Electrobun native window for AgilePlus

### DIFF
--- a/crates/agileplus-dashboard/desktop-electrobun/electrobun.config.ts
+++ b/crates/agileplus-dashboard/desktop-electrobun/electrobun.config.ts
@@ -1,29 +1,24 @@
 /**
- * phenotype-desktop Electrobun shell template
+ * AgilePlus Desktop Shell — Electrobun Configuration
  *
- * USAGE: Copy this directory alongside your web app, then edit the three
- * CONFIGURE sections below. Run `bun install && bun dev` on macOS.
- *
- * Template variables (find-replace before use):
- *   AgilePlus         e.g. "MyApp"
- *   com.phenotype.agileplus           e.g. "com.example.myapp"
- *   0.1.0      e.g. "0.1.0"
- *   http://localhost:5173  e.g. "http://localhost:3000"
- *   ../web/dist/index.html e.g. "../web/dist/index.html"  (relative from this dir)
+ * RENDERER_URL environment variable:
+ *   - Dev: RENDERER_URL=http://localhost:5173 (vite dev server with HMR)
+ *   - Prod: RENDERER_URL=http://localhost:8770 (dashboard daemon, set by launcher)
  */
 import type { ElectrobunConfig } from "electrobun";
 
-// ── CONFIGURE 1: App identity ─────────────────────────────────────────────────
+// ── App identity ──────────────────────────────────────────────────────────────
 const APP_NAME = "AgilePlus";
 const APP_ID = "com.phenotype.agileplus";
 const APP_VERSION = "0.1.0";
 
-// ── CONFIGURE 2: Renderer (dev server URL or bundled views path) ──────────────
-const DEFAULT_DEV_URL = "http://localhost:5173";
+// ── Renderer configuration ────────────────────────────────────────────────────
+// Dev server (HMR): localhost:5173 (vite dev server)
+// Daemon (prod): localhost:8770 (agileplus-dashboard binary)
+// The launcher sets RENDERER_URL=http://localhost:$PORT when starting Electrobun.
+const DEFAULT_RENDERER_URL = "http://localhost:8770";
 
-// ── CONFIGURE 3: Bundled views entrypoint (production) ───────────────────────
-// Self-contained dev/HMR fallback page; it polls + redirects to the live
-// dev server (RENDERER_URL). Keeps `electrobun build` independent of the web build.
+// ── Bundled fallback page (used when renderer is unreachable) ────────────────
 const VIEWS_ENTRYPOINT = "src/views/index.html";
 
 export default {
@@ -34,8 +29,8 @@ export default {
   },
   runtime: {
     exitOnLastWindowClosed: true,
-    // Passed through to main.ts via BuildConfig at runtime
-    devRendererUrl: process.env.RENDERER_URL ?? DEFAULT_DEV_URL,
+    // Passed to main.ts via process.env.RENDERER_URL at runtime
+    devRendererUrl: process.env.RENDERER_URL ?? DEFAULT_RENDERER_URL,
   },
   build: {
     bun: {

--- a/crates/agileplus-dashboard/desktop-electrobun/src/main.ts
+++ b/crates/agileplus-dashboard/desktop-electrobun/src/main.ts
@@ -1,77 +1,34 @@
 /**
- * phenotype-desktop Electrobun shell — main process template
+ * AgilePlus Desktop Shell — Electrobun main process
  *
- * Features out of the box:
- *  - One-click service boot: runs `process-compose up -d` if SERVICES_COMPOSE_FILE is set
- *  - Loads renderer from RENDERER_URL env or falls back to bundled views://app/index.html
- *  - Standard window with hiddenInset title bar, 1400x900 default
- *  - Minimal app menu wired to webview JS dispatch
+ * When launched from agileplus-launch.ps1:
+ * - The daemon (agileplus-dashboard) is already running via the launcher
+ * - RENDERER_URL is set to http://localhost:$AGILEPLUS_DASHBOARD_PORT
+ * - This window simply displays the running dashboard
+ *
+ * Features:
+ *  - Loads renderer from RENDERER_URL env (set by launcher)
+ *  - Fallback to bundled views://app/index.html if unreachable
+ *  - Standard window with hiddenInset title bar (macOS), 1400x900
+ *  - Minimal app menu
  */
 import { BrowserWindow, ApplicationMenu } from "electrobun/bun";
-import { $ } from "bun";
 import { join } from "node:path";
 
 // ── Config ────────────────────────────────────────────────────────────────────
 const APP_NAME = process.env.APP_NAME ?? "AgilePlus";
-// Bundled fallback page (polls + redirects to the live dev server).
-const RENDERER_URL = "views://app/index.html";
-// Live vite dev server (HMR) the window navigates to once reachable.
-const DEV_URL = process.env.RENDERER_URL ?? "http://localhost:5173";
-// Repo root, four levels up from crates/agileplus-dashboard/desktop-electrobun/src.
-const REPO_ROOT = join(import.meta.dir, "..", "..", "..", "..");
-const API_CRATE = process.env.AGILEPLUS_API_CRATE ?? "agileplus-api";
-const BOOT_API = (process.env.BOOT_API ?? "1") !== "0";
 
-/**
- * Path to process-compose.yml (absolute or relative to CWD).
- * Set SERVICES_COMPOSE_FILE env var, e.g.:
- *   SERVICES_COMPOSE_FILE=/path/to/repo/process-compose.yml
- * Leave unset to skip service boot.
- */
-const SERVICES_COMPOSE_FILE = process.env.SERVICES_COMPOSE_FILE;
+// Fallback page (shown while waiting for renderer to be reachable)
+const RENDERER_FALLBACK = "views://app/index.html";
 
-// ── Backend boot (cargo run -p agileplus-api :4000) ───────────────────────────
-function bootBackend(): void {
-  if (!BOOT_API) {
-    console.log(`[${APP_NAME}] BOOT_API=0 — skipping backend boot`);
-    return;
-  }
-  try {
-    Bun.spawn(["cargo", "run", "-p", API_CRATE], {
-      cwd: REPO_ROOT,
-      stdout: "inherit",
-      stderr: "inherit",
-      env: { ...process.env },
-    });
-    console.log(`[${APP_NAME}] Backend: cargo run -p ${API_CRATE} (cwd ${REPO_ROOT})`);
-  } catch (err) {
-    console.warn(`[${APP_NAME}] backend boot skipped:`, (err as Error).message);
-  }
-}
+// Live renderer URL (set by launcher via RENDERER_URL=http://localhost:$PORT)
+const RENDERER_URL = process.env.RENDERER_URL ?? "http://localhost:8770";
 
-// ── Service boot ─────────────────────────────────────────────────────────────
-async function bootServices(): Promise<void> {
-  if (!SERVICES_COMPOSE_FILE) {
-    console.log(`[${APP_NAME}] SERVICES_COMPOSE_FILE not set — skipping service boot`);
-    return;
-  }
-  console.log(`[${APP_NAME}] Booting services: process-compose up -d`);
-  try {
-    const result = await $`process-compose up -d --config ${SERVICES_COMPOSE_FILE}`.quiet();
-    console.log(`[${APP_NAME}] Services:`, result.text().trim());
-  } catch (err) {
-    console.warn(
-      `[${APP_NAME}] process-compose boot skipped (not found or services already running):`,
-      (err as Error).message
-    );
-  }
-}
-
-// ── Window ───────────────────────────────────────────────────────────────────
+// ── Window ────────────────────────────────────────────────────────────────────
 function createMainWindow(): BrowserWindow {
   const win = new BrowserWindow({
     title: APP_NAME,
-    url: RENDERER_URL,
+    url: RENDERER_FALLBACK,
     frame: {
       x: 0,
       y: 0,
@@ -80,16 +37,18 @@ function createMainWindow(): BrowserWindow {
     },
     titleBarStyle: "hiddenInset",
   });
-  // Tell the bundled fallback page which dev server to poll + redirect to.
+
+  // Tell the fallback page which renderer URL to poll and navigate to
   try {
-    win.webview.executeJavascript(`window.__RENDERER_URL__ = ${JSON.stringify(DEV_URL)};`);
+    win.webview.executeJavascript(`window.__RENDERER_URL__ = ${JSON.stringify(RENDERER_URL)};`);
   } catch {
-    /* webview not ready yet — fallback page defaults to localhost:5173 */
+    // Webview not ready yet; fallback page will use its default
   }
+
   return win;
 }
 
-// ── Menu ─────────────────────────────────────────────────────────────────────
+// ── Menu ──────────────────────────────────────────────────────────────────────
 function setupMenu(win: BrowserWindow): void {
   ApplicationMenu.setApplicationMenu([
     {
@@ -128,28 +87,14 @@ function setupMenu(win: BrowserWindow): void {
         { role: "togglefullscreen" },
       ],
     },
-    // Add app-specific menus below this line
-    // Example — dispatch to webview via executeJavaScript:
-    // {
-    //   label: "File",
-    //   submenu: [
-    //     {
-    //       label: "New",
-    //       accelerator: "CmdOrCtrl+N",
-    //       click: () => win.webview.executeJavaScript("window.__app?.onNew?.()"),
-    //     },
-    //   ],
-    // },
   ]);
 }
 
-// ── Bootstrap ────────────────────────────────────────────────────────────────
+// ── Bootstrap ─────────────────────────────────────────────────────────────────
 async function main(): Promise<void> {
-  bootBackend();
-  await bootServices();
   const win = createMainWindow();
   setupMenu(win);
-  console.log(`[${APP_NAME}] Launched → ${DEV_URL} (fallback ${RENDERER_URL})`);
+  console.log(`[${APP_NAME}] Desktop shell launched → ${RENDERER_URL} (fallback: ${RENDERER_FALLBACK})`);
 }
 
 main().catch((err) => {

--- a/packaging/agileplus-launch.ps1
+++ b/packaging/agileplus-launch.ps1
@@ -1,11 +1,12 @@
-# AgilePlus Dashboard Launcher
+# AgilePlus Dashboard Launcher + Electrobun Desktop Shell
 # Idempotent daemon launcher that:
 # 1. Checks if AGILEPLUS_DASHBOARD_PORT is free
 # 2. If free → starts agileplus-dashboard as hidden daemon
 # 3. If occupied → health-checks http://localhost:$PORT/health
 #    - Healthy → reuse existing instance
 #    - Unhealthy/foreign → kill + start fresh
-# 4. Opens native Electrobun window or fallback to browser
+# 4. Builds Electrobun desktop shell (if needed)
+# 5. Launches Electrobun app window pointing at the daemon
 
 $ErrorActionPreference = "SilentlyContinue"
 
@@ -16,6 +17,8 @@ if (-not $DashboardPort -or $DashboardPort -le 0) { $DashboardPort = 8770 }
 $HealthCheckUrl = "http://127.0.0.1:$DashboardPort/health"
 $DashboardUrl = "http://127.0.0.1:$DashboardPort"
 $RepoPath = "E:\Dev\AgilePlus"
+$ElectrobunDir = "$RepoPath\crates\agileplus-dashboard\desktop-electrobun"
+$ElectrobunBinary = "$ElectrobunDir\build\AgilePlus.exe"  # Post-build artifact
 
 # Validate binary exists
 if (-not (Test-Path $DashboardBinary)) {
@@ -65,21 +68,67 @@ function Kill-ProcessOnPort {
     }
 }
 
-# Main logic
-Write-Host "[AgilePlus Dashboard Launcher]" -ForegroundColor Cyan
+# Helper: Build Electrobun app (if needed)
+function Build-ElectrobunApp {
+    if (-not (Test-Path $ElectrobunDir)) {
+        Write-Host "[ERROR] Electrobun directory not found: $ElectrobunDir" -ForegroundColor Red
+        return $false
+    }
 
-# Check if port is in use
+    # Check if build artifact exists and is recent
+    $buildCacheValid = $false
+    if (Test-Path $ElectrobunBinary) {
+        $binaryAge = (Get-Date) - (Get-Item $ElectrobunBinary).LastWriteTime
+        if ($binaryAge.TotalHours -lt 24) {
+            Write-Host "[OK] Electrobun build is recent (< 24h). Skipping rebuild." -ForegroundColor Green
+            $buildCacheValid = $true
+        }
+    }
+
+    if (-not $buildCacheValid) {
+        Write-Host "[INFO] Building Electrobun app..." -ForegroundColor Blue
+        Push-Location $ElectrobunDir
+        try {
+            # Ensure Bun dependencies are installed
+            bunx bun install 2>&1 | Out-Null
+
+            # Build Electrobun app
+            bunx electrobun build --release 2>&1 | Out-Null
+
+            # Verify build succeeded
+            if (Test-Path $ElectrobunBinary) {
+                Write-Host "[OK] Electrobun build succeeded: $ElectrobunBinary" -ForegroundColor Green
+                return $true
+            } else {
+                Write-Host "[ERROR] Electrobun build failed. Binary not found at: $ElectrobunBinary" -ForegroundColor Red
+                return $false
+            }
+        } catch {
+            Write-Host "[ERROR] Failed to build Electrobun: $_" -ForegroundColor Red
+            return $false
+        } finally {
+            Pop-Location
+        }
+    }
+
+    return $true
+}
+
+# Main logic
+Write-Host "[AgilePlus Dashboard Launcher + Electrobun Desktop Shell]" -ForegroundColor Cyan
+
+# ── Step 1: Ensure dashboard daemon is running ────────────────────────────────
+Write-Host "[INFO] Checking dashboard daemon..." -ForegroundColor Blue
+
 $portInUse = Test-PortInUse $DashboardPort
 
 if ($portInUse) {
     Write-Host "[INFO] Port $DashboardPort is occupied. Health-checking..." -ForegroundColor Blue
     if (Test-DashboardHealth $HealthCheckUrl) {
         Write-Host "[OK] Healthy dashboard found on port $DashboardPort. Reusing." -ForegroundColor Green
-        # Proceed to open the URL
     } else {
         Write-Host "[WARN] Port $DashboardPort occupied by unhealthy service. Freeing & restarting..." -ForegroundColor Yellow
         Kill-ProcessOnPort $DashboardPort
-        # Start fresh below
         $portInUse = $false
     }
 }
@@ -88,8 +137,7 @@ if (-not $portInUse) {
     Write-Host "[INFO] Starting agileplus-dashboard on port $DashboardPort..." -ForegroundColor Blue
     Push-Location $RepoPath
     try {
-        $env:AGILEPLUS_DASHBOARD_PORT = $DashboardPort
-        # Start as hidden, detached daemon (no console window)
+        # Start as hidden, detached daemon
         $proc = Start-Process -FilePath $DashboardBinary `
             -NoNewWindow `
             -WindowStyle Hidden `
@@ -108,25 +156,37 @@ if (-not $portInUse) {
     }
 }
 
-# Now open the dashboard URL
-Write-Host "[INFO] Opening dashboard at $DashboardUrl" -ForegroundColor Blue
-
-# Try Electrobun first (native app container)
-# NOTE: Electrobun wiring for AgilePlus is the end-state target; for now, fallback to browser
-$electronBunPath = "C:\Users\koosh\AppData\Local\Apps\Electrobun\Electrobun.exe"
-$electrobunAgilePlusApp = "E:\Dev\AgilePlus\packaging\electrobun-app.exe"  # Hypothetical final artifact
-
-if (Test-Path $electrobunAgilePlusApp) {
-    Write-Host "[INFO] Opening via Electrobun (AgilePlus native app)" -ForegroundColor Cyan
-    Start-Process -FilePath $electrobunAgilePlusApp
-} elseif (Test-Path $electronBunPath) {
-    Write-Host "[INFO] Electrobun found but AgilePlus app not yet wired. (Target: native Electrobun app)" -ForegroundColor DarkYellow
-    Write-Host "[INTERIM] Opening in default browser..." -ForegroundColor DarkYellow
+# ── Step 2: Build Electrobun app (if needed) ───────────────────────────────────
+Write-Host "[INFO] Preparing Electrobun desktop shell..." -ForegroundColor Blue
+if (-not (Build-ElectrobunApp)) {
+    Write-Host "[ERROR] Failed to build Electrobun app. Falling back to browser." -ForegroundColor Red
     Start-Process $DashboardUrl
-} else {
-    Write-Host "[INTERIM] Opening in default browser (Electrobun not set up yet)" -ForegroundColor DarkYellow
+    exit 0
+}
+
+# ── Step 3: Launch Electrobun app window ───────────────────────────────────────
+Write-Host "[INFO] Launching Electrobun app window..." -ForegroundColor Blue
+
+# Pass the dashboard port to Electrobun via RENDERER_URL environment variable
+$env:RENDERER_URL = $DashboardUrl
+$env:APP_NAME = "AgilePlus"
+$env:WINDOW_WIDTH = "1400"
+$env:WINDOW_HEIGHT = "900"
+
+try {
+    Start-Process -FilePath $ElectrobunBinary `
+        -EnvironmentVariables @{
+            "RENDERER_URL" = $DashboardUrl
+            "APP_NAME" = "AgilePlus"
+            "WINDOW_WIDTH" = "1400"
+            "WINDOW_HEIGHT" = "900"
+        }
+    Write-Host "[OK] Electrobun app launched" -ForegroundColor Green
+} catch {
+    Write-Host "[ERROR] Failed to launch Electrobun app: $_" -ForegroundColor Red
+    Write-Host "[INTERIM] Opening in default browser..." -ForegroundColor DarkYellow
     Start-Process $DashboardUrl
 }
 
-Write-Host "[OK] Done. Dashboard dashboard is live at $DashboardUrl" -ForegroundColor Green
+Write-Host "[OK] Done. Dashboard is live at $DashboardUrl" -ForegroundColor Green
 exit 0


### PR DESCRIPTION
## Summary
- Integrate Electrobun native desktop shell for AgilePlus dashboard
- Update launcher to build and launch Electrobun app instead of default browser
- Electrobun config now points to running dashboard daemon port (8770)
- Main process simplified: just displays the daemon (no backend boot)

## Implementation
1. **electrobun.config.ts**: Updated to use dashboard daemon URL (RENDERER_URL env)
2. **src/main.ts**: Simplified — displays daemon at configured RENDERER_URL
3. **packaging/agileplus-launch.ps1**: Enhanced to:
   - Start dashboard daemon (existing logic)
   - Build Electrobun app with caching (skip if < 24h old)
   - Launch Electrobun window with RENDERER_URL pointing to daemon
   - Fallback to browser if build fails

## Architecture
```
Launcher (PowerShell)
├─ Start daemon (agileplus-dashboard.exe on port 8770)
├─ Build Electrobun (bunx electrobun build --release)
└─ Launch native window (RENDERER_URL=http://localhost:8770)
   └─ Window displays dashboard from running daemon
```

## Test plan
- Run packaging/agileplus-launch.ps1 on Windows
- Should see native Electrobun window open with AgilePlus dashboard
- If Electrobun build fails, fallback to default browser

## Status
- Scaffold is fully wired
- Build path configured: crates/agileplus-dashboard/desktop-electrobun/build/AgilePlus.exe
- Next: test the build and verify window launch

🤖 Generated with Claude Code