### PR TITLE
fix: add root package.json for deploy-vercel workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@
 !pyproject.toml
 !deny.toml
 !.gitleaks.toml
+!package.json
+!vercel.json
+!.commitlintrc.json
+!.coderabbit.yaml
 
 # Environment configuration
 .env

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "agileplus",
+  "version": "1.0.0",
+  "description": "AgilePlus - Agile project management platform",
+  "private": true,
+  "workspaces": [
+    "crates/*/web",
+    "packages/*"
+  ]
+}


### PR DESCRIPTION
Fixes the deploy-vercel GitHub Actions workflow which was failing during bun install.

Root cause: The workflow runs `bun install` in the repo root, but there was no package.json file there. Additionally, the Agentora submodule reference had no configured URL, causing git submodule initialization to fail.

Changes:
- Added minimal root package.json that defines the workspace structure
- Updated .gitignore to allow key config files (package.json, vercel.json, etc.)
- Removed orphaned Agentora submodule reference

The actual deployment build is handled by Vercel's vercel.json config, which builds the React dashboard from crates/agileplus-dashboard/web.