### PR TITLE
fix(journey-gate): correct Vale action GitHub Actions syntax

### DIFF
--- a/.github/workflows/journey-gate.yml
+++ b/.github/workflows/journey-gate.yml
@@ -91,7 +91,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Run Vale lint on docs
-        uses: errata-ai/vale-action@floyd@0.2.1
+        uses: errata-ai/vale-action@v2.1.0
         with:
           files: docs/
         continue-on-error: true


### PR DESCRIPTION
## Summary
Fixed invalid GitHub Actions ref syntax in journey-gate.yml workflow.

## Issue
The Vale action ref was malformed: `errata-ai/vale-action@floyd@0.2.1`

In GitHub Actions, the @ symbol can only appear once, separating the action owner/name from the version tag.

## Fix
Changed to: `errata-ai/vale-action@v2.1.0`

This fixes the workflow file validation error.

## Test Plan
- [x] journey-gate.yml syntax is valid
- [ ] Workflow triggers on journey documentation changes
- [ ] journey-gate.yml passes validation on next PR

Generated with Claude Code