### PR TITLE
fix: Remove invalid --skip flag from pre-commit workflow

### DIFF
--- a/.github/workflows/security-guard.yml
+++ b/.github/workflows/security-guard.yml
@@ -34,4 +34,4 @@ jobs:
         env:
           SKIP: legacy-tooling-scan
         with:
-          extra_args: --hook-stage pre-commit --config .pre-commit-config.yaml --show-diff-on-failure --skip legacy-tooling-scan
+          extra_args: --hook-stage pre-commit --config .pre-commit-config.yaml --show-diff-on-failure


### PR DESCRIPTION
## Summary

The Security Guard workflow was failing because it attempted to pass a `--skip` flag to pre-commit, which is not a valid command-line argument. Pre-commit manages hook skipping exclusively through the `SKIP` environment variable.

This PR removes the invalid `--skip legacy-tooling-scan` from the `extra_args` configuration, keeping only the environment variable-based approach which is already in place.

## Issue

Pre-commit error: "pre-commit: error: unrecognized arguments: --skip"

This caused the Security Guard workflow to fail on every push and PR.

## Solution

Removed `--skip legacy-tooling-scan` from the `extra_args` line in `.github/workflows/security-guard.yml` (line 37). The `SKIP` environment variable is already set correctly to accomplish the same goal of skipping the legacy-tooling-scan hook.

## Test Plan

- Verify fresh Security Guard workflow run passes on this branch
- The workflow should complete without the "unrecognized arguments: --skip" error