### PR TITLE
Fix VitePress base path for custom domain deployments

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,8 +1,9 @@
 import { createPhenotypeConfig } from '@phenotype/docs/config'
 
 const isPagesBuild = process.env.GITHUB_ACTIONS === 'true' || process.env.GITHUB_PAGES === 'true'
+const isCustomDomain = process.env.PHENOTYPE_CUSTOM_DOMAIN === 'true'
 const repoName = process.env.GITHUB_REPOSITORY?.split('/')[1] || 'AgilePlus'
-const docsBase = isPagesBuild ? `/${repoName}/` : '/'
+const docsBase = isCustomDomain ? '/' : (isPagesBuild ? `/${repoName}/` : '/')
 
 import { createSiteMeta } from './site-meta.mjs'
 


### PR DESCRIPTION
## Summary
Fixes 404 errors on asset resources (vp-icons.css, app.*.js, fonts, theme.*.js, style.*.css, framework.*.js) when deploying VitePress docs to a custom domain (agileplus.phenotype.space).

## Root Cause
The VitePress config.mts determines the base path based on GITHUB_PAGES flag without checking if PHENOTYPE_CUSTOM_DOMAIN is set. When deploying to a custom domain:
- GITHUB_PAGES=true (because it's a GitHub Pages deployment)
- This triggers the repo-prefixed logic: base=/AgilePlus/
- But custom domains serve from root, not from /AgilePlus/
- Assets resolve to wrong paths: /AgilePlus/assets/... instead of /assets/...

## Solution
Check PHENOTYPE_CUSTOM_DOMAIN first in config.mts, just like site-meta.mjs already does. Custom domains get base=/ regardless of GITHUB_PAGES flag. This ensures:
- Standard GitHub Pages deployments (phenotype.space/AgilePlus) use base=/AgilePlus/
- Custom domain deployments (agileplus.phenotype.space) use base=/

## Same pattern as Tracera #703
This applies the same fix pattern that resolved the identical issue in Tracera repo.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>