### PR TITLE
fix(ci): resolve invalid job schema in deploy.yml (VitePress Pages)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,16 +8,20 @@ on:
       - ".github/workflows/deploy.yml"
   workflow_dispatch:
 
+concurrency:
+  group: agileplus-vitepress-pages
+  cancel-in-progress: true
+
 jobs:
   deploy:
-    uses: KooshaPari/phenoShared/.github/workflows/vitepress-pages.yml@main
-    with:
-      concurrency_group: agileplus-vitepress-pages
-      custom_domain: "true"
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       pages: write
       id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683


### PR DESCRIPTION
## Summary
- deploy.yml's deploy job mixed a reusable-workflow-call (uses: KooshaPari/phenoShared/...@main + with:) with an inline job (runs-on: + steps:) in the same job block - invalid per the Actions job schema.
- GitHub Actions rejects this at parse time: the run is created with conclusion=failure, zero jobs, no logs - surfacing as "This run likely failed because of a workflow file issue" on every push to main.
- This is why agileplus.pheno.studio docs have been stale - no successful deploy.yml (VitePress Pages) run has produced a Pages deployment.
- Root cause is distinct from PR #879 (which fixed the VitePress base-path/PHENOTYPE_CUSTOM_DOMAIN config) - that fix is preserved.

## Fix
- Dropped the dead reusable-workflow-call fields (uses/with) - KooshaPari/phenoShared is 404 upstream (per #856).
- Kept the working inline job (checkout -> clone phenodocs -> bun install -> build -> upload/deploy Pages artifact).
- Restored the intended concurrency group as a top-level concurrency: block.
- Added environment: github-pages so the deployment attaches to the configured environment.

## Test plan
- [x] YAML is schema-valid
- [ ] CI green on this PR
- [ ] deploy.yml run succeeds and produces a Pages deployment

Generated with Claude Code