### PR TITLE
ci(release): fix Windows zip staging (exit 127) in agileplus-release.yml

### DIFF
--- a/.github/workflows/agileplus-release.yml
+++ b/.github/workflows/agileplus-release.yml
@@ -97,7 +97,10 @@ jobs:
           cp docs/INSTALL.md "$staging/" 2>/dev/null || true
           mkdir -p release-upload
           if [ "${{ matrix.archive }}" = "zip" ]; then
-            (cd dist && zip -r "../release-upload/agileplus-${version}-${{ matrix.asset_name }}.zip" "${{ matrix.asset_name }}")
+            # windows-latest's Git Bash does not ship a `zip` binary on PATH
+            # (only tar/gzip are guaranteed); use PowerShell's native
+            # Compress-Archive instead of depending on an external tool.
+            pwsh -NoLogo -NoProfile -Command "Compress-Archive -Path 'dist/${{ matrix.asset_name }}' -DestinationPath 'release-upload/agileplus-${version}-${{ matrix.asset_name }}.zip' -Force"
           else
             tar -C dist -czf "release-upload/agileplus-${version}-${{ matrix.asset_name }}.tar.gz" "${{ matrix.asset_name }}"
           fi


### PR DESCRIPTION
## Summary
- Root cause of the Windows job's "Stage artifact" exit 127: `windows-latest`'s Git Bash ships `tar`/`gzip` but not a `zip` CLI on PATH, so the bash-only `zip -r ...` invocation for the zip-archive matrix leg always fails with `zip: command not found`. Confirmed directly from the failed job log on the v0.4.0 tag run (job 84905805791, current main-HEAD workflow, post-PR#878).
- Fix: for the `archive: zip` case, invoke PowerShell's native `Compress-Archive` via `pwsh` (preinstalled on `windows-latest`) instead of depending on an external `zip` binary. The tar.gz path (linux/macos legs) is unchanged.
- macOS x86_64 (`macos-13`) queuing 11h+ on both v0.4.0 and v0.4.1: verified `macos-13` is a valid, currently-supported GitHub-hosted runner label (not a typo'd/nonexistent label like `macos-13-xlarge`, and not a self-hosted label). This is expected shared-runner capacity scarcity for Intel macOS hosted runners, not a workflow config bug — no change made for that leg.

## Test plan
- [x] Confirmed exact failure via `gh api .../actions/jobs/<id>/logs`: `line 33: zip: command not found` / `Process completed with exit code 127`
- [x] Confirmed `macos-13` label is valid/current (not the root cause of queuing)
- [ ] Once merged, next real tag push will exercise the fixed Windows leg end-to-end (no test tag cut as part of this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)