### PR TITLE
fix(docs): correct @phenotype/docs symlink path breaking Pages branding

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,13 +40,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Link @phenotype/docs from phenodocs
-          mkdir -p docs/node_modules/@phenotype
-          ln -sf /tmp/phenodocs/packages/docs docs/node_modules/@phenotype/docs
           # Configure npm for GitHub Packages
           echo "@phenotype:registry=https://npm.pkg.github.com" >> ~/.npmrc
           echo "//npm.pkg.github.com/:_authToken=\${GITHUB_TOKEN}" >> ~/.npmrc
           bun install
+          # Link @phenotype/docs from phenodocs (after install so bun doesn't
+          # clobber the unmanaged symlink; path is relative to this
+          # working-directory, i.e. docs/node_modules/@phenotype/docs)
+          mkdir -p node_modules/@phenotype
+          ln -sf /tmp/phenodocs/packages/docs node_modules/@phenotype/docs
 
       - name: Build VitePress site
         working-directory: docs


### PR DESCRIPTION
## Summary
- The docs Pages deploy workflow ran with `working-directory: docs` but created the `@phenotype/docs` symlink at a path resolving to `docs/docs/node_modules/@phenotype/docs` instead of `docs/node_modules/@phenotype/docs` — the actual node_modules root vitepress resolves from.
- `config.mts`'s `import { createPhenotypeConfig } from '@phenotype/docs/config'` therefore never resolved to the real package, silently falling back to vitepress defaults — hence the live site (agileplus.phenotype.space) showing generic "VitePress" title / "A VitePress site" description despite config.mts already containing correct AgilePlus branding.
- Moved symlink creation to after `bun install` so bun doesn't disturb the unmanaged directory.

## Test plan
- [x] Verified docs/.vitepress/config.mts + site-meta.mjs already have correct title "AgilePlus" / real description / teal theme-color
- [x] Confirmed via job logs that bun install only resolved 4 packages (no phenotype package) prior to this fix
- [ ] After merge, confirm Pages workflow run succeeds and live site shows real title/meta

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the deployment workflow’s dependency installation process to be more reliable during site builds.
  * Improved package authentication and installation order to help prevent deployment issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->