### PR TITLE
fix(docs): real AgilePlus branding in site-meta.mjs (was placeholder)

### DIFF
--- a/docs/.vitepress/site-meta.mjs
+++ b/docs/.vitepress/site-meta.mjs
@@ -6,13 +6,20 @@ export function createSiteMeta({ base = '/' } = {}) {
 
   return {
     base: resolvedBase,
-    title: 'apps/AgilePlus',
-    description: 'Documentation',
+    title: 'AgilePlus',
+    description: 'AgilePlus — a lightweight, standalone project-management and PM substrate: requirements, epics, stories, and repo sync, from the CLI or as an embedded library.',
     themeConfig: {
+      siteTitle: 'AgilePlus',
       nav: [
         { text: 'Home', link: resolvedBase || '/' },
         { text: 'Guide', link: '/guide/' },
       ],
+      socialLinks: [
+        { icon: 'github', link: 'https://github.com/KooshaPari/AgilePlus' },
+      ],
     },
+    head: [
+      ['meta', { name: 'theme-color', content: '#7ebab5' }],
+    ],
   }
 }


### PR DESCRIPTION
## Summary
- docs/.vitepress/site-meta.mjs shipped with placeholder branding since it was authored: title 'apps/AgilePlus', description 'Documentation', no siteTitle/socialLinks/theme-color.
- This is why the live docs site (agileplus.phenotype.space) shows generic-looking VitePress meta even after fixing the @phenotype/docs symlink resolution bug in #886.
- Sets real title "AgilePlus", a real description, siteTitle, GitHub social link, and the teal (#7ebab5) theme-color per the Phenotype design system.

## Test plan
- [ ] After merge, confirm Pages deploy picks up the change and live site title/meta description reflect real AgilePlus branding