### PR TITLE
fix(docs): build vitepress from correct root (fixes silent config-not-found)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9
         with:
-          path: docs/docs/.vitepress/dist
+          path: docs/.vitepress/dist
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/docs/package.json
+++ b/docs/package.json
@@ -3,9 +3,9 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "docs:dev": "vitepress dev docs",
-    "docs:build": "vitepress build docs",
-    "docs:preview": "vitepress preview docs",
+    "docs:dev": "vitepress dev .",
+    "docs:build": "vitepress build .",
+    "docs:preview": "vitepress preview .",
     "docs:test:unit": "node --test docs/tests/unit/*.test.mjs",
     "docs:test:component": "node --test docs/tests/component/*.test.mjs",
     "docs:test:e2e": "playwright test --config docs/tests/playwright.config.ts",


### PR DESCRIPTION
## Summary
- Root cause of the live docs site showing generic "VitePress" title / "A VitePress site" description despite correct branding in config.mts (#887) and a correct symlink (#886): `docs:build` ran `vitepress build docs`, setting VitePress's project root to `docs/docs`. But `.vitepress/` (config.mts, theme, etc.) lives at `docs/.vitepress` — one level up from that root.
- VitePress looks for `<root>/.vitepress/config.*`; with root=`docs/docs` it found nothing there and silently built with zero config. Confirmed locally via vitepress debug output: `vitepress:config no config file found`.
- Fix: point vitepress root at `.` (the `docs/` dir where `.vitepress` actually lives) for build/dev/preview scripts, and update the Pages workflow's artifact upload path from `docs/docs/.vitepress/dist` to `docs/.vitepress/dist` to match the new build output location.

## Test plan
- [ ] After merge, confirm Pages deploy succeeds and live site (agileplus.phenotype.space) shows real `<title>AgilePlus</title>` and description