### PR TITLE
fix(ci): resolve vitepress ERR_MODULE_NOT_FOUND in docs deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,6 +49,19 @@ jobs:
           # working-directory, i.e. docs/node_modules/@phenotype/docs)
           mkdir -p node_modules/@phenotype
           ln -sf /tmp/phenodocs/packages/docs node_modules/@phenotype/docs
+          # Node's ESM resolver follows the symlink to its real path
+          # (/tmp/phenodocs/packages/docs) and walks up ITS OWN node_modules
+          # chain (/tmp/phenodocs/packages/docs/node_modules,
+          # /tmp/phenodocs/packages/node_modules, /tmp/phenodocs/node_modules,
+          # /tmp/node_modules) to resolve bare imports like "vitepress" -
+          # none of which exist, since /tmp/phenodocs was only git-cloned,
+          # never installed. vitepress is correctly declared as a
+          # peerDependency in @phenotype/docs (not a bug there), so give the
+          # phenodocs real path its own node_modules with vitepress resolvable
+          # by symlinking back to the copy already installed here.
+          mkdir -p /tmp/phenodocs/node_modules
+          ln -sf "$(pwd)/node_modules/vitepress" /tmp/phenodocs/node_modules/vitepress
+          ln -sf "$(pwd)/node_modules/vue" /tmp/phenodocs/node_modules/vue
 
       - name: Build VitePress site
         working-directory: docs


### PR DESCRIPTION
## Summary
- The VitePress Pages workflow (.github/workflows/deploy.yml) symlinks `docs/node_modules/@phenotype/docs` to a freshly git-cloned `/tmp/phenodocs/packages/docs`.
- Node's ESM resolver follows that symlink to its real path and walks up `/tmp/phenodocs`'s own node_modules chain to resolve the bare `vitepress` import (declared correctly as a peerDependency in `@phenotype/docs`, not a bug in that package). Since `/tmp/phenodocs` is only cloned, never installed, that chain is empty -> `ERR_MODULE_NOT_FOUND`.
- Fix: after `bun install` in `docs/`, symlink `vitepress` and `vue` from `docs/node_modules` into `/tmp/phenodocs/node_modules`, so resolution from the real (symlink-target) path succeeds.

## Test plan
- [x] Confirmed root cause via `gh run view --log` on prior failing run (28664990387)
- [x] Confirmed `@phenotype/docs` package.json declares `vitepress` as peerDependency (correct usage) via fresh clone
- [ ] Workflow run on main post-merge succeeds and Pages deploy shows real AgilePlus branding at https://agileplus.phenotype.space

🤖 Generated with [Claude Code](https://claude.com/claude-code)