### PR TITLE
fix(sqlite): register migrations 024-026 + harden parse_up + fix upsert_requirement_id

### DIFF
--- a/crates/agileplus-sqlite/src/migrations/mod.rs
+++ b/crates/agileplus-sqlite/src/migrations/mod.rs
@@ -32,6 +32,11 @@ const MIGRATION_020: &str = include_str!("020_create_stories.sql");
 const MIGRATION_021: &str = include_str!("021_add_requirement_id.sql");
 const MIGRATION_022: &str = include_str!("022_create_trace_links.sql");
 const MIGRATION_023: &str = include_str!("023_create_worklog_entries.sql");
+const MIGRATION_024: &str = include_str!("024_l2_38_worklog_trace_gate_run_scope.sql");
+const MIGRATION_025: &str = include_str!("025_create_intent_graph.sql");
+const MIGRATION_025_GOV: &str = include_str!("025_governance_channel_iteration.sql");
+const MIGRATION_025_VIEWS: &str = include_str!("025_intent_graph_views.sql");
+const MIGRATION_026: &str = include_str!("026_feature_labels.sql");
 
 /// All migrations in order: (name, up_sql, down_sql)
 const MIGRATIONS: &[(&str, &str)] = &[
@@ -58,21 +63,53 @@ const MIGRATIONS: &[(&str, &str)] = &[
     ("021_add_requirement_id", MIGRATION_021),
     ("022_create_trace_links", MIGRATION_022),
     ("023_create_worklog_entries", MIGRATION_023),
+    ("024_l2_38_worklog_trace_gate_run_scope", MIGRATION_024),
+    ("025_create_intent_graph", MIGRATION_025),
+    ("025_governance_channel_iteration", MIGRATION_025_GOV),
+    ("025_intent_graph_views", MIGRATION_025_VIEWS),
+    ("026_feature_labels", MIGRATION_026),
 ];
+
+/// Find the byte offset where the UP body starts, given a `-- UP` marker
+/// (the `UP` token may be followed by `:`, whitespace, or anything). Returns
+/// `None` if no UP marker is present.
+fn find_up_body_start(sql: &str) -> Option<usize> {
+    // Look for `-- UP` not followed by a lowercase letter (avoids matching
+    // `-- UPGRADE` etc); allows `-- UP`, `-- UP:`, `-- UP --` ...
+    let bytes = sql.as_bytes();
+    let mut i = 0;
+    while i + 5 <= bytes.len() {
+        if &bytes[i..i + 5] == b"-- UP"
+            && (i + 5 == bytes.len()
+                || !bytes[i + 5].is_ascii_lowercase())
+        {
+            // Skip the marker + any trailing `:`, whitespace, or `--` (line comment).
+            let mut j = i + 5;
+            // Single trailing ':'
+            if j < bytes.len() && bytes[j] == b':' { j += 1; }
+            // Skip rest of the line (the marker comment)
+            while j < bytes.len() && bytes[j] != b'\n' { j += 1; }
+            // Skip the newline
+            if j < bytes.len() { j += 1; }
+            return Some(j);
+        }
+        i += 1;
+    }
+    None
+}
 
 /// Parse the UP section from a migration SQL file.
 fn parse_up(sql: &str) -> &str {
     // Format is:
-    //   -- UP
+    //   -- UP [-- up to text]
     //   <sql>
     //   -- DOWN
     //   <sql>
-    if let Some(up_start) = sql.find("-- UP") {
-        let after_up = &sql[up_start + 5..];
-        if let Some(down_start) = after_up.find("-- DOWN") {
-            return after_up[..down_start].trim();
+    if let Some(up_start) = find_up_body_start(sql) {
+        if let Some(down_start) = sql[up_start..].find("-- DOWN") {
+            return sql[up_start..up_start + down_start].trim();
         }
-        return after_up.trim();
+        return sql[up_start..].trim();
     }
     sql.trim()
 }

--- a/crates/agileplus-sqlite/src/repository/epics.rs
+++ b/crates/agileplus-sqlite/src/repository/epics.rs
@@ -77,7 +77,9 @@ pub fn get_epic_by_requirement_id(
 }
 
 pub fn upsert_epic_by_requirement_id(conn: &Connection, epic: &Epic) -> Result<i64, DomainError> {
-    let Some(requirement_id) = epic.requirement_id.as_deref() else {
+    let now = chrono::Utc::now().to_rfc3339();
+    let req_id_owned = epic.requirement_id.clone();
+    let Some(requirement_id) = req_id_owned.as_deref() else {
         return create_epic(conn, epic);
     };
 
@@ -85,7 +87,25 @@ pub fn upsert_epic_by_requirement_id(conn: &Connection, epic: &Epic) -> Result<i
         return Ok(existing.id);
     }
 
-    create_epic(conn, epic)
+    // Insert path: create_epic ignores requirement_id (a pre-existing bug). Insert
+    // here directly so the row is keyed on requirement_id and get-by-requirement-id
+    // can find it on the next call.
+    conn.execute(
+        "INSERT INTO epics (project_id, title, description, status, owner_id, requirement_id, created_at, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+        rusqlite::params![
+            epic.project_id,
+            epic.title,
+            epic.description,
+            epic.status.to_string(),
+            epic.owner_id,
+            requirement_id,
+            &now,
+            &now,
+        ],
+    )
+    .map_err(map_err)?;
+    Ok(conn.last_insert_rowid())
 }
 
 /// Look up an epic by ID. Returns `None` if not found.

--- a/crates/agileplus-sqlite/src/repository/stories.rs
+++ b/crates/agileplus-sqlite/src/repository/stories.rs
@@ -85,7 +85,9 @@ pub fn upsert_story_by_requirement_id(
     conn: &Connection,
     story: &Story,
 ) -> Result<i64, DomainError> {
-    let Some(requirement_id) = story.requirement_id.as_deref() else {
+    let now = chrono::Utc::now().to_rfc3339();
+    let req_id_owned = story.requirement_id.clone();
+    let Some(requirement_id) = req_id_owned.as_deref() else {
         return create_story(conn, story);
     };
 
@@ -93,7 +95,27 @@ pub fn upsert_story_by_requirement_id(
         return Ok(existing.id);
     }
 
-    create_story(conn, story)
+    // Insert path: create_story ignores requirement_id (same pre-existing bug as
+    // upsert_epic_by_requirement_id). Insert here directly so the row is keyed on
+    // requirement_id and get-by-requirement-id can find it on the next call.
+    conn.execute(
+        "INSERT INTO stories (epic_id, project_id, title, description, status, points, assignee_id, requirement_id, created_at, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+        rusqlite::params![
+            story.epic_id,
+            story.project_id,
+            story.title,
+            story.description,
+            story.status.to_string(),
+            story.points.map(|p| p as i64),
+            story.assignee_id,
+            requirement_id,
+            &now,
+            &now,
+        ],
+    )
+    .map_err(map_err)?;
+    Ok(conn.last_insert_rowid())
 }
 
 /// Look up a story by ID. Returns `None` if not found.


### PR DESCRIPTION
Closes the 30 sqlite RUNTIME test failures (now 80 passed / 0 failed / 0 ignored). Three real bugs closed together; details in the commit message.

Lenses: DEBUG (root-caused via migration array + parser + upsert chain), OPTIMIZE (no perf cost), ENRICH (the upsert fix improves production seed behavior, not just tests).