### PR TITLE
fix(dashboard): unblock workspace build (add member + resolve routes.rs conflicts)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
   "crates/agileplus-sqlite",
   "crates/agileplus-triage",
   "crates/agileplus-telemetry",
+  "crates/agileplus-dashboard",
 ]
 
 [workspace.package]


### PR DESCRIPTION
Adds crates/agileplus-dashboard to workspace members and resolves 4 sets of unresolved Git conflict markers in crates/agileplus-dashboard/src/routes.rs (kept pr-769 additive side per CODEOWNER direction):

1. config_path() — adds AGILEPLUS_CONFIG_PATH branch (test isolation)
2. save() error format — modern {err} placeholder
3. isolate_config() test helper definition
4. toggle_service test call site

Unblocks cargo build -p agileplus-dashboard for the agileplus-classic.pheno.studio deploy lane.