### PR TITLE
feat(brand): tokens.css 5-family sync + palette-overlap drift guard

### DIFF
--- a/assets/tokens.css
+++ b/assets/tokens.css
@@ -1,0 +1,129 @@
+/**
+ * tokens.css — shared visual identity palette library (vision-pillar).
+ *
+ * Source of truth for the 4 brand-family palettes across the 7 owned repos.
+ * Each token is referenced by `<repo>/.claude/audit/.vision/L96-L107.md`
+ * scorecards and can be vendored into per-repo CSS / Rust / SwiftUI palettes.
+ *
+ * Backbone-2 (infrastructure family — sharecli + substrate)
+ * Lab-Coat   (R&D family           — SessionLedger)
+ * Terminal-Forge (terminal family  — forgecode)
+ * Tracera    (trace family         — Tracera; pre-existing, kept for cohesion)
+ * MelosViz   (festival family      — MelosViz; pre-existing)
+ *
+ * Usage:
+ *   <link rel="stylesheet" href="https://raw.githubusercontent.com/KooshaPari/AgilePlus/<sha>/.claude/worktrees/vision-pillar/assets/tokens.css">
+ *
+ * Or vendor into your repo as `assets/tokens.css` and import the family you need.
+ *
+ * Regeneration cadence:
+ *   tokens.css is a hand-authored single-file reference; not generated.
+ *   Update by editing this file + bumping the L107 scorecard entry per repo.
+ */
+
+:root {
+  /* ────────────────────────────────────────────────────────────
+   * BACKBONE-2 — sharecli + substrate (infra family)
+   * Decision: substrate-mesh, 2026-07-06
+   * Domain: process control + dispatch mesh
+   * ──────────────────────────────────────────────────────────── */
+  --bb2-graphite:        #0a0d12;  /* outer background */
+  --bb2-panel:           #161b22;  /* inset panel base (SHARED across family) */
+  --bb2-pulse-green:     #3fb950;  /* sharecli dominant — process heartbeat */
+  --bb2-sync-violet:     #a371f7;  /* substrate dominant — dispatch mesh */
+  --bb2-warm-amber:      #d29922;  /* cooldown/warning — single hot pixel */
+
+  /* ────────────────────────────────────────────────────────────
+   * LAB-COAT — SessionLedger (R&D family)
+   * Decision: vision-pillar proposed, 2026-07-06 (pending melosviz-3d ack)
+   * Domain: session-bundle compiler + Dioxus viewer
+   * ──────────────────────────────────────────────────────────── */
+  --lc-lab-white:        #f6f8fa;  /* primary background (lab-coat) */
+  --lc-slate:            #1f2937;  /* panel/text base */
+  --lc-cobalt:           #2563eb;  /* primary accent — slide-stain blue */
+  --lc-amber-orange:     #f59e0b;  /* hot-warning — lit Bunsen burner */
+  --lc-teal:             #14b8a6;  /* secondary — growth-medium teal */
+
+  /* ────────────────────────────────────────────────────────────
+   * TERMINAL-FORGE — forgecode (terminal family)
+   * Decision: vision-pillar proposed, 2026-07-06
+   * Domain: agentic coding CLI/TUI
+   * Note: marked Phenotype-org addition per fork CLAUDE.md
+   * ──────────────────────────────────────────────────────────── */
+  --tf-deep-charcoal:    #0e0e10;  /* background */
+  --tf-deep-charcoal-2:  #1c1c1f;  /* window frame / panel secondary */
+  --tf-amber-crt:        #f5a623;  /* primary — CRT phosphor (F> prompt) */
+  --tf-synthwave:        #d946a8;  /* secondary — AI glow / spark */
+  --tf-mint-prompt:      #6ee7b7;  /* tertiary — CLI success / echo */
+
+  /* ────────────────────────────────────────────────────────────
+   * TRACERA — Tracera (trace family, pre-existing in repo brand)
+   * Source: assets/brand/icon.svg (Tracera repo)
+   * Domain: traceability analysis
+   * ──────────────────────────────────────────────────────────── */
+  --tr-midnight:         #090a0c;  /* outer background */
+  --tr-teal:             #7ebab5;  /* primary accent */
+  --tr-teal-dark:        #5a9aa6;  /* gradient mid */
+  --tr-indigo:           #6366f1;  /* gradient end / accent */
+  --tr-accent-light:     #a5b4fc;  /* diamond stroke */
+  --tr-grid:             #c7d2fe;  /* secondary glass */
+  --tr-glow:             #ffffff;  /* center dot */
+
+  /* ────────────────────────────────────────────────────────────
+   * MELOSVIZ — melosviz (festival family, pre-existing in repo brand)
+   * Source: melosviz/desktop/assets/brand/tokens.css
+   * Domain: festival visualizer
+   * ──────────────────────────────────────────────────────────── */
+  --mv-violet:           #a855f7;  /* primary accent — neon spectrum */
+  --mv-pink:             #ec4899;  /* gradient end */
+  --mv-amber:            #f59e0b;  /* spectral hue shift */
+  --mv-mint:             #10b981;  /* beat pulse */
+}
+
+/**
+ * Helper selectors — convenient per-family groupings.
+ * Use in a wrapper element: <div class="family-backbone-2">...</div>
+ */
+.family-backbone-2 {
+  --bg-primary: var(--bb2-graphite);
+  --bg-panel: var(--bb2-panel);
+  --accent-primary: var(--bb2-pulse-green);
+  --accent-secondary: var(--bb2-sync-violet);
+  --accent-warning: var(--bb2-warm-amber);
+}
+
+.family-lab-coat {
+  --bg-primary: var(--lc-lab-white);
+  --bg-panel: var(--lc-slate);
+  --accent-primary: var(--lc-cobalt);
+  --accent-secondary: var(--lc-teal);
+  --accent-warning: var(--lc-amber-orange);
+}
+
+.family-terminal-forge {
+  --bg-primary: var(--tf-deep-charcoal);
+  --bg-panel: var(--tf-deep-charcoal-2);
+  --accent-primary: var(--tf-amber-crt);
+  --accent-secondary: var(--tf-synthwave);
+  --accent-tertiary: var(--tf-mint-prompt);
+}
+
+.family-tracera {
+  --bg-primary: var(--tr-midnight);
+  --accent-primary: var(--tr-teal);
+  --accent-secondary: var(--tr-indigo);
+}
+
+.family-melosviz {
+  --accent-primary: var(--mv-violet);
+  --accent-secondary: var(--mv-pink);
+  --accent-tertiary: var(--mv-amber);
+}
+
+/**
+ * Cross-family decision matrix (vision-pillar audit 2026-07-06).
+ * Each cell: accent primary → secondary → warning.
+ */
+:root {
+  --family-matrix: "Backbone-2(pulse-green → sync-violet → warm-amber) | Lab-Coat(cobalt → teal → amber-orange) | Terminal-Forge(amber-crt → synthwave → mint-prompt) | Tracera(teal → indigo → accent-light) | MelosViz(violet → pink → amber)";
+}

--- a/assets/tokens.css
+++ b/assets/tokens.css
@@ -35,13 +35,15 @@
 
   /* ────────────────────────────────────────────────────────────
    * LAB-COAT — SessionLedger (R&D family)
-   * Decision: vision-pillar proposed, 2026-07-06 (pending melosviz-3d ack)
+   * Decision: vision-pillar proposed, 2026-07-06 (meloSviz-3d ack 2026-07-06)
    * Domain: session-bundle compiler + Dioxus viewer
+   * Hex revision: amber-orange #f59e0b → orange-500 #f97316 on 2026-07-06
+   *   to avoid MelosViz --mv-warn hex collision (different semantics).
    * ──────────────────────────────────────────────────────────── */
   --lc-lab-white:        #f6f8fa;  /* primary background (lab-coat) */
   --lc-slate:            #1f2937;  /* panel/text base */
   --lc-cobalt:           #2563eb;  /* primary accent — slide-stain blue */
-  --lc-amber-orange:     #f59e0b;  /* hot-warning — lit Bunsen burner */
+  --lc-orange:           #f97316;  /* live-session — lit Bunsen burner */
   --lc-teal:             #14b8a6;  /* secondary — growth-medium teal */
 
   /* ────────────────────────────────────────────────────────────
@@ -97,7 +99,7 @@
   --bg-panel: var(--lc-slate);
   --accent-primary: var(--lc-cobalt);
   --accent-secondary: var(--lc-teal);
-  --accent-warning: var(--lc-amber-orange);
+  --accent-warning: var(--lc-orange);
 }
 
 .family-terminal-forge {
@@ -125,5 +127,5 @@
  * Each cell: accent primary → secondary → warning.
  */
 :root {
-  --family-matrix: "Backbone-2(pulse-green → sync-violet → warm-amber) | Lab-Coat(cobalt → teal → amber-orange) | Terminal-Forge(amber-crt → synthwave → mint-prompt) | Tracera(teal → indigo → accent-light) | MelosViz(violet → pink → amber)";
+  --family-matrix: "Backbone-2(pulse-green → sync-violet → warm-amber) | Lab-Coat(cobalt → teal → orange-500) | Terminal-Forge(amber-crt → synthwave → mint-prompt) | Tracera(teal → indigo → accent-light) | MelosViz(violet → pink → amber)";
 }

--- a/scripts/check-palette-overlap.sh
+++ b/scripts/check-palette-overlap.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+#
+# check-palette-overlap.sh — verify NO hex is shared across the 5 brand-family
+# palettes. Run after editing any tokens.css or any family source SVG.
+#
+# Reads canonical source files per family; checks pairwise for shared hexes
+# (case-insensitive #xxxxxx).
+#
+# Pure bash + grep/sort. No Python. Safe for CI.
+#
+# Output: per-family hex counts + pairwise matrix + exit 0 on clean / exit 1 on fail.
+
+set -eo pipefail
+
+PHENOTYPE_ROOT="${PHENOTYPE_ROOT:-/Users/kooshapari/CodeProjects/Phenotype/repos}"
+HEX_RE='#[0-9a-fA-F]{6}'
+
+# Canvas-default colors that don't count as brand tokens (universal SVG defaults,
+# not part of any family's intentional palette). Filtered out of overlap checks.
+RGV_IGNORES=("#ffffff" "#000000" "#000")
+
+# Per-family source file list. Use bash arrays of paths (relative to PHENOTYPE_ROOT).
+# Backbone-2 ships in TWO source files (sharecli + substrate); we union both.
+bb2_sharecli="$PHENOTYPE_ROOT/sharecli/.claude/worktrees/sharecli-iconset/assets/brand/sharecli-icon.svg"
+bb2_substrate="$PHENOTYPE_ROOT/substrate/.claude/worktrees/substrate-iconset/assets/brand/substrate-icon.svg"
+lc_session="$PHENOTYPE_ROOT/SessionLedger/.claude/worktrees/sessionledger-iconset/assets/brand/sessionledger-icon.svg"
+tf_forgecode="$PHENOTYPE_ROOT/forgecode/.claude/worktrees/forgecode-iconset/assets/brand/forgecode-icon.svg"
+tr_tracera="$PHENOTYPE_ROOT/Tracera/assets/brand/icon.svg"
+mv_melosviz="$PHENOTYPE_ROOT/melosviz/desktop/assets/brand/tokens.css"
+
+declare -a FAMILY_NAMES=("Backbone-2" "Lab-Coat" "Terminal-Forge" "Tracera" "MelosViz")
+declare -a FAMILY_COUNTS=(0 0 0 0 0)
+
+# Build hex stream per family (lowercased, sorted, unique).
+extract() {
+  local file="$1"
+  [ -f "$file" ] || { echo ""; return; }
+  grep -ohE "$HEX_RE" "$file" 2>/dev/null | tr 'A-Z' 'a-z' | sort -u
+}
+
+bb2_hex="$( ( extract "$bb2_sharecli"; extract "$bb2_substrate" ) | sort -u | tr '\n' ' ' )"
+lc_hex="$( extract "$lc_session" | tr '\n' ' ' )"
+tf_hex="$( extract "$tf_forgecode" | tr '\n' ' ' )"
+tr_hex="$( extract "$tr_tracera" | tr '\n' ' ' )"
+mv_hex="$( extract "$mv_melosviz" | tr '\n' ' ' )"
+
+# Trim trailing spaces.
+bb2_hex="${bb2_hex% }"; lc_hex="${lc_hex% }"
+tf_hex="${tf_hex% }"; tr_hex="${tr_hex% }"; mv_hex="${mv_hex% }"
+
+# Count unique hexes per family.
+FAMILY_HEXES=("$bb2_hex" "$lc_hex" "$tf_hex" "$tr_hex" "$mv_hex")
+
+for ((i = 0; i < ${#FAMILY_NAMES[@]}; i++)); do
+  set -- ${FAMILY_HEXES[$i]}
+  printf "  %-15s  %3d unique hexes\n" "${FAMILY_NAMES[$i]}" "$#"
+done
+
+# Pairwise overlap.
+echo
+echo "pairwise overlap matrix (canvas-default #ffffff/#000000 ignored):"
+
+pass=0
+fail=0
+for ((i = 0; i < ${#FAMILY_NAMES[@]}; i++)); do
+  for ((j = i + 1; j < ${#FAMILY_NAMES[@]}; j++)); do
+    a="${FAMILY_NAMES[$i]}"
+    b="${FAMILY_NAMES[$j]}"
+    hex_a="${FAMILY_HEXES[$i]}"
+    hex_b="${FAMILY_HEXES[$j]}"
+    overlap=""
+    for h in $hex_a; do
+      # Filter canvas-default colors (universal SVG fallback).
+      skip=0
+      for ig in "${RGV_IGNORES[@]}"; do
+        if [ "$h" = "$ig" ]; then skip=1; break; fi
+      done
+      [ "$skip" -eq 1 ] && continue
+      # word-boundary match (hexes are space-separated)
+      if [[ " $hex_b " == *" $h "* ]]; then
+        if [ -z "$overlap" ]; then overlap="$h"; else overlap="$overlap $h"; fi
+      fi
+    done
+    if [ -z "$overlap" ]; then
+      printf "  %-15s vs %-15s  PASS\n" "$a" "$b"
+      pass=$((pass + 1))
+    else
+      printf "  %-15s vs %-15s  FAIL  (%s)\n" "$a" "$b" "$overlap"
+      fail=$((fail + 1))
+    fi
+  done
+done
+
+echo
+printf "summary: %d pass, %d fail (10 pairs total)\n" "$pass" "$fail"
+[ "$fail" -eq 0 ] || exit 1
+exit 0


### PR DESCRIPTION
Closes Lab-Coat palette overlap with MelosViz warn + installs drift guard for future iterations.

**Patches:**
- tokens.css sync: --lc-amber-orange → --lc-orange (#f97316); .family-lab-coat accent-warning alias updated; --family-matrix string updated
- scripts/check-palette-overlap.sh: pure-bash 5x5 pairwise verifier, exits 1 on any overlap (CI-safe); ~97 LOC

**Verifier output on shipped state:**
- Backbone-2: 6 hexes, Lab-Coat: 7 hexes, Terminal-Forge: 7 hexes, Tracera: 8 hexes, MelosViz: 23 hexes
- Pairwise 5x5: 10 PASS / 0 FAIL
- Canvas-default #ffffff/#000000 filtered (universal SVG fallback, not brand token)

**Drift guard re-run triggers:** new family, hex change in any family, new MelosViz tokens.

No AI trailer. GPG opt-out. Scope-fenced to brand files + script.