### PR TITLE
docs(readme): inject centered brand icon + tagline (L104)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@
 [![PWA](https://img.shields.io/badge/PWA-installable-orange)](workspace/manifest.json)
 **Quality Gate:** coverage ≥85% · e2e 100% · perf 100% · qe 100%
 
+<p align="center">
+  <a href="assets/brand/logo.svg"><img src="assets/brand/logo.svg" alt="AgilePlus" width="160" height="160"></a>
+</p>
+<p align="center"><em>AI-native project management with hexagonal Rust core, Plane.so / GitHub integration, and an AI-agent MCP surface.</em></p>
+<p align="center"><sub><a href="assets/brand/README.md">Brand assets &amp; palette</a></sub></p>
+
+---
+
 # AgilePlus
 
 **Project management system with AI agent integration** — 24-crate Rust monorepo with hexagonal architecture, Python MCP server, and Plane.so/GitHub integration.


### PR DESCRIPTION
## What
Phase 3 of the vision-pillar rollout (L104) — inject a centered brand icon + tagline at the top of `README.md`, so the canonical visual identity is the first thing renderers see.

## Files
- `README.md` — additive header block (icon link + tagline + brand-README pointer)
- `assets/brand/logo.svg` — already on origin/main (vision-pillar shipped)

## Why
L102 (Linux menu entry / dock icon) and L103 (Electrobun splash) hand off to L104 (README banner) as the final visual-pillar step. With the README header locked, every fork + clone now leads with the brand mark.

## Scope-fence
- Additive insert only. Existing prose preserved (badges, quality-gate line, H1, body sections all intact).
- No code, no CI, no `tokens.css` edits.
- ≤8 LOC added.

## Asset provenance
The brand SVG (`assets/brand/logo.svg`) is **hand-authored vector** (`AI-CODED, not AI-generated`, per `assets/brand/README.md`). No AI model produced the mark — paths were written by hand. This commit does not modify the mark; it only references it from README.