### PR TITLE
feat(brand): L101 motion polish — animated SVG variant

### DIFF
--- a/assets/brand/README.md
+++ b/assets/brand/README.md
@@ -20,6 +20,7 @@ on a dark rounded app tile.
 | `logo.png` | Canonical 512px PNG |
 | `logo.jpg` | 512px, white matte |
 | `app.ico` | Multi-resolution Windows icon (16/32/48/256) — feeds the Start-Menu / desktop shortcut |
+| `logo-animated.svg` | L101 motion variant — SMIL rotating sprint-loop + sequential velocity bars (no JS) |
 
 ## Regenerating
 
@@ -41,3 +42,16 @@ The standing backlog per-OS icon pipeline lives at
 TODO: `assets/brand/source/icon.svg` is only a placeholder. Replace it with the
 approved AgilePlus icon design before treating the generated `.ico`, `.icns`, or
 `.png` assets in `assets/brand/generated/icons/` as release-ready.
+
+## Motion variant (L101)
+
+`logo-animated.svg` ships a 4-second loop:
+
+- The agile-sprint loop (blue→purple ring + arrowhead) rotates clockwise 360° per 8s (half the
+  loop period — visually pairs with the bars).
+- The three velocity bars pulse upward in sequence (0s / 0.3s / 0.6s offsets), reading as a
+  burnup burndown.
+- Loop is seamless: last frame == first frame.
+
+All animation is SVG-native SMIL — no JavaScript, no external CSS. Safe to inline in HTML, SVG
+`<img src>`, README previews, and the splash banner.

--- a/assets/brand/logo-animated.svg
+++ b/assets/brand/logo-animated.svg
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  AgilePlus brand logo — Animated motion variant (vision-pillar L101).
+  Companion to the static logo.svg.
+  Animation: the agile-sprint loop (ring) slowly rotates clockwise; the
+  velocity bars pulse upward in sequence (burnup metaphor).
+  Loop: 4s seamless.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024" width="1024" height="1024" role="img" aria-label="AgilePlus (animated)">
+  <title>AgilePlus — animated</title>
+  <desc>Sprint loop rotating clockwise with sequential velocity-bar burnup.</desc>
+
+  <defs>
+    <linearGradient id="ap-panel" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0e1116"/>
+      <stop offset="100%" stop-color="#161b22"/>
+    </linearGradient>
+    <linearGradient id="ap-loop-grad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#3b82f6"/>
+      <stop offset="100%" stop-color="#a371f7"/>
+    </linearGradient>
+    <linearGradient id="ap-bar-grad" x1="0" y1="1" x2="0" y2="0">
+      <stop offset="0%" stop-color="#14b8a6"/>
+      <stop offset="100%" stop-color="#3fb950"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Dark app-tile panel -->
+  <rect width="1024" height="1024" rx="184" ry="184" fill="url(#ap-panel)"/>
+
+  <!-- Rotating agile-sprint loop (ring + arrowhead) -->
+  <g transform-origin="512 512">
+    <animateTransform attributeName="transform" attributeType="XML"
+                      type="rotate" from="0 512 512" to="360 512 512"
+                      dur="8s" repeatCount="indefinite"/>
+    <!-- 3/4 arc -->
+    <path d="M 512 220 A 292 292 0 1 1 256 644"
+          fill="none" stroke="url(#ap-loop-grad)" stroke-width="44" stroke-linecap="round"/>
+    <!-- Arrowhead -->
+    <polygon points="240,604 220,672 290,668" fill="#a371f7"/>
+  </g>
+
+  <!-- Velocity bars (sequential burnup) -->
+  <g fill="url(#ap-bar-grad)">
+    <rect x="380" y="560" width="64" height="80" rx="12">
+      <animate attributeName="height" values="60;140;60" dur="4s" begin="0s" repeatCount="indefinite"/>
+      <animate attributeName="y" values="580;500;580" dur="4s" begin="0s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="480" y="540" width="64" height="100" rx="12">
+      <animate attributeName="height" values="80;180;80" dur="4s" begin="0.3s" repeatCount="indefinite"/>
+      <animate attributeName="y" values="560;460;560" dur="4s" begin="0.3s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="580" y="520" width="64" height="120" rx="12">
+      <animate attributeName="height" values="100;220;100" dur="4s" begin="0.6s" repeatCount="indefinite"/>
+      <animate attributeName="y" values="540;420;540" dur="4s" begin="0.6s" repeatCount="indefinite"/>
+    </rect>
+  </g>
+
+  <!-- Static white plus accent -->
+  <rect x="488" y="488" width="48" height="48" rx="8" fill="#ffffff"/>
+</svg>


### PR DESCRIPTION
## L101 motion polish (vision-pillar Tier-3)

Companion to L96 static `logo.svg`. Adds a SMIL-driven animated motion variant.

### Changes
- **NEW** `assets/brand/logo-animated.svg` — rotating sprint-loop ring + sequential velocity bars burnup (4s loop, SMIL only, no JS)
- Append Motion variant section to `assets/brand/README.md`
- Static `logo.svg` (L96) untouched

### Scope-fence
~80 LOC. Brand-asset scope only. No changes to source, dependencies, or CI.

### Animation spec
- 4s seamless loop (bars); 8s loop (ring) — visually pairs with the bars
- Blue→purple sprint ring rotates clockwise 360° per 8s
- 3 velocity bars pulse upward in sequence (0s / 0.3s / 0.6s offsets) — reads as burnup/throughput
- SVG-native SMIL — safe for HTML inline, SVG `<img src>`, README previews, and the AgilePlus splash banner

vision-pillar L101 — Tier-3 deferral polish