### PR TITLE
feat(cli): wire RealAgentAdapter for implement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,8 +74,10 @@ dependencies = [
  "chrono",
  "clap",
  "comfy-table",
+ "dashmap",
  "predicates",
  "proptest",
+ "regex",
  "rusqlite",
  "serde",
  "serde_json",
@@ -86,6 +88,7 @@ dependencies = [
  "tokio-test",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/agileplus-cli/Cargo.toml
+++ b/crates/agileplus-cli/Cargo.toml
@@ -41,6 +41,9 @@ serde.workspace = true
 serde_json.workspace = true
 comfy-table = "7"
 similar = "2"
+dashmap = "6"
+uuid = { workspace = true }
+regex = { workspace = true }
 
 [dev-dependencies]
 assert_cmd.workspace = true

--- a/crates/agileplus-cli/src/main.rs
+++ b/crates/agileplus-cli/src/main.rs
@@ -4,7 +4,7 @@
 //! Platform health uses real HTTP/TCP probes via `agileplus-subcmds`.
 //! Traceability: WP11-T060, T065 / WP12-T072 / WP14-T084..T087
 
-mod agent_stub;
+mod agent_adapter;
 
 use std::path::PathBuf;
 use std::process;
@@ -12,7 +12,7 @@ use std::process;
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 
-use agent_stub::StubAgentAdapter;
+use agent_adapter::RealAgentAdapter;
 use agileplus_cli::commands::{
     cycle::CycleArgs, dashboard::DashboardArgs, list::ListArgs, module::ModuleArgs,
     queue::QueueArgs, specify::SpecifyArgs,
@@ -177,7 +177,7 @@ async fn run(cli: Cli) -> Result<()> {
             let storage = SqliteStorageAdapter::new(&cli.db)
                 .with_context(|| format!("opening database at {}", cli.db.display()))?;
             let vcs = open_vcs(&cli.repo)?;
-            let agent = StubAgentAdapter;
+            let agent = RealAgentAdapter::new();
             agileplus_cli::commands::implement::run_implement(args, &storage, &vcs, &agent).await
         }
         #[cfg(feature = "full-deps")]

--- a/crates/agileplus-domain/src/error.rs
+++ b/crates/agileplus-domain/src/error.rs
@@ -84,6 +84,14 @@ pub enum DomainError {
     /// Catch-all for errors that do not map to a more specific variant.
     #[error("{0}")]
     Other(String),
+
+    /// Agent dispatch / execution failure.
+    #[error("Agent error: {0}")]
+    Agent(String),
+
+    /// Operation timed out after the given number of seconds.
+    #[error("Timed out after {0} seconds")]
+    Timeout(u64),
 }
 
 /// Project the AgilePlus domain error onto the canonical Phenotype wire
@@ -113,9 +121,11 @@ impl From<DomainError> for ErrorCode {
 
             DomainError::NoOpTransition => Self::ValidationError,
 
-            DomainError::Storage(_) | DomainError::LockPoisoned | DomainError::Other(_) => {
-                Self::InternalError
-            }
+            DomainError::Storage(_)
+            | DomainError::LockPoisoned
+            | DomainError::Other(_)
+            | DomainError::Agent(_)
+            | DomainError::Timeout(_) => Self::InternalError,
         }
     }
 }


### PR DESCRIPTION
## Summary
- `implement` now constructs `RealAgentAdapter::new()` (env: `FOCAL_AGENT_BACKEND`)
- Adds `DomainError::Agent` / `Timeout` for dispatch failures
- Links `regex`, `dashmap`, `uuid` for the existing adapter module

## Test plan
- [x] `cargo check -p agileplus-cli`
- [x] release install; `implement --help`
- [x] `cargo test -p agileplus-cli --bin agileplus test_backend_selection`
- [ ] Live claude dispatch optional (`FOCAL_AGENT_BACKEND=stub` for no-op)


Made with [Cursor](https://cursor.com)