### PR TITLE
fix(api): align OpenAPI version to 0.2.1

### DIFF
--- a/crates/agileplus-api/src/openapi.rs
+++ b/crates/agileplus-api/src/openapi.rs
@@ -34,7 +34,7 @@ use crate::routes::features::CreateFeatureRequest;
 #[openapi(
     info(
         title = "AgilePlus REST API",
-        version = "0.1.1",
+        version = "0.2.1",
         description = "MVP OpenAPI scaffold — 5 representative endpoints. \
                        Full coverage of all 36 handlers is tracked as a follow-up.",
         license(name = "MIT"),


### PR DESCRIPTION
## Summary
- OpenAPI `info.version` was stuck at `0.1.1`; align to workspace release `0.2.1`
- Runtime `/health` already reports `CARGO_PKG_VERSION` (verified 0.2.1 after process restart)

## Test plan
- [x] process-compose restart `agileplus-api` → `/health` = `0.2.1`
- [ ] OpenAPI JSON reflects `0.2.1` after deploy


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the API documentation version to 0.2.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->