### PR TITLE
chore(deps): bump regex from 1.12.4 to 1.13.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4458,9 +4458,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
 dependencies = [
  "aho-corasick",
  "memchr",


### PR DESCRIPTION
## Summary
- Bumps `regex` 1.12.4 → 1.13.0 in `Cargo.lock` on current `main`
- Replaces conflicted Dependabot PR #913 (DIRTY / CONFLICTING)

## Test plan
- [x] `cargo update -p regex --precise 1.13.0`
- [ ] Local `cargo check -p agileplus-domain` (optional; CI billing may fail)

Closes #913

Made with [Cursor](https://cursor.com)