### PR TITLE
fix(domain): declare optional keychain feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,6 +127,7 @@ dependencies = [
  "chrono",
  "dirs-next",
  "indexmap",
+ "keyring",
  "proptest",
  "regex",
  "serde",
@@ -3255,6 +3256,16 @@ dependencies = [
  "serde",
  "serde_json",
  "simple_asn1",
+]
+
+[[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "log",
+ "zeroize",
 ]
 
 [[package]]

--- a/crates/agileplus-domain/Cargo.toml
+++ b/crates/agileplus-domain/Cargo.toml
@@ -19,6 +19,11 @@ zeroize.workspace = true
 regex.workspace = true
 async-trait.workspace = true
 indexmap.workspace = true
+keyring = { workspace = true, optional = true }
+
+[features]
+default = []
+keychain = ["dep:keyring"]
 
 [dev-dependencies]
 tokio.workspace = true


### PR DESCRIPTION
## Summary
- Declares optional `keychain` feature + `keyring` dep on `agileplus-domain`
- Fixes `unexpected_cfgs` / undeclared feature that blocked strict Clippy/CI
- Replaces conflicted bulk PR #914 (fmt/tonic churn already diverged; otel requires prost 0.14 so the old tonic/prost 0.13-only pin is no longer correct)

## Test plan
- [x] `cargo check -p agileplus-domain --features keychain`
- CI billing failures expected; merge with admin after local verify

Closes #914

Made with [Cursor](https://cursor.com)