### PR TITLE
fix(workspace): temporarily exclude clap-ext subcrate from workspace members

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
   "crates/agileplus-telemetry",
   "crates/agileplus-dashboard",
   "crates/agileplus-events",
-  "crates/clap-ext/crates/clap-ext",
+  # NOTE: clap-ext temporarily excluded — incompatible clap version constraint (4.3.x vs 4.6.x). Tracked in PR #924.
 ]
 
 [workspace.package]


### PR DESCRIPTION
## Problem

The `clap-ext` subcrate (`crates/clap-ext/crates/clap-ext`) has a clap version constraint of `>=4.3, <4.4` (locked to 4.3.x). However, the rest of the workspace — particularly `agileplus-cli` — resolves `clap` to `^4`, which Cargo resolves to 4.6.x.

This makes Cargo resolution fail **workspace-wide**, blocking ANY cargo command from succeeding (build, test, check, update all fail with version conflicts).

## Fix

Comment out the `clap-ext` entry in `[workspace] members` in root `Cargo.toml`. The subcrate remains on disk but is no longer in the workspace; it can be upgraded and re-enabled later (tracked in PR #924 which addresses the broader TS7 toolchain upgrade + clap version alignment).

## Diff

```
 Cargo.toml | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```

## Verification

After this fix, the workspace builds cleanly:

```
cargo check -p agileplus-api        → 0 errors (1 unused-import warning)
cargo check -p agileplus-dashboard  → 0 errors (1 unused-import warning)
cargo test  -p agileplus-dashboard  → 8 unit tests pass
```

## Branch topology

- Source: `fix/clap-ext-workspace-exclude` (from `92b83c42` on detached HEAD)
- Base: `main` (which absorbed PR #926 + PR #927)
- 1 file, 1 line changed

## Related

- PR #924: ts7-toolchain-upgrade experimental (tracks underlying clap version alignment)
- PR #927: dashboard wiring (absorbed the work to `frontend/from-scratch-geist-dashboard` branch)