### PR TITLE
docs: add Planify2 and RepoLedger preservation manifests

### DIFF
--- a/docs/airlock/manifests-pre-squash-2026-07-29/planify2-preservation-manifest.txt
+++ b/docs/airlock/manifests-pre-squash-2026-07-29/planify2-preservation-manifest.txt
@@ -1,0 +1,18 @@
+Repository: KooshaPari/Planify2
+Captured: 2026-07-29
+Disposition: KEEP DISTINCT; Planify is the frontend parent candidate
+Fork: false
+Archived: false
+Local HEAD: e6b8e23511e6e43ac5466543b57ab4d192ddb50d
+Authoritative origin/main: d5088392caead6f851052e93de688b677735a672
+Parity: FAIL (local checkout is stale; no ref rewrite performed)
+Bundle: /tmp/planify2-bundle.tzbewT/Planify2-all.bundle
+Bundle bytes: 860738272
+Bundle SHA-256: 683b563f4e47f1dde173df5a645945d93784b70b094d3a26763fa10ec58ccdf7
+Bundle verify: PASS (complete history, 72 refs)
+fsck: PASS (no missing/corrupt objects; dangling objects only)
+Independent restore: PASS (local temporary restore)
+Second-cloud copy: NOT VERIFIED
+Archive eligibility: FAIL (parity and dual-cloud gates unmet)
+License note: root Apache-2.0; embedded Plane upstream contains AGPL-3.0-only material
+Policy: no deletion; any future retirement requires zz-archive- prefix, dual-cloud proof, and sponsor ACK

--- a/docs/airlock/manifests-pre-squash-2026-07-29/planify2-preservation-manifest.txt
+++ b/docs/airlock/manifests-pre-squash-2026-07-29/planify2-preservation-manifest.txt
@@ -6,14 +6,14 @@ Archived: false
 Local HEAD: e6b8e23511e6e43ac5466543b57ab4d192ddb50d
 Authoritative origin/main: d5088392caead6f851052e93de688b677735a672
 Parity: FAIL (local checkout is stale; no ref rewrite performed)
-Bundle: /tmp/planify2-bundle.tzbewT/Planify2-all.bundle (ephemeral local path; durable artifact location absent)
+Bundle: r2://tracera-artifacts/preservation/Planify2/683b563f4e47f1dde173df5a645945d93784b70b094d3a26763fa10ec58ccdf7/chunks-v3/ (nine 100 MiB parts; remote restore/hash verification pending)
 Bundle bytes: 860738272
 Bundle SHA-256: 683b563f4e47f1dde173df5a645945d93784b70b094d3a26763fa10ec58ccdf7
 Bundle verify: PASS (complete history, 72 refs)
 fsck: PASS (no missing/corrupt objects; dangling objects only)
 Independent restore: PASS (local temporary restore)
 Second-cloud copy: NOT VERIFIED
-Durable artifact location: ABSENT (bundle is not independently retrievable)
+Durable artifact location: r2://tracera-artifacts/preservation/Planify2/683b563f4e47f1dde173df5a645945d93784b70b094d3a26763fa10ec58ccdf7/chunks-v3/ (chunk upload receipts present; per-object GET/reconstruction pending)
 Dual-cloud gate: HELD (second-cloud copy and independent restore not verified)
 Sponsor ACK: NOT RECEIVED
 Archive eligibility: FAIL / HELD (parity, dual-cloud, and sponsor-ACK gates unmet)

--- a/docs/airlock/manifests-pre-squash-2026-07-29/planify2-preservation-manifest.txt
+++ b/docs/airlock/manifests-pre-squash-2026-07-29/planify2-preservation-manifest.txt
@@ -6,13 +6,16 @@ Archived: false
 Local HEAD: e6b8e23511e6e43ac5466543b57ab4d192ddb50d
 Authoritative origin/main: d5088392caead6f851052e93de688b677735a672
 Parity: FAIL (local checkout is stale; no ref rewrite performed)
-Bundle: /tmp/planify2-bundle.tzbewT/Planify2-all.bundle
+Bundle: /tmp/planify2-bundle.tzbewT/Planify2-all.bundle (ephemeral local path; durable artifact location absent)
 Bundle bytes: 860738272
 Bundle SHA-256: 683b563f4e47f1dde173df5a645945d93784b70b094d3a26763fa10ec58ccdf7
 Bundle verify: PASS (complete history, 72 refs)
 fsck: PASS (no missing/corrupt objects; dangling objects only)
 Independent restore: PASS (local temporary restore)
 Second-cloud copy: NOT VERIFIED
-Archive eligibility: FAIL (parity and dual-cloud gates unmet)
+Durable artifact location: ABSENT (bundle is not independently retrievable)
+Dual-cloud gate: HELD (second-cloud copy and independent restore not verified)
+Sponsor ACK: NOT RECEIVED
+Archive eligibility: FAIL / HELD (parity, dual-cloud, and sponsor-ACK gates unmet)
 License note: root Apache-2.0; embedded Plane upstream contains AGPL-3.0-only material
 Policy: no deletion; any future retirement requires zz-archive- prefix, dual-cloud proof, and sponsor ACK

--- a/docs/airlock/manifests-pre-squash-2026-07-29/repoledger-preservation-manifest.txt
+++ b/docs/airlock/manifests-pre-squash-2026-07-29/repoledger-preservation-manifest.txt
@@ -1,0 +1,17 @@
+Repository: KooshaPari/RepoLedger
+Captured: 2026-07-29
+Disposition: KEEP DISTINCT; integrate with phenotype-registry by explicit contracts
+Fork: false
+Archived: false
+Local HEAD: b664b757215df00a49536a861372cf864cb98bf1
+Authoritative origin/main: d6fcb37e8fd90dc5d12ae4fb9eaead0bc5046432
+Parity: FAIL (local checkout is behind by 4; no ref rewrite performed)
+Bundle: /tmp/repoledger-bundle.jH9uGP/RepoLedger-all.bundle
+Bundle SHA-256: 07187fac803fc96a8ed5d6c9109041ffda44c3e1708f82a20b46c42a8a6188a7
+Bundle verify: PASS (complete history, 8 refs)
+fsck: PASS (no missing/corrupt objects)
+Independent restore: PASS (local temporary restore to b664b757)
+Second-cloud copy: NOT VERIFIED
+Archive eligibility: FAIL (parity and dual-cloud gates unmet)
+License note: GitHub license metadata absent; no LICENSE file detected
+Policy: no deletion; any future retirement requires zz-archive- prefix, dual-cloud proof, and sponsor ACK

--- a/docs/airlock/manifests-pre-squash-2026-07-29/repoledger-preservation-manifest.txt
+++ b/docs/airlock/manifests-pre-squash-2026-07-29/repoledger-preservation-manifest.txt
@@ -6,14 +6,14 @@ Archived: false
 Local HEAD: b664b757215df00a49536a861372cf864cb98bf1
 Authoritative origin/main: d6fcb37e8fd90dc5d12ae4fb9eaead0bc5046432
 Parity: FAIL (local checkout is behind by 4; no ref rewrite performed)
-Bundle: /tmp/repoledger-bundle.jH9uGP/RepoLedger-all.bundle (ephemeral local path; durable artifact location absent)
+Bundle: r2://tracera-artifacts/preservation/RepoLedger/07187fac803fc96a8ed5d6c9109041ffda44c3e1708f82a20b46c42a8a6188a7/RepoLedger-all.bundle
 Bundle bytes: 60351
 Bundle SHA-256: 07187fac803fc96a8ed5d6c9109041ffda44c3e1708f82a20b46c42a8a6188a7
 Bundle verify: PASS (complete history, 8 refs)
 fsck: PASS (no missing/corrupt objects; dangling remote-tracking objects only)
 Independent restore: PASS (temporary local clone restored b664b757; not a second-cloud restore)
 Second-cloud copy: NOT VERIFIED
-Durable artifact location: ABSENT (bundle is not independently retrievable)
+Durable artifact location: r2://tracera-artifacts/preservation/RepoLedger/07187fac803fc96a8ed5d6c9109041ffda44c3e1708f82a20b46c42a8a7/RepoLedger-all.bundle (R2 upload and checksum restore receipt recorded)
 Dual-cloud gate: HELD (second-cloud copy and independent restore not verified)
 Sponsor ACK: NOT RECEIVED
 Archive eligibility: FAIL / HELD (parity, dual-cloud, and sponsor-ACK gates unmet)

--- a/docs/airlock/manifests-pre-squash-2026-07-29/repoledger-preservation-manifest.txt
+++ b/docs/airlock/manifests-pre-squash-2026-07-29/repoledger-preservation-manifest.txt
@@ -6,12 +6,13 @@ Archived: false
 Local HEAD: b664b757215df00a49536a861372cf864cb98bf1
 Authoritative origin/main: d6fcb37e8fd90dc5d12ae4fb9eaead0bc5046432
 Parity: FAIL (local checkout is behind by 4; no ref rewrite performed)
-Bundle: /tmp/repoledger-bundle.jH9uGP/RepoLedger-all.bundle
+Bundle: /tmp/repoledger-bundle.jH9uGP/RepoLedger-all.bundle (ephemeral local path; not the durable receipt)
+Bundle bytes: 60351
 Bundle SHA-256: 07187fac803fc96a8ed5d6c9109041ffda44c3e1708f82a20b46c42a8a6188a7
 Bundle verify: PASS (complete history, 8 refs)
-fsck: PASS (no missing/corrupt objects)
-Independent restore: PASS (local temporary restore to b664b757)
+fsck: PASS (no missing/corrupt objects; dangling remote-tracking objects only)
+Independent restore: PASS (temporary local clone restored b664b757; not a second-cloud restore)
 Second-cloud copy: NOT VERIFIED
-Archive eligibility: FAIL (parity and dual-cloud gates unmet)
+Archive eligibility: FAIL / HELD (parity and dual-cloud gates unmet; no sponsor ACK)
 License note: GitHub license metadata absent; no LICENSE file detected
 Policy: no deletion; any future retirement requires zz-archive- prefix, dual-cloud proof, and sponsor ACK

--- a/docs/airlock/manifests-pre-squash-2026-07-29/repoledger-preservation-manifest.txt
+++ b/docs/airlock/manifests-pre-squash-2026-07-29/repoledger-preservation-manifest.txt
@@ -6,13 +6,16 @@ Archived: false
 Local HEAD: b664b757215df00a49536a861372cf864cb98bf1
 Authoritative origin/main: d6fcb37e8fd90dc5d12ae4fb9eaead0bc5046432
 Parity: FAIL (local checkout is behind by 4; no ref rewrite performed)
-Bundle: /tmp/repoledger-bundle.jH9uGP/RepoLedger-all.bundle (ephemeral local path; not the durable receipt)
+Bundle: /tmp/repoledger-bundle.jH9uGP/RepoLedger-all.bundle (ephemeral local path; durable artifact location absent)
 Bundle bytes: 60351
 Bundle SHA-256: 07187fac803fc96a8ed5d6c9109041ffda44c3e1708f82a20b46c42a8a6188a7
 Bundle verify: PASS (complete history, 8 refs)
 fsck: PASS (no missing/corrupt objects; dangling remote-tracking objects only)
 Independent restore: PASS (temporary local clone restored b664b757; not a second-cloud restore)
 Second-cloud copy: NOT VERIFIED
-Archive eligibility: FAIL / HELD (parity and dual-cloud gates unmet; no sponsor ACK)
+Durable artifact location: ABSENT (bundle is not independently retrievable)
+Dual-cloud gate: HELD (second-cloud copy and independent restore not verified)
+Sponsor ACK: NOT RECEIVED
+Archive eligibility: FAIL / HELD (parity, dual-cloud, and sponsor-ACK gates unmet)
 License note: GitHub license metadata absent; no LICENSE file detected
 Policy: no deletion; any future retirement requires zz-archive- prefix, dual-cloud proof, and sponsor ACK


### PR DESCRIPTION
## Summary
- add immutable preservation manifest for Planify2
- add immutable preservation manifest for RepoLedger
- record parity, bundle verification, and archive-gate evidence

## Safety
- no source code changes
- no archive, rename, delete, or merge
- forks remain protected by existing governance policy

## Validation
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added preservation records for Planify2 and RepoLedger.
  * Documented repository identity, capture details, commit status, licensing, and archival disposition.
  * Recorded successful bundle, integrity, and local restoration checks.
  * Noted pending secondary-cloud and reconstruction verification, along with unmet approval requirements.
  * Defined no-deletion retirement safeguards, including dual-cloud confirmation, sponsor approval, and archive naming requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->