### PR TITLE
docs(airlock): complete preservation branch inventories

### DIFF
--- a/docs/airlock/manifests-pre-squash-2026-07-29/planify2-preservation-manifest.txt
+++ b/docs/airlock/manifests-pre-squash-2026-07-29/planify2-preservation-manifest.txt
@@ -1,5 +1,27 @@
 Repository: KooshaPari/Planify2
 Captured: 2026-07-29
+HEAD metadata: checkout branch `feat/dual-harness-fixture-path-fix`; tip `e6b8e23511e6e43ac5466543b57ab4d192ddb50d`; committed `2026-07-23T02:53:25-07:00`; subject `fix(dual-harness): make fixture path resolution robust across repo root & worktrees`
+Branch inventory captured: 2026-08-02T04:19:30Z
+Branch inventory source: 16 local `refs/heads/*` plus cached `refs/remotes/origin/*` branch refs (17 rows; symbolic `origin/HEAD` omitted). `git ls-remote origin` returned `Repository not found`, so the remote rows are cached provenance only.
+Novel-count baseline: local `main` (`e6b8e23511e6e43ac5466543b57ab4d192ddb50d`). Counts are reachable-graph counts; this checkout retains 25 shallow boundaries, so counts are lower bounds where a branch crosses an unavailable parent.
+Branch inventory (sorted; scope | branch | novel commits vs baseline | tip OID | committed | subject):
+local | `chore/dual-harness-baseline-20260722` | 0 (reachable graph) | `c3ad6008b133511b7fe98858747aa1b3fb2d5af2` | `2026-07-08T17:15:12-07:00` | `feat: add upstream sync workflow, ADR-0005, and CI badges`
+local | `consolidate/agileplus-from-planify2` | 2 (reachable graph) | `f4df500df94923a9cf6d986cec896a1d8fcaef74` | `2026-07-23T02:51:48-07:00` | `feat(consolidation): merge Planify2 provenance + landing into Planify (canonical)`
+local | `feat/dual-harness-fixture-adapter` | 1 (lower bound; shallow history) | `6d35ba6c7ba84dc36162b7c9f8df0efd1304f7d7` | `2026-07-22T20:25:44-07:00` | `feat(dual-harness): Planify2 shared-3task.v1 adapter (FR-DH-001)`
+local | `feat/dual-harness-fixture-path-fix` | 0 (reachable graph) | `e6b8e23511e6e43ac5466543b57ab4d192ddb50d` | `2026-07-23T02:53:25-07:00` | `fix(dual-harness): make fixture path resolution robust across repo root & worktrees`
+local | `frontend/legacy-forge-snapshot` | 1765 (reachable graph) | `3e2ea97e4745c42338087977444cf50bd263ec2d` | `2026-07-15T19:50:01-07:00` | `feat(agileplus): capture forge/AgilePlus WIP 2026-07-15`
+local | `frontend/legacy-forge-wip` | 1765 (reachable graph) | `3e2ea97e4745c42338087977444cf50bd263ec2d` | `2026-07-15T19:50:01-07:00` | `feat(agileplus): capture forge/AgilePlus WIP 2026-07-15`
+local | `frontend/plane-integration-adapter` | 1767 (reachable graph) | `d4dcd098245c5e850725c875f225a642f58a61c9` | `2026-07-22T04:04:52-07:00` | `fix(api): compile agileplus-api against current domain ports`
+local | `frontend/planify-candidate-1` | 1585 (reachable graph) | `f84140634a644012426777f8dd30188bed0d8c5e` | `2026-07-17T04:27:48-07:00` | `recovery: preserve meaningful local work (20260717-0410)`
+local | `frontend/planify-eval-doc` | 1359 (reachable graph) | `07f151cdbb6e596cd24627d85e49088357ede9bc` | `2026-05-30T21:17:38-07:00` | `docs: add Planify frontend candidate #1 evaluation (#629)`
+local | `frontend/planify-recovery-preserve` | 1585 (reachable graph) | `f84140634a644012426777f8dd30188bed0d8c5e` | `2026-07-17T04:27:48-07:00` | `recovery: preserve meaningful local work (20260717-0410)`
+local | `frontend/planify-rest-shim` | 1365 (reachable graph) | `87daa898f1148cea9ffe0ed5911466ac1a6f476e` | `2026-05-31T16:27:45-07:00` | `feat: Planify<->AgilePlus REST shim adapter (frontend candidate #1 wiring) (#630)`
+local | `frontend/planify-shim-workspace` | 1767 (reachable graph) | `d4dcd098245c5e850725c875f225a642f58a61c9` | `2026-07-22T04:04:52-07:00` | `fix(api): compile agileplus-api against current domain ports`
+local | `frontend/recovery-isolated` | 1765 (reachable graph) | `0aafdf9692c11abb6e426f36857aeec7bb6cd942` | `2026-07-14T21:39:01-07:00` | `docs(recovery): establish isolated recovery boundary`
+local | `frontend/recovery-isolated-20260714` | 1765 (reachable graph) | `0aafdf9692c11abb6e426f36857aeec7bb6cd942` | `2026-07-14T21:39:01-07:00` | `docs(recovery): establish isolated recovery boundary`
+local | `main` | 0 (reachable graph) | `e6b8e23511e6e43ac5466543b57ab4d192ddb50d` | `2026-07-23T02:53:25-07:00` | `fix(dual-harness): make fixture path resolution robust across repo root & worktrees`
+remote | `origin/main` | 2 (cached reachable graph) | `d5088392caead6f851052e93de688b677735a672` | `2026-07-29T00:01:59-07:00` | `ci: add .github/workflows/ci.yml (smart-discover template)`
+local | `wip/20260801T0904-18c7a309f413de78` | 0 (reachable graph) | `e6b8e23511e6e43ac5466543b57ab4d192ddb50d` | `2026-07-23T02:53:25-07:00` | `fix(dual-harness): make fixture path resolution robust across repo root & worktrees`
 Disposition: KEEP DISTINCT; Planify is the frontend parent candidate
 Fork: false
 Archived: false
@@ -11,7 +33,7 @@ Bundle bytes: 860738272
 Bundle SHA-256: 683b563f4e47f1dde173df5a645945d93784b70b094d3a26763fa10ec58ccdf7
 Bundle verify: PASS (complete history, 72 refs)
 fsck: PASS (no missing/corrupt objects; dangling objects only)
-Independent restore: PASS (local temporary restore)
+Independent restore: PASS (local temporary restore only; not a second-cloud restore)
 Second-cloud copy: NOT VERIFIED
 Durable artifact location: r2://tracera-artifacts/preservation/Planify2/683b563f4e47f1dde173df5a645945d93784b70b094d3a26763fa10ec58ccdf7/chunks-v3/ (chunk upload receipts present; per-object GET/reconstruction pending)
 Dual-cloud gate: HELD (second-cloud copy and independent restore not verified)

--- a/docs/airlock/manifests-pre-squash-2026-07-29/planify2-preservation-manifest.txt
+++ b/docs/airlock/manifests-pre-squash-2026-07-29/planify2-preservation-manifest.txt
@@ -26,8 +26,8 @@ Disposition: KEEP DISTINCT; Planify is the frontend parent candidate
 Fork: false
 Archived: false
 Local HEAD: e6b8e23511e6e43ac5466543b57ab4d192ddb50d
-Authoritative origin/main: d5088392caead6f851052e93de688b677735a672
-Parity: FAIL (local checkout is stale; no ref rewrite performed)
+Preservation snapshot origin/main: d5088392caead6f851052e93de688b677735a672 (captured 2026-07-29; cached; endpoint unavailable)
+Parity: FAIL (local checkout is stale; cached origin parity unverified; no ref rewrite performed)
 Bundle: r2://tracera-artifacts/preservation/Planify2/683b563f4e47f1dde173df5a645945d93784b70b094d3a26763fa10ec58ccdf7/chunks-v3/ (nine 100 MiB parts; remote restore/hash verification pending)
 Bundle bytes: 860738272
 Bundle SHA-256: 683b563f4e47f1dde173df5a645945d93784b70b094d3a26763fa10ec58ccdf7
@@ -36,7 +36,7 @@ fsck: PASS (no missing/corrupt objects; dangling objects only)
 Independent restore: PASS (local temporary restore only; not a second-cloud restore)
 Second-cloud copy: NOT VERIFIED
 Durable artifact location: r2://tracera-artifacts/preservation/Planify2/683b563f4e47f1dde173df5a645945d93784b70b094d3a26763fa10ec58ccdf7/chunks-v3/ (chunk upload receipts present; per-object GET/reconstruction pending)
-Dual-cloud gate: HELD (second-cloud copy and independent restore not verified)
+Dual-cloud gate: HELD (second-cloud copy and second-cloud restore not verified; local temporary restore verified)
 Sponsor ACK: NOT RECEIVED
 Archive eligibility: FAIL / HELD (parity, dual-cloud, and sponsor-ACK gates unmet)
 License note: root Apache-2.0; embedded Plane upstream contains AGPL-3.0-only material

--- a/docs/airlock/manifests-pre-squash-2026-07-29/repoledger-preservation-manifest.txt
+++ b/docs/airlock/manifests-pre-squash-2026-07-29/repoledger-preservation-manifest.txt
@@ -1,5 +1,16 @@
 Repository: KooshaPari/RepoLedger
 Captured: 2026-07-29
+HEAD metadata: checkout branch `main`; tip `b664b757215df00a49536a861372cf864cb98bf1`; committed `2026-07-22T05:55:56-07:00`; subject `build(deps): Bump golang.org/x/net (#2)`
+Branch inventory captured: 2026-08-02T04:19:30Z
+Branch inventory source: 3 local `refs/heads/*` plus current `refs/remotes/origin/*` branch refs (6 rows; symbolic `origin/HEAD` omitted). `origin` was fetched before capture; current remote heads are represented.
+Novel-count baseline: authoritative `origin/main` (`b2af7482a7e61d58b5a2da84ccd43d7a672a2a38`). Counts use the complete fetched graph.
+Branch inventory (sorted; scope | branch | novel commits vs baseline | tip OID | committed | subject):
+local | `feat/ts7-toolchain-upgrade-monorepo` | 1 | `5c0b8fbf82198839c49ec405a953d21ffc666af8` | `2026-07-21T20:13:04-07:00` | `feat(ops): add Bun as side-by-side runner for the pnpm monorepo`
+local | `main` | 0 | `b664b757215df00a49536a861372cf864cb98bf1` | `2026-07-22T05:55:56-07:00` | `build(deps): Bump golang.org/x/net (#2)`
+remote | `origin/dependabot/go_modules/apps/ecosystem-console/server/go_modules-57bd245098` | 1 | `316f7ab60e4d4ad2809e7ddcf9dc3cb1a4299e9b` | `2026-07-22T08:15:45Z` | `build(deps): Bump golang.org/x/net`
+remote | `origin/main` | 0 | `b2af7482a7e61d58b5a2da84ccd43d7a672a2a38` | `2026-08-01T19:01:42-07:00` | `ci: update workflow with stable lint/test gate names`
+remote | `origin/wip/20260722T1300-18c49e2a97a9b680` | 0 | `b664b757215df00a49536a861372cf864cb98bf1` | `2026-07-22T05:55:56-07:00` | `build(deps): Bump golang.org/x/net (#2)`
+local | `wip/20260722T1300-18c49e2a97a9b680` | 0 | `b664b757215df00a49536a861372cf864cb98bf1` | `2026-07-22T05:55:56-07:00` | `build(deps): Bump golang.org/x/net (#2)`
 Disposition: KEEP DISTINCT; integrate with phenotype-registry by explicit contracts
 Fork: false
 Archived: false

--- a/docs/airlock/manifests-pre-squash-2026-07-29/repoledger-preservation-manifest.txt
+++ b/docs/airlock/manifests-pre-squash-2026-07-29/repoledger-preservation-manifest.txt
@@ -15,8 +15,8 @@ Disposition: KEEP DISTINCT; integrate with phenotype-registry by explicit contra
 Fork: false
 Archived: false
 Local HEAD: b664b757215df00a49536a861372cf864cb98bf1
-Authoritative origin/main: d6fcb37e8fd90dc5d12ae4fb9eaead0bc5046432
-Parity: FAIL (local checkout is behind by 4; no ref rewrite performed)
+Preservation snapshot origin/main: d6fcb37e8fd90dc5d12ae4fb9eaead0bc5046432 (captured 2026-07-29; bundle/parity evidence below refers to this snapshot)
+Parity: FAIL (2026-07-29 preservation snapshot local checkout was behind by 4; current origin/main inventory `b2af7482a7e61d58b5a2da84ccd43d7a672a2a38` captured 2026-08-02; no ref rewrite performed)
 Bundle: r2://tracera-artifacts/preservation/RepoLedger/07187fac803fc96a8ed5d6c9109041ffda44c3e1708f82a20b46c42a8a6188a7/RepoLedger-all.bundle
 Bundle bytes: 60351
 Bundle SHA-256: 07187fac803fc96a8ed5d6c9109041ffda44c3e1708f82a20b46c42a8a6188a7
@@ -25,7 +25,7 @@ fsck: PASS (no missing/corrupt objects; dangling remote-tracking objects only)
 Independent restore: PASS (temporary local clone restored b664b757; not a second-cloud restore)
 Second-cloud copy: NOT VERIFIED
 Durable artifact location: r2://tracera-artifacts/preservation/RepoLedger/07187fac803fc96a8ed5d6c9109041ffda44c3e1708f82a20b46c42a8a7/RepoLedger-all.bundle (R2 upload and checksum restore receipt recorded)
-Dual-cloud gate: HELD (second-cloud copy and independent restore not verified)
+Dual-cloud gate: HELD (second-cloud copy and second-cloud restore not verified; temporary local restore verified)
 Sponsor ACK: NOT RECEIVED
 Archive eligibility: FAIL / HELD (parity, dual-cloud, and sponsor-ACK gates unmet)
 License note: GitHub license metadata absent; no LICENSE file detected


### PR DESCRIPTION
## **User description**
Follow-up to #930.

## Scope
- Add complete sorted local + cached origin branch inventories to both Planify2 and RepoLedger preservation manifests.
- Include HEAD metadata, tip OID, timestamp, subject, and novel-commit count versus the stated baseline.
- Clarify Planify2 restore evidence as local temporary only; second-cloud gate remains explicitly unverified.

## Evidence
- Planify2: 17 refs (16 local + cached origin/main); origin endpoint currently returns Repository not found, and the checkout retains shallow boundaries, both recorded in the manifest.
- RepoLedger: 6 refs (3 local + 3 fetched origin); baseline is current origin/main.
- Targeted parser/source-ref inventory validation: PASS.
- git diff --check: PASS.
- Airlock snapshot: wip/20260802T0439-18c7e333b129adf8.

No files, branches, or refs were deleted. This PR is intentionally not merged by the agent.


___

## **CodeAnt-AI Description**
Document complete branch inventories and preservation verification status

### What Changed
- Added sorted local and cached remote branch inventories for the RepoLedger and Planify2 preservation manifests, including branch tips, commit details, and commit counts against a stated baseline
- Recorded repository state details such as checkout heads, fetch timing, shallow-history limits, and unavailable remote access
- Clarified that Planify2 restoration was verified only in a temporary local environment; second-cloud copying and independent restoration remain unverified

### Impact
`✅ Complete branch recovery records`
`✅ Clearer preservation and restore boundaries`
`✅ Traceable repository snapshot provenance`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded preservation records with captured HEAD information, branch inventory provenance, and novel-commit baselines.
  * Added sorted local and remote branch details, including branch tips, commit timestamps, and subjects.
  * Clarified restore verification status to distinguish local temporary restoration checks from second-cloud restoration checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->