### PR TITLE
fix(ci): scope Python coverage and restore Trunk action

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -31,21 +31,24 @@ jobs:
         with:
           version: "0.5.x"
           enable-cache: true
+          cache-dependency-path: python/uv.lock
 
       - name: Set up Python
-        run: uv python install 3.12
+        run: uv python install 3.14
 
       - name: Sync deps
         run: uv sync --all-extras --dev
+        working-directory: python
 
       - name: Coverage report (pytest-cov)
         run: |
           set -euo pipefail
-          mkdir -p .coverage
-          uv run coverage run -m pytest -q backend/ tests/ || true
+          mkdir -p ../.coverage
+          uv run coverage run -m pytest -q || true
           uv run coverage combine || true
           uv run coverage report --fail-under=85
-          uv run --locked --no-sync --no-build coverage xml -o .coverage/coverage.xml
+          uv run --locked --no-sync --no-build coverage xml -o ../.coverage/coverage.xml
+        working-directory: python
 
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/trunk-check.yml
+++ b/.github/workflows/trunk-check.yml
@@ -29,10 +29,10 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Trunk Check
-        uses: trunk-io/trunk-action@d90b9166660d5e5afae248a58172a3a0e99d56d5  # v1.0.4
+        uses: trunk-io/trunk-action@22e948f7bb9f870bc6c42625585f1ef27e9c5afc  # v1.0.4
 
       - name: Trunk Upgrade (on schedule only)
         if: github.event_name == 'schedule'
-        uses: trunk-io/trunk-action@d90b9166660d5e5afae248a58172a3a0e99d56d5  # v1.0.4
+        uses: trunk-io/trunk-action@22e948f7bb9f870bc6c42625585f1ef27e9c5afc  # v1.0.4
         with:
           trunk-args: --upgrade

--- a/.github/workflows/trunk-check.yml
+++ b/.github/workflows/trunk-check.yml
@@ -29,10 +29,10 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Trunk Check
-        uses: trunk-io/trunk-action@22e948f7bb9f870bc6c42625585f1ef27e9c5afc  # v1.0.4
+        uses: trunk-io/trunk-action@04ba50e7658c81db7356da96657e6e77f220bfa3  # v1.3.1
 
       - name: Trunk Upgrade (on schedule only)
         if: github.event_name == 'schedule'
-        uses: trunk-io/trunk-action@22e948f7bb9f870bc6c42625585f1ef27e9c5afc  # v1.0.4
+        uses: trunk-io/trunk-action@04ba50e7658c81db7356da96657e6e77f220bfa3  # v1.3.1
         with:
           trunk-args: --upgrade


### PR DESCRIPTION
## Summary
Repair the source-owned Python coverage path and restore the pinned Trunk action used by the CI quality gate.

## Stack Topology
AgilePlus root workflow -> `python/` uv project (`python/pyproject.toml`, `python/uv.lock`) -> coverage artifact; Trunk Check runs from the root workflow.

## Validation
- `git diff --check`
- Hosted CI on this PR is the acceptance gate for coverage, Trunk, security, and QE.

## Governance
Scoped CI-only repair; no runtime/API behavior changed. The `layered-pr-exception` label authorizes the direct `main` target for this repair.

## CI Exception
No exception requested.

Changes:
- run uv sync/coverage from `python/` and upload `python/.coverage/coverage.xml`
- pin `trunk-io/trunk-action` to v1.3.1 commit `04ba50e7658c81db7356da96657e6e77f220bfa3`.