### PR TITLE
airlock: absorb archived repos into AgilePlus (2026-08-08)

### DIFF
--- a/.archive/AgilePlus-recovery-20260714/.commitlintrc.yml
+++ b/.archive/AgilePlus-recovery-20260714/.commitlintrc.yml
@@ -1,0 +1,47 @@
+extends:
+  - "@commitlint/config-conventional"
+rules:
+  type-enum:
+    - 2
+    - always
+    - - feat
+      - fix
+      - docs
+      - style
+      - refactor
+      - perf
+      - test
+      - chore
+      - ci
+      - build
+      - revert
+  scope-enum:
+    - 1
+    - always
+    - - proto
+      - rust
+      - python
+      - ci
+      - deps
+      - WP00
+      - WP01
+      - WP02
+      - WP03
+      - WP04
+      - WP05
+      - WP06
+      - WP07
+      - WP08
+      - WP09
+      - WP10
+      - WP11
+      - WP12
+      - WP13
+      - WP14
+      - WP15
+      - WP16
+      - WP17
+      - WP18
+      - WP19
+      - WP20
+      - WP21

--- a/.archive/AgilePlus-recovery-20260714/.trufflehog.yml
+++ b/.archive/AgilePlus-recovery-20260714/.trufflehog.yml
@@ -1,0 +1,14 @@
+exclude:
+  paths:
+    - ".git/**"
+    - "target/**"
+    - "node_modules/**"
+    - "*.sum"
+    - "*.lock"
+    - "dist/**"
+    - ".github/workflows/**"
+    - "**/*.yml"
+    - "**/*.yaml"
+include:
+  files:
+    - "**/*"

--- a/.archive/AgilePlus-recovery-20260714/PhenoLang-crates-2026-06-20/ORIGIN.md
+++ b/.archive/AgilePlus-recovery-20260714/PhenoLang-crates-2026-06-20/ORIGIN.md
@@ -1,0 +1,5 @@
+# PhenoLang AgilePlus crate preservation
+
+Preserved from `KooshaPari/PhenoLang/crates/agileplus-*` into `KooshaPari/AgilePlus/archive/PhenoLang-crates-2026-06-20`.
+
+Reason: same-name AgilePlus active crates exist, but byte-level diffs showed source deltas. This archive preserves PhenoLang variants without overwriting active AgilePlus implementations.

--- a/.archive/AgilePlus-recovery-20260714/README.md
+++ b/.archive/AgilePlus-recovery-20260714/README.md
@@ -1,0 +1,89 @@
+# `AgilePlus-recovery-20260714` — Absorbed Recovery Snapshot
+
+This directory preserves the unique content from
+`KooshaPari/zz-archive-AgilePlus-recovery-20260714` (archived 2026-07-15),
+which was a recovery snapshot of the `AgilePlus` repo taken on 2026-07-14
+when the live working tree had gotten into a dirty state during the cleanup
+wave and a clean baseline was needed.
+
+**Date merged:** 2026-08-08
+**Source commit:** `KooshaPari/zz-archive-AgilePlus-recovery-20260714@main`
+**Merger:** forge-airlock (manual semantic integration)
+
+## What this archive was
+
+A pre-2026-07-14 snapshot of `KooshaPari/AgilePlus`, created via:
+
+```
+git clone --depth 1 git@github.com:KooshaPari/AgilePlus.git AgilePlus-recovery-20260714
+```
+
+The recovery was performed at baseline `a83a7677ecacac0a3080e41da312d80def74fee5`
+while the dirty live working tree at `~/CodeProjects/Phenotype/repos/AgilePlus/`
+was quarantined as evidence-only. See
+[`docs/sessions/20260714-isolated-recovery/00_SESSION_OVERVIEW.md`](docs/sessions/20260714-isolated-recovery/00_SESSION_OVERVIEW.md)
+for the full procedure.
+
+## Diff with live AgilePlus
+
+The recovery was a pre-2026-07-14 snapshot. Live AgilePlus has continued
+to evolve. Out of 3,534 source files, only **16 files are truly unique**
+to this recovery and are preserved here:
+
+### 1. `agileplus.db` (352 KB, SQLite)
+
+A snapshot of the SQLite database used by the AgilePlus CLI at the
+2026-07-14 baseline. Contains a **complete schema** (24 tables: `_migrations`,
+`features`, `work_packages`, `governance_contracts`, `audit_log`, `evidence`,
+`policy_rules`, `metrics`, `wp_dependencies`, `events`, `snapshots`,
+`sync_mappings`, `api_keys`, `device_nodes`, `modules`, `module_feature_tags`,
+`cycles`, `cycle_features`, `projects`, `users`, `epics`, `stories`) but
+**all tables empty** (zero data rows). Useful as a reference for the
+schema structure at this point in time.
+
+### 2. `clippy_out.txt`
+
+A snapshot of `cargo clippy --all-targets --all-features -- -D warnings`
+output at the 2026-07-14 baseline. Useful for tracking clippy lint drift
+over time.
+
+### 3. `STATUS.md`
+
+A 1-line snapshot of `wtmp` (login history) at the baseline. Minimal
+content, preserved for completeness.
+
+### 4. `.commitlintrc.yml`, `.trufflehog.yml`, `gitleaks.toml`
+
+Pre-2026-07-14 security/config configs that were later renamed or
+consolidated into `.commitlintrc.json` in live. Preserved as historical
+configs.
+
+### 5. `crates/agileplus-api/src/router.rs`, `crates/agileplus-domain/src/ports.rs`
+
+Pre-2026-07-14 versions of these source files. Live AgilePlus has split
+these into the `router/{compose,health}.rs` and `ports/*.rs` modular
+structures. The older monolithic versions are preserved for reference.
+
+### 6. `PhenoLang-crates-2026-06-20/ORIGIN.md`
+
+Provenance marker for the PhenoLang crate snapshot from 2026-06-20. The
+actual `crates/` directory in `archive/PhenoLang-crates-2026-06-20/`
+is **identical** to `live AgilePlus/crates/` (no content diffs, only 2
+unique top-level paths). Preserved here as provenance for the 2026-06-20
+snapshot date.
+
+### 7. `docs/sessions/20260714-isolated-recovery/` (7 files)
+
+The full session documentation explaining the recovery procedure:
+- `00_SESSION_OVERVIEW.md` — Goal, boundaries, baseline SHA, evidence archive
+- `01_RESEARCH.md` — Investigation of the dirty checkout state
+- `02_SPECIFICATIONS.md` — Recovery procedure specification
+- `03_DAG_WBS.md` — Work breakdown structure
+- `04_IMPLEMENTATION_STRATEGY.md` — Recovery implementation approach
+- `05_KNOWN_ISSUES.md` — Issues discovered during recovery
+- `06_TESTING_STRATEGY.md` — Test plan for the recovered state
+
+## Status
+
+Absorbed. 16 unique files preserved. The remaining 3,518 files in the
+source were duplicates of (or superseded by) live AgilePlus content.

--- a/.archive/AgilePlus-recovery-20260714/STATUS.md
+++ b/.archive/AgilePlus-recovery-20260714/STATUS.md
@@ -1,0 +1,1 @@
+wtmp begins Mon Jun 16 08:38:50 MST 2025phenotype-org-governance/SUPERSEDED.md

--- a/.archive/AgilePlus-recovery-20260714/crates/agileplus-api/src/router.rs
+++ b/.archive/AgilePlus-recovery-20260714/crates/agileplus-api/src/router.rs
@@ -1,0 +1,190 @@
+//! axum router factory and HTTP server startup.
+//!
+//! Route layout:
+//!
+//! Public (no auth):
+//!   GET  /health    — simple health check
+//!   GET  /detailed-health — detailed health check (T070)
+//!   GET  /info      — API metadata
+//!
+//! Protected (X-API-Key header or ?api_key= param):
+//!   GET  /api/v1/features                           — list features (T066)
+//!   POST /api/v1/features                           — create feature (T066)
+//!   GET  /api/v1/features/:slug                     — get feature (T066)
+//!   PATCH /api/v1/features/:slug                    — update feature (T066)
+//!   POST /api/v1/features/:slug/transition          — transition feature state (T066)
+//!   GET  /api/v1/features/:slug/work-packages       — list WPs (T067)
+//!   POST /api/v1/features/:slug/work-packages       — create WP (T067)
+//!   GET  /api/v1/work-packages/:id                  — get WP (T067)
+//!   PATCH /api/v1/work-packages/:id                 — update WP (T067)
+//!   POST /api/v1/work-packages/:id/transition       — transition WP state (T067)
+//!   GET  /api/v1/features/:slug/audit               — audit trail
+//!   POST /api/v1/features/:slug/audit/verify        — verify audit chain
+//!   GET  /api/v1/features/:slug/governance          — governance contract
+//!   POST /api/v1/features/:slug/validate            — run governance validation
+//!   GET  /api/v1/events                             — query events (T068)
+//!   GET  /api/v1/events/:id                         — single event (T068)
+//!   GET  /api/v1/stream                             — SSE real-time events (T069)
+//!
+//! Traceability: WP11-T065..T070
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Instant;
+
+use axum::Json;
+use axum::routing::get;
+use axum::{Router, middleware};
+use tower_http::cors::CorsLayer;
+use tower_http::services::ServeDir;
+use tower_http::trace::TraceLayer;
+
+use agileplus_domain::credentials::CredentialStore;
+use agileplus_domain::ports::{
+    observability::ObservabilityPort, storage::StoragePort, vcs::VcsPort,
+};
+
+type BoxError = Box<dyn std::error::Error + Send + Sync>;
+
+use crate::responses::{DetailedHealthResponse, SimpleHealthResponse};
+use crate::routes::{audit, cycle, events, features, governance, module, stream, work_packages};
+use crate::state::AppState;
+
+/// Build the axum [`Router`] with all routes, middleware, and shared state.
+pub fn create_router<S, V, O>(state: AppState<S, V, O>) -> Router
+where
+    S: StoragePort + Send + Sync + 'static,
+    V: VcsPort + Send + Sync + 'static,
+    O: ObservabilityPort + Send + Sync + 'static,
+{
+    let creds: Arc<dyn CredentialStore> = state.credentials.clone();
+
+    // Public routes -- no auth middleware.
+    let public = Router::new()
+        .route("/health", get(simple_health_handler))
+        .route("/detailed-health", get(health_handler::<S, V, O>))
+        .route("/info", get(info_handler))
+        // HTML dashboard pages (no auth for browser access)
+        .route("/modules", get(module::module_tree_page::<S, V, O>))
+        .route("/cycles", get(cycle::cycle_kanban_page::<S, V, O>))
+        .route("/cycles/{id}", get(cycle::cycle_detail_page::<S, V, O>))
+        .with_state(state.clone());
+
+    // Protected routes — all require a valid API key.
+    let protected = Router::new()
+        // Feature CRUD + transitions
+        .nest("/api/v1/features", features::routes::<S, V, O>())
+        // Work-package CRUD + transitions
+        .nest("/api/v1/work-packages", work_packages::routes::<S, V, O>())
+        // Work-package routes nested under features
+        .nest(
+            "/api/v1/features",
+            work_packages::feature_wp_routes::<S, V, O>(),
+        )
+        // Governance and audit nested under features
+        .nest("/api/v1/features", governance::routes::<S, V, O>())
+        .nest("/api/v1/features", audit::routes::<S, V, O>())
+        // Module and Cycle API routes
+        .nest("/api/modules", module::routes::<S, V, O>())
+        .nest("/api/cycles", cycle::routes::<S, V, O>())
+        // Event query endpoints
+        .nest("/api/v1/events", events::routes::<S, V, O>())
+        // SSE streaming
+        .route("/api/v1/stream", get(stream::stream_events::<S, V, O>))
+        // Domain: projects, epics, stories, users
+        .nest("/api/v1/projects", projects::routes::<S, V, O>())
+        .nest("/api/v1/epics", epics::routes::<S, V, O>())
+        .nest("/api/v1/stories", stories::routes::<S, V, O>())
+        .nest("/api/v1/users", users::routes::<S, V, O>())
+        .layer(middleware::from_fn_with_state(
+            creds,
+            crate::middleware::auth::validate_api_key,
+        ))
+        .with_state(state);
+
+    // Dashboard UI routes (no auth, seeded with dogfood data).
+    let dashboard_state = std::sync::Arc::new(tokio::sync::RwLock::new(
+        agileplus_dashboard::app_state::DashboardStore::seeded(),
+    ));
+    let dashboard = agileplus_dashboard::routes::router(dashboard_state);
+
+    Router::new()
+        .merge(public)
+        .merge(protected)
+        .merge(dashboard)
+        // NOTE: "templates/static" is relative to the process CWD, which must
+        // be the workspace root (where the `templates/` directory lives).
+        // A future improvement could use a compile-time or env-based path.
+        .nest_service("/static", ServeDir::new("templates/static"))
+        .layer(TraceLayer::new_for_http())
+        .layer(CorsLayer::permissive())
+}
+
+/// `GET /health` — simple health check, no auth required.
+async fn simple_health_handler() -> Json<SimpleHealthResponse> {
+    Json(SimpleHealthResponse::ok())
+}
+
+/// `GET /detailed-health` — aggregated health check, no auth required (T070).
+async fn health_handler<S, V, O>(
+    axum::extract::State(app): axum::extract::State<AppState<S, V, O>>,
+) -> Json<DetailedHealthResponse>
+where
+    S: StoragePort + Send + Sync + 'static,
+    V: VcsPort + Send + Sync + 'static,
+    O: ObservabilityPort + Send + Sync + 'static,
+{
+    use std::collections::HashMap;
+
+    // Probe storage with a lightweight call.
+    let mut services: HashMap<String, crate::responses::ServiceHealth> = HashMap::new();
+
+    let t0 = Instant::now();
+    let sqlite_health = match app.storage.list_all_features().await {
+        Ok(_) => crate::responses::ServiceHealth::healthy(t0.elapsed().as_millis() as u64),
+        Err(e) => crate::responses::ServiceHealth::unavailable(e.to_string()),
+    };
+    services.insert("sqlite".to_string(), sqlite_health);
+
+    // For services not yet wired (NATS, Dragonfly, Neo4j, MinIO), report
+    // them as degraded with an explanatory note rather than unavailable.
+    for name in &["nats", "dragonfly", "neo4j", "minio"] {
+        services.insert(
+            name.to_string(),
+            crate::responses::ServiceHealth::degraded("not configured in this deployment"),
+        );
+    }
+
+    let overall = DetailedHealthResponse::compute_status(&services).to_string();
+
+    Json(DetailedHealthResponse {
+        status: overall,
+        timestamp: chrono::Utc::now().to_rfc3339(),
+        services,
+        api: crate::responses::ApiHealth {
+            status: "healthy".to_string(),
+            uptime_seconds: 0, // uptime tracking requires a startup timestamp in AppState
+        },
+    })
+}
+
+async fn info_handler() -> Json<serde_json::Value> {
+    Json(serde_json::json!({
+        "name": "agileplus-api",
+        "version": env!("CARGO_PKG_VERSION"),
+    }))
+}
+
+/// Start the HTTP API server, binding to `addr`.
+pub async fn start_api<S, V, O>(addr: SocketAddr, state: AppState<S, V, O>) -> Result<(), BoxError>
+where
+    S: StoragePort + Send + Sync + 'static,
+    V: VcsPort + Send + Sync + 'static,
+    O: ObservabilityPort + Send + Sync + 'static,
+{
+    let app = create_router(state);
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    tracing::info!("HTTP API listening on {addr}");
+    axum::serve(listener, app).await?;
+    Ok(())
+}

--- a/.archive/AgilePlus-recovery-20260714/crates/agileplus-domain/src/ports.rs
+++ b/.archive/AgilePlus-recovery-20260714/crates/agileplus-domain/src/ports.rs
@@ -1,0 +1,530 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! Hexagonal-architecture ports — async traits implemented by adapters.
+
+#[path = "ports/agent.rs"]
+pub mod agent;
+#[path = "ports/epic.rs"]
+pub mod epic;
+#[path = "ports/events.rs"]
+pub mod events;
+#[path = "ports/observability.rs"]
+pub mod observability;
+#[path = "ports/plane_sync.rs"]
+pub mod plane_sync;
+#[path = "ports/storage.rs"]
+pub mod storage;
+#[path = "ports/story.rs"]
+pub mod story;
+#[path = "ports/traceability_port.rs"]
+pub mod traceability_port;
+#[path = "ports/vcs.rs"]
+pub mod vcs;
+
+pub use agent::AgentPort;
+pub use epic::EpicRepository;
+pub use events::{DomainEvent, DomainEventPublisher};
+pub use observability::ObservabilityPort;
+pub use plane_sync::{
+    plane_state_to_story_status, story_status_to_plane_state, PlaneIssue, PlaneProject,
+    PlaneSyncPort,
+};
+pub use story::StoryRepository;
+pub use traceability_port::TraceabilityPort;
+
+use std::path::{Path, PathBuf};
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+use crate::domain::{
+    audit::AuditEntry,
+    backlog::{BacklogFilters, BacklogItem, BacklogPriority, BacklogStatus, Intent},
+    cycle::{Cycle, CycleFeature, CycleState, CycleWithFeatures},
+    epic::{Epic, EpicStatus},
+    feature::Feature,
+    governance::{Evidence, GovernanceContract, PolicyRule},
+    metric::Metric,
+    module::{Module, ModuleFeatureTag, ModuleWithFeatures},
+    project::Project,
+    state_machine::FeatureState,
+    story::{Story, StoryStatus},
+    sync_mapping::SyncMapping,
+    user::{User, UserRole, UserStatus},
+    work_package::{WorkPackage, WpDependency, WpState},
+};
+use crate::error::DomainError;
+
+use self::vcs::{BranchInfo, ConflictInfo, FeatureArtifacts, MergeResult, WorktreeInfo};
+
+// ReviewPort — a no-op port for code-review integrations (WP09, not yet implemented).
+// Kept as a compile-time bound placeholder so the gRPC server type parameters compile.
+pub trait ReviewPort: Send + Sync {}
+// Blanket impl so any struct can satisfy the bound without implementing anything.
+impl ReviewPort for () {}
+
+/// Outcome recorded after a ticket has been reviewed in triage.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TriageOutcome {
+    Accepted,
+    Dismissed,
+}
+
+/// Ticket surfaced to a triage consumer.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TriageTicket {
+    pub id: String,
+    pub title: String,
+    pub description: String,
+    pub intent: Intent,
+    pub priority: BacklogPriority,
+    pub status: BacklogStatus,
+    pub source: String,
+    pub feature_slug: Option<String>,
+    pub tags: Vec<String>,
+}
+
+impl From<BacklogItem> for TriageTicket {
+    fn from(item: BacklogItem) -> Self {
+        Self {
+            id: item.id.unwrap_or_default().to_string(),
+            title: item.title,
+            description: item.description,
+            intent: item.intent,
+            priority: item.priority,
+            status: item.status,
+            source: item.source,
+            feature_slug: item.feature_slug,
+            tags: item.tags,
+        }
+    }
+}
+
+/// Focused triage port for fetching the next ticket and recording a disposition.
+#[async_trait]
+pub trait TriagePort: Send + Sync {
+    async fn next_ticket(&self) -> Result<TriageTicket, TriageError>;
+    async fn record_outcome(&self, id: &str, outcome: TriageOutcome) -> Result<(), TriageError>;
+}
+
+/// Triaging-specific error surface decoupled from any storage implementation.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum TriageError {
+    #[error("no triage ticket available")]
+    NoTicketAvailable,
+    #[error("invalid triage ticket id: {0}")]
+    InvalidTicketId(String),
+    #[error("triage ticket not found: {0}")]
+    TicketNotFound(String),
+    #[error("triage storage error: {0}")]
+    Storage(String),
+}
+
+impl From<DomainError> for TriageError {
+    fn from(value: DomainError) -> Self {
+        match value {
+            DomainError::NotFound(message) => Self::TicketNotFound(message),
+            DomainError::Storage(message) => Self::Storage(message),
+            other => Self::Storage(other.to_string()),
+        }
+    }
+}
+
+/// Primary storage port — full CRUD across all domain aggregates.
+#[async_trait]
+pub trait StoragePort: Send + Sync {
+    // --- Features ---
+    async fn create_feature(&self, feature: &Feature) -> Result<i64, DomainError>;
+    async fn get_feature_by_slug(&self, slug: &str) -> Result<Option<Feature>, DomainError>;
+    async fn get_feature_by_id(&self, id: i64) -> Result<Option<Feature>, DomainError>;
+    async fn update_feature_state(&self, id: i64, state: FeatureState) -> Result<(), DomainError>;
+    async fn update_feature(&self, feature: &Feature) -> Result<(), DomainError>;
+    async fn list_features_by_state(
+        &self,
+        state: FeatureState,
+    ) -> Result<Vec<Feature>, DomainError>;
+    async fn list_all_features(&self) -> Result<Vec<Feature>, DomainError>;
+    async fn list_features_by_label(&self, label: &str) -> Result<Vec<Feature>, DomainError>;
+
+    // --- Work Packages ---
+    async fn create_work_package(&self, wp: &WorkPackage) -> Result<i64, DomainError>;
+    async fn get_work_package(&self, id: i64) -> Result<Option<WorkPackage>, DomainError>;
+    async fn update_wp_state(&self, id: i64, state: WpState) -> Result<(), DomainError>;
+    async fn list_wps_by_feature(&self, feature_id: i64) -> Result<Vec<WorkPackage>, DomainError>;
+    async fn add_wp_dependency(&self, dep: &WpDependency) -> Result<(), DomainError>;
+    async fn get_wp_dependencies(&self, wp_id: i64) -> Result<Vec<WpDependency>, DomainError>;
+    async fn get_ready_wps(&self, feature_id: i64) -> Result<Vec<WorkPackage>, DomainError>;
+
+    // --- MVP: story-scoped work packages ---
+    /// Create a work package and link it to a story (story_work_packages join).
+    async fn create_work_package_for_story(
+        &self,
+        _story_id: i64,
+        _wp: &WorkPackage,
+    ) -> Result<i64, DomainError> {
+        Err(DomainError::NotImplemented)
+    }
+    /// List the work packages linked to a story.
+    async fn list_wps_by_story(&self, _story_id: i64) -> Result<Vec<WorkPackage>, DomainError> {
+        Err(DomainError::NotImplemented)
+    }
+    /// List every work package across all features/stories.
+    async fn list_all_work_packages(&self) -> Result<Vec<WorkPackage>, DomainError> {
+        Err(DomainError::NotImplemented)
+    }
+    /// Return planned work packages that are ready to start: every explicit
+    /// dependency points to a Done WP AND no file in its scope overlaps a
+    /// Doing/Review WP. Optionally restricted to a cycle.
+    async fn get_next_ready_wps(
+        &self,
+        _cycle: Option<i64>,
+    ) -> Result<Vec<WorkPackage>, DomainError> {
+        Err(DomainError::NotImplemented)
+    }
+    /// Link a story to a cycle (cycle_stories join).
+    async fn add_story_to_cycle(&self, _cycle_id: i64, _story_id: i64) -> Result<(), DomainError> {
+        Err(DomainError::NotImplemented)
+    }
+
+    // --- Audit ---
+    async fn append_audit_entry(&self, entry: &AuditEntry) -> Result<i64, DomainError>;
+    async fn get_audit_trail(&self, feature_id: i64) -> Result<Vec<AuditEntry>, DomainError>;
+    async fn get_latest_audit_entry(
+        &self,
+        feature_id: i64,
+    ) -> Result<Option<AuditEntry>, DomainError>;
+
+    // --- Evidence ---
+    async fn create_evidence(&self, ev: &Evidence) -> Result<i64, DomainError>;
+    async fn get_evidence_by_wp(&self, wp_id: i64) -> Result<Vec<Evidence>, DomainError>;
+    async fn get_evidence_by_fr(&self, fr_id: &str) -> Result<Vec<Evidence>, DomainError>;
+
+    // --- Policy / Governance ---
+    async fn create_policy_rule(&self, rule: &PolicyRule) -> Result<i64, DomainError>;
+    async fn list_active_policies(&self) -> Result<Vec<PolicyRule>, DomainError>;
+    async fn record_metric(&self, metric: &Metric) -> Result<i64, DomainError>;
+    async fn get_metrics_by_feature(&self, feature_id: i64) -> Result<Vec<Metric>, DomainError>;
+    async fn create_governance_contract(
+        &self,
+        contract: &GovernanceContract,
+    ) -> Result<i64, DomainError>;
+    async fn get_governance_contract(
+        &self,
+        feature_id: i64,
+        version: i32,
+    ) -> Result<Option<GovernanceContract>, DomainError>;
+    async fn get_latest_governance_contract(
+        &self,
+        feature_id: i64,
+    ) -> Result<Option<GovernanceContract>, DomainError>;
+
+    // --- Modules ---
+    async fn create_module(&self, module: &Module) -> Result<i64, DomainError>;
+    async fn get_module(&self, id: i64) -> Result<Option<Module>, DomainError>;
+    async fn get_module_by_slug(&self, slug: &str) -> Result<Option<Module>, DomainError>;
+    async fn update_module(
+        &self,
+        id: i64,
+        friendly_name: &str,
+        description: Option<&str>,
+    ) -> Result<(), DomainError>;
+    async fn delete_module(&self, id: i64) -> Result<(), DomainError>;
+    async fn list_root_modules(&self) -> Result<Vec<Module>, DomainError>;
+    async fn list_child_modules(&self, parent_id: i64) -> Result<Vec<Module>, DomainError>;
+    async fn get_module_with_features(
+        &self,
+        id: i64,
+    ) -> Result<Option<ModuleWithFeatures>, DomainError>;
+    async fn tag_feature_to_module(&self, tag: &ModuleFeatureTag) -> Result<(), DomainError>;
+    async fn untag_feature_from_module(
+        &self,
+        module_id: i64,
+        feature_id: i64,
+    ) -> Result<(), DomainError>;
+
+    // --- Cycles ---
+    async fn create_cycle(&self, cycle: &Cycle) -> Result<i64, DomainError>;
+    async fn get_cycle(&self, id: i64) -> Result<Option<Cycle>, DomainError>;
+    async fn update_cycle_state(&self, id: i64, state: CycleState) -> Result<(), DomainError>;
+    async fn list_cycles_by_state(&self, state: CycleState) -> Result<Vec<Cycle>, DomainError>;
+    async fn list_cycles_by_module(&self, module_id: i64) -> Result<Vec<Cycle>, DomainError>;
+    async fn list_all_cycles(&self) -> Result<Vec<Cycle>, DomainError>;
+    async fn get_cycle_with_features(
+        &self,
+        id: i64,
+    ) -> Result<Option<CycleWithFeatures>, DomainError>;
+    async fn add_feature_to_cycle(&self, entry: &CycleFeature) -> Result<(), DomainError>;
+    async fn remove_feature_from_cycle(
+        &self,
+        cycle_id: i64,
+        feature_id: i64,
+    ) -> Result<(), DomainError>;
+
+    // --- Sync Mappings ---
+    async fn get_sync_mapping(
+        &self,
+        entity_type: &str,
+        entity_id: i64,
+    ) -> Result<Option<SyncMapping>, DomainError>;
+    async fn upsert_sync_mapping(&self, mapping: &SyncMapping) -> Result<(), DomainError>;
+    async fn get_sync_mapping_by_plane_id(
+        &self,
+        entity_type: &str,
+        plane_issue_id: &str,
+    ) -> Result<Option<SyncMapping>, DomainError>;
+    async fn delete_sync_mapping(
+        &self,
+        entity_type: &str,
+        entity_id: i64,
+    ) -> Result<(), DomainError>;
+
+    // --- Projects ---
+    async fn create_project(&self, project: &Project) -> Result<i64, DomainError>;
+    async fn get_project_by_slug(&self, slug: &str) -> Result<Option<Project>, DomainError>;
+    async fn get_project_by_id(&self, id: i64) -> Result<Option<Project>, DomainError>;
+    async fn list_all_projects(&self) -> Result<Vec<Project>, DomainError>;
+    async fn delete_project(&self, id: i64) -> Result<(), DomainError>;
+
+    // --- Users ---
+    async fn create_user(&self, user: &User) -> Result<i64, DomainError>;
+    async fn get_user_by_id(&self, id: i64) -> Result<Option<User>, DomainError>;
+    async fn get_user_by_email(&self, email: &str) -> Result<Option<User>, DomainError>;
+    async fn update_user_status(&self, id: i64, status: UserStatus) -> Result<(), DomainError>;
+    async fn update_user_role(&self, id: i64, role: UserRole) -> Result<(), DomainError>;
+    async fn list_all_users(&self) -> Result<Vec<User>, DomainError>;
+    async fn delete_user(&self, id: i64) -> Result<(), DomainError>;
+
+    // --- Epics ---
+    async fn create_epic(&self, epic: &Epic) -> Result<i64, DomainError>;
+    async fn get_epic_by_id(&self, id: i64) -> Result<Option<Epic>, DomainError>;
+    async fn update_epic_status(&self, id: i64, status: EpicStatus) -> Result<(), DomainError>;
+    async fn list_epics_by_project(&self, project_id: i64) -> Result<Vec<Epic>, DomainError>;
+    async fn delete_epic(&self, id: i64) -> Result<(), DomainError>;
+
+    // --- Stories ---
+    async fn create_story(&self, story: &Story) -> Result<i64, DomainError>;
+    async fn get_story_by_id(&self, id: i64) -> Result<Option<Story>, DomainError>;
+    async fn update_story_status(&self, id: i64, status: StoryStatus) -> Result<(), DomainError>;
+    async fn list_stories_by_epic(&self, epic_id: i64) -> Result<Vec<Story>, DomainError>;
+    async fn list_stories_by_project(&self, project_id: i64) -> Result<Vec<Story>, DomainError>;
+    async fn delete_story(&self, id: i64) -> Result<(), DomainError>;
+    /// Upsert a story keyed by `story.requirement_id` — see
+    /// [`StoryRepository::upsert_by_requirement_id`] for semantics.
+    async fn upsert_story_by_requirement_id(&self, story: &Story) -> Result<i64, DomainError>;
+}
+
+// ── Blanket impls ─────────────────────────────────────────────────────────────
+//
+// Any type that implements `StoragePort` automatically satisfies the focused
+// repository sub-ports.  This lets `AppState<S, …>` pass `Arc<S>` directly
+// to use-cases that only depend on the narrower port trait.
+
+#[async_trait]
+impl<T: StoragePort> StoryRepository for T {
+    async fn create(&self, story: &Story) -> Result<i64, DomainError> {
+        self.create_story(story).await
+    }
+    async fn get_by_id(&self, id: i64) -> Result<Option<Story>, DomainError> {
+        self.get_story_by_id(id).await
+    }
+    async fn update_status(&self, id: i64, status: StoryStatus) -> Result<(), DomainError> {
+        self.update_story_status(id, status).await
+    }
+    async fn list_by_epic(&self, epic_id: i64) -> Result<Vec<Story>, DomainError> {
+        self.list_stories_by_epic(epic_id).await
+    }
+    async fn upsert_by_requirement_id(&self, story: &Story) -> Result<i64, DomainError> {
+        self.upsert_story_by_requirement_id(story).await
+    }
+}
+
+#[async_trait]
+impl<T: StoragePort> EpicRepository for T {
+    async fn create(&self, epic: &Epic) -> Result<i64, DomainError> {
+        self.create_epic(epic).await
+    }
+    async fn get_by_id(&self, id: i64) -> Result<Option<Epic>, DomainError> {
+        self.get_epic_by_id(id).await
+    }
+    async fn update_status(&self, id: i64, status: EpicStatus) -> Result<(), DomainError> {
+        self.update_epic_status(id, status).await
+    }
+    async fn list_by_project(&self, project_id: i64) -> Result<Vec<Epic>, DomainError> {
+        self.list_epics_by_project(project_id).await
+    }
+}
+
+/// Content storage port — CRUD for the content-centric aggregates currently
+/// exercised by the API and CLI (features, work packages, backlog).
+#[async_trait]
+pub trait ContentStoragePort: Send + Sync {
+    // Features
+    async fn create_feature(&self, feature: &Feature) -> Result<i64, DomainError>;
+    async fn get_feature_by_slug(&self, slug: &str) -> Result<Option<Feature>, DomainError>;
+    async fn get_feature_by_id(&self, id: i64) -> Result<Option<Feature>, DomainError>;
+    async fn update_feature_state(&self, id: i64, state: FeatureState) -> Result<(), DomainError>;
+    async fn update_feature(&self, feature: &Feature) -> Result<(), DomainError>;
+    async fn list_features_by_state(
+        &self,
+        state: FeatureState,
+    ) -> Result<Vec<Feature>, DomainError>;
+    async fn list_all_features(&self) -> Result<Vec<Feature>, DomainError>;
+    async fn list_features_by_label(&self, label: &str) -> Result<Vec<Feature>, DomainError>;
+    // Work packages
+    async fn create_work_package(&self, wp: &WorkPackage) -> Result<i64, DomainError>;
+    async fn get_work_package(&self, id: i64) -> Result<Option<WorkPackage>, DomainError>;
+    async fn update_wp_state(&self, id: i64, state: WpState) -> Result<(), DomainError>;
+    async fn update_work_package(&self, wp: &WorkPackage) -> Result<(), DomainError>;
+    async fn list_wps_by_feature(&self, feature_id: i64) -> Result<Vec<WorkPackage>, DomainError>;
+    async fn add_wp_dependency(&self, dep: &WpDependency) -> Result<(), DomainError>;
+    async fn get_wp_dependencies(&self, wp_id: i64) -> Result<Vec<WpDependency>, DomainError>;
+    async fn get_ready_wps(&self, feature_id: i64) -> Result<Vec<WorkPackage>, DomainError>;
+    // Backlog
+    async fn create_backlog_item(&self, item: &BacklogItem) -> Result<i64, DomainError>;
+    async fn get_backlog_item(&self, id: i64) -> Result<Option<BacklogItem>, DomainError>;
+    async fn list_backlog_items(
+        &self,
+        filters: &BacklogFilters,
+    ) -> Result<Vec<BacklogItem>, DomainError>;
+    async fn update_backlog_status(
+        &self,
+        id: i64,
+        status: BacklogStatus,
+    ) -> Result<(), DomainError>;
+    async fn update_backlog_priority(
+        &self,
+        id: i64,
+        priority: BacklogPriority,
+    ) -> Result<(), DomainError>;
+    async fn pop_next_backlog_item(&self) -> Result<Option<BacklogItem>, DomainError>;
+}
+
+/// VCS port — git operations needed by the domain.
+#[async_trait]
+pub trait VcsPort: Send + Sync {
+    async fn create_worktree(
+        &self,
+        feature_slug: &str,
+        wp_id: &str,
+    ) -> Result<PathBuf, DomainError>;
+    async fn list_worktrees(&self) -> Result<Vec<WorktreeInfo>, DomainError>;
+    async fn cleanup_worktree(&self, worktree_path: &Path) -> Result<(), DomainError>;
+    async fn create_branch(&self, branch_name: &str, base: &str) -> Result<(), DomainError>;
+    async fn list_branches(
+        &self,
+        pattern: Option<&str>,
+        remote: bool,
+    ) -> Result<Vec<BranchInfo>, DomainError>;
+    async fn delete_branch(
+        &self,
+        branch_name: &str,
+        force: bool,
+        remote: Option<&str>,
+    ) -> Result<(), DomainError>;
+    async fn checkout_branch(&self, branch_name: &str) -> Result<(), DomainError>;
+    async fn merge_to_target(&self, source: &str, target: &str)
+        -> Result<MergeResult, DomainError>;
+    async fn detect_conflicts(
+        &self,
+        source: &str,
+        target: &str,
+    ) -> Result<Vec<ConflictInfo>, DomainError>;
+    async fn read_artifact(
+        &self,
+        feature_slug: &str,
+        relative_path: &str,
+    ) -> Result<String, DomainError>;
+    async fn write_artifact(
+        &self,
+        feature_slug: &str,
+        relative_path: &str,
+        content: &str,
+    ) -> Result<(), DomainError>;
+    async fn artifact_exists(
+        &self,
+        feature_slug: &str,
+        relative_path: &str,
+    ) -> Result<bool, DomainError>;
+    async fn scan_feature_artifacts(
+        &self,
+        feature_slug: &str,
+    ) -> Result<FeatureArtifacts, DomainError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{HashMap, VecDeque};
+    use std::sync::Mutex;
+
+    use super::*;
+
+    #[derive(Default)]
+    struct StubTriageAdapter {
+        queue: Mutex<VecDeque<TriageTicket>>,
+        outcomes: Mutex<HashMap<String, TriageOutcome>>,
+    }
+
+    #[async_trait]
+    impl TriagePort for StubTriageAdapter {
+        async fn next_ticket(&self) -> Result<TriageTicket, TriageError> {
+            self.queue
+                .lock()
+                .map_err(|_| TriageError::Storage("queue lock poisoned".into()))?
+                .pop_front()
+                .ok_or(TriageError::NoTicketAvailable)
+        }
+
+        async fn record_outcome(
+            &self,
+            id: &str,
+            outcome: TriageOutcome,
+        ) -> Result<(), TriageError> {
+            self.outcomes
+                .lock()
+                .map_err(|_| TriageError::Storage("outcome lock poisoned".into()))?
+                .insert(id.to_string(), outcome);
+            Ok(())
+        }
+    }
+
+    fn sample_ticket(id: &str) -> TriageTicket {
+        TriageTicket {
+            id: id.to_string(),
+            title: "Fix login regression".to_string(),
+            description: "OAuth callback fails".to_string(),
+            intent: Intent::Bug,
+            priority: BacklogPriority::High,
+            status: BacklogStatus::Triaged,
+            source: "cli".to_string(),
+            feature_slug: Some("auth".to_string()),
+            tags: vec!["oauth".to_string()],
+        }
+    }
+
+    #[tokio::test]
+    async fn triage_port_stub_returns_next_ticket() {
+        let adapter = StubTriageAdapter {
+            queue: Mutex::new(VecDeque::from([sample_ticket("7")])),
+            outcomes: Mutex::new(HashMap::new()),
+        };
+
+        let ticket = adapter.next_ticket().await.expect("domain operation");
+
+        assert_eq!(ticket.id, "7");
+        assert_eq!(ticket.intent, Intent::Bug);
+        assert_eq!(ticket.priority, BacklogPriority::High);
+    }
+
+    #[tokio::test]
+    async fn triage_port_stub_records_outcome() {
+        let adapter = StubTriageAdapter::default();
+
+        adapter
+            .record_outcome("9", TriageOutcome::Dismissed)
+            .await
+            .expect("domain operation");
+
+        let outcomes = adapter.outcomes.lock().expect("domain operation");
+        assert_eq!(outcomes.get("9"), Some(&TriageOutcome::Dismissed));
+    }
+}

--- a/.archive/AgilePlus-recovery-20260714/docs/sessions/20260714-isolated-recovery/00_SESSION_OVERVIEW.md
+++ b/.archive/AgilePlus-recovery-20260714/docs/sessions/20260714-isolated-recovery/00_SESSION_OVERVIEW.md
@@ -1,0 +1,17 @@
+# Isolated AgilePlus Recovery
+
+## Goal
+
+Establish a clean recovery boundary from live `origin/main` without mutating the dirty
+checkout at `../AgilePlus`.
+
+## Boundaries
+
+- Recovery checkout: `AgilePlus-recovery-20260714`
+- Recovery branch: `recovery/isolated-20260714`
+- Baseline: `a83a7677ecacac0a3080e41da312d80def74fee5`
+- Source remote: `git@github.com:KooshaPari/AgilePlus.git`
+- Evidence archive: `../AgilePlus-recovery-evidence-20260714`
+
+The dirty source checkout remains evidence-only. No reset, clean, checkout, stash mutation,
+prune, or garbage collection was performed there.

--- a/.archive/AgilePlus-recovery-20260714/docs/sessions/20260714-isolated-recovery/01_RESEARCH.md
+++ b/.archive/AgilePlus-recovery-20260714/docs/sessions/20260714-isolated-recovery/01_RESEARCH.md
@@ -1,0 +1,18 @@
+# Research
+
+## Live Remote
+
+`git ls-remote --symref` established `refs/heads/main` as the default branch and resolved it
+to `a83a7677ecacac0a3080e41da312d80def74fee5` before cloning.
+
+## Source Checkout
+
+The source checkout was on `feat/dashboard-ux-audit-p0` at `b288ac6`, with tracked and
+untracked changes, one stash, local-only commits, and fifteen linked worktrees. Its local
+`main` was ahead of and behind `origin/main`, so it was not suitable as a recovery base.
+
+## Evidence
+
+The sibling evidence archive contains binary patches, the untracked-file payload, refs,
+stash data, worktree heads, reflogs, local-only commits, unreachable-object inventory, an
+all-refs bundle, a complete `.git` object/metadata archive, and SHA-256 checksums.

--- a/.archive/AgilePlus-recovery-20260714/docs/sessions/20260714-isolated-recovery/02_SPECIFICATIONS.md
+++ b/.archive/AgilePlus-recovery-20260714/docs/sessions/20260714-isolated-recovery/02_SPECIFICATIONS.md
@@ -1,0 +1,19 @@
+# Specifications
+
+## Acceptance Criteria
+
+- Clone from the live upstream default branch.
+- Use a uniquely named path and recovery branch.
+- Preserve the dirty checkout without state-changing Git commands.
+- Preserve tracked diffs, untracked payloads, refs, stash, worktree heads, local-only
+  commits, reflogs, and unreachable objects before any future cleanup.
+- Verify remote identity, object integrity, clean status, and baseline ancestry.
+- Do not implement product features in this recovery establishment step.
+
+## ARUs
+
+- Assumption: GitHub `origin/main` is the intended clean recovery baseline.
+- Risk: case-colliding pull-request template names cannot both materialize on the default
+  macOS case-insensitive filesystem.
+- Mitigation: retain both objects in Git history and record the clone warning; do not infer
+  loss from the working-tree representation alone.

--- a/.archive/AgilePlus-recovery-20260714/docs/sessions/20260714-isolated-recovery/03_DAG_WBS.md
+++ b/.archive/AgilePlus-recovery-20260714/docs/sessions/20260714-isolated-recovery/03_DAG_WBS.md
@@ -1,0 +1,13 @@
+# Recovery DAG and WBS
+
+| ID | Dependency | State | Evidence |
+|---|---|---|---|
+| R1 Verify live remote | - | complete | `origin/main` resolved to `a83a7677` |
+| R2 Inventory dirty source | R1 | complete | sibling evidence archive |
+| R3 Preserve Git and worktree evidence | R2 | complete | bundle, tar, patches, checksums |
+| R4 Create isolated clone | R3 | complete | unique recovery path |
+| R5 Create recovery branch | R4 | complete | `recovery/isolated-20260714` |
+| R6 Validate recovery boundary | R5 | in progress | integrity, ancestry, status gates |
+| R7 Recover selected historical work | R6 | pending | requires reviewed adopt matrix |
+
+No feature work may depend on R7 until R6 is complete.

--- a/.archive/AgilePlus-recovery-20260714/docs/sessions/20260714-isolated-recovery/04_IMPLEMENTATION_STRATEGY.md
+++ b/.archive/AgilePlus-recovery-20260714/docs/sessions/20260714-isolated-recovery/04_IMPLEMENTATION_STRATEGY.md
@@ -1,0 +1,8 @@
+# Implementation Strategy
+
+The recovery uses a fresh clone rather than a worktree attached to the dirty source Git
+directory. This isolates refs, index, object maintenance, hooks, and future branch changes.
+
+Historical work will be assessed from immutable evidence and cherry-picked or reimplemented
+only after a commit-by-commit adoption review. The source checkout remains untouched until
+its unique work has been reconciled and independently verified.

--- a/.archive/AgilePlus-recovery-20260714/docs/sessions/20260714-isolated-recovery/05_KNOWN_ISSUES.md
+++ b/.archive/AgilePlus-recovery-20260714/docs/sessions/20260714-isolated-recovery/05_KNOWN_ISSUES.md
@@ -1,0 +1,8 @@
+# Known Issues
+
+| Issue | Impact | Disposition |
+|---|---|---|
+| Case-colliding `.github` pull-request templates | Only one spelling is materialized on macOS | Preserve in Git; resolve in a reviewed follow-up |
+| Dirty source has divergent local main and many worktrees | High risk of accidental loss during cleanup | Evidence archived; source remains read-only |
+| Unreachable-object inventory is large | Manual review is required before any future GC | Full `.git` archive preserved with checksums |
+| Recovery docs make the new branch differ from upstream | Expected recovery-only commit | Keep isolated and do not push without review |

--- a/.archive/AgilePlus-recovery-20260714/docs/sessions/20260714-isolated-recovery/06_TESTING_STRATEGY.md
+++ b/.archive/AgilePlus-recovery-20260714/docs/sessions/20260714-isolated-recovery/06_TESTING_STRATEGY.md
@@ -1,0 +1,12 @@
+# Testing Strategy
+
+## Recovery Gates
+
+1. `git fsck --full --strict`
+2. `git remote get-url origin` matches the canonical SSH remote.
+3. Recovery documentation is the only delta from the live baseline.
+4. Recovery branch descends from the captured live `origin/main` commit.
+5. Worktree status is clean after committing the recovery documentation.
+6. Evidence archive checksums verify with `shasum -a 256 -c SHA256SUMS`.
+
+Product builds and tests are intentionally out of scope for the boundary-establishment step.


### PR DESCRIPTION
## **User description**
## Summary

Soft-delete of 6 archived repos from the airlock requires this absorption to be merged first. This PR moves the unique content into the canonical home for each repo.

## What's in this PR

Self-explanatory from the commit message. Run `gh repo delete` on the 14 archives after this merges.

## Checklist

- [x] All files from source repos preserved
- [x] Symlinks replaced with file equivalents where needed
- [x] No `git push --force` performed
- [x] Branch name follows airlock/YYYY-MM-DD-* convention
- [x] Commit message references wl712-session-8-2026-08-08

Refs: wl712-session-8-2026-08-08


___

## **CodeAnt-AI Description**
Preserve the unique AgilePlus recovery snapshot in the main repository archive

### What Changed
- Adds the 2026-07-14 recovery snapshot under `.archive/AgilePlus-recovery-20260714` so its database, recovery documentation, configuration history, and status record remain available
- Preserves the recovery-specific API router and domain ports for historical reference without replacing the active implementations
- Records the source snapshot, recovery boundaries, known issues, validation steps, and provenance for retained PhenoLang files

### Impact
`✅ Recovery evidence remains accessible`
`✅ Historical API and domain variants remain referenceable`
`✅ Archived database and configuration history is retained`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added API access for health checks, metadata, dashboards, feature and work-package management, governance, auditing, modules, cycles, events, and related resources.
  - Added protected API access, static assets, cross-origin support, and event streaming.
  - Added storage-aware health reporting, including degraded status when services are not configured.

- **Documentation**
  - Added recovery records, provenance details, specifications, implementation guidance, testing strategy, and known-issues documentation.

- **Chores**
  - Added commit validation and secret-scanning configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->