### PR TITLE
fix: expose dashboard data failures and restore non-Plane build floor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,14 +384,17 @@ version = "0.2.1"
 dependencies = [
  "agileplus-domain",
  "anyhow",
+ "bitvec",
  "chrono",
  "clap",
+ "rusqlite",
  "serde",
  "serde_json",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "ureq",
 ]
 
 [[package]]
@@ -850,6 +853,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "bitvec"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
 ]
 
 [[package]]
@@ -1767,6 +1782,12 @@ checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -4696,6 +4717,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rand"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5681,6 +5708,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6401,6 +6434,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7085,6 +7135,15 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "yaml-rust2"

--- a/crates/agileplus-api/src/main.rs
+++ b/crates/agileplus-api/src/main.rs
@@ -12,7 +12,6 @@ use agileplus_domain::ports::observability::{LogEntry, ObservabilityPort, SpanCo
 use agileplus_git::GitVcsAdapter;
 use agileplus_sqlite::SqliteStorageAdapter;
 use anyhow::{Context, Result, anyhow};
-use tracing::warn;
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/crates/agileplus-api/src/routes/features.rs
+++ b/crates/agileplus-api/src/routes/features.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 use utoipa::{IntoParams, ToSchema};
 
 use agileplus_domain::domain::feature::Feature;
-use agileplus_domain::domain::state_machine::{self, FeatureState};
+use agileplus_domain::domain::state_machine::FeatureState;
 use agileplus_domain::ports::{ObservabilityPort, StoragePort};
 use agileplus_domain::ports::vcs::VcsPort;
 

--- a/crates/agileplus-dashboard/Cargo.toml
+++ b/crates/agileplus-dashboard/Cargo.toml
@@ -15,10 +15,7 @@ agileplus-sqlite = { path = "../agileplus-sqlite" }
 agileplus-fixtures = { path = "../agileplus-fixtures" }
 agileplus-governance = { path = "../agileplus-governance" }
 agileplus-plane = { path = "../agileplus-plane" }
-<<<<<<< Updated upstream
 agileplus-api = { path = "../agileplus-api" }
-=======
->>>>>>> Stashed changes
 askama = "0.12"
 axum = { version = "0.8", features = ["json", "macros", "tokio"] }
 async-stream = "0.3"

--- a/crates/agileplus-dashboard/src/routes/dashboard.rs
+++ b/crates/agileplus-dashboard/src/routes/dashboard.rs
@@ -466,7 +466,11 @@ pub async fn epics_stories_json() -> impl IntoResponse {
         PathBuf::from("agileplus.db")
     };
 
-    let conn = match rusqlite::Connection::open(&db_path) {
+    epics_stories_json_for_path(&db_path)
+}
+
+fn epics_stories_json_for_path(db_path: &std::path::Path) -> axum::Json<serde_json::Value> {
+    let conn = match rusqlite::Connection::open(db_path) {
         Ok(c) => c,
         Err(e) => {
             return axum::Json(serde_json::json!({
@@ -479,39 +483,47 @@ pub async fn epics_stories_json() -> impl IntoResponse {
         }
     };
 
-    // Query epics
-    let epics: Vec<serde_json::Value> = {
-        let mut stmt = conn
-            .prepare("SELECT id, title, status, requirement_id FROM epics ORDER BY id")
-            .unwrap_or_else(|_| conn.prepare("SELECT 1 WHERE 0").unwrap());
-        stmt.query_map([], |row| {
+    let mut epics_statement = match conn
+        .prepare("SELECT id, title, status, requirement_id FROM epics ORDER BY id")
+    {
+        Ok(statement) => statement,
+        Err(e) => return epics_stories_error("epics query failed", e),
+    };
+    let epics = match epics_statement
+        .query_map([], |row| {
             Ok(serde_json::json!({
-                "id": row.get::<_, i64>(0).unwrap_or(0),
-                "title": row.get::<_, String>(1).unwrap_or_default(),
-                "status": row.get::<_, String>(2).unwrap_or_default(),
-                "requirement_id": row.get::<_, Option<String>>(3).unwrap_or(None),
+                "id": row.get::<_, i64>(0)?,
+                "title": row.get::<_, String>(1)?,
+                "status": row.get::<_, String>(2)?,
+                "requirement_id": row.get::<_, Option<String>>(3)?,
             }))
         })
-        .map(|rows| rows.filter_map(|r| r.ok()).collect())
-        .unwrap_or_default()
+        .and_then(Iterator::collect::<Result<Vec<_>, _>>)
+    {
+        Ok(rows) => rows,
+        Err(e) => return epics_stories_error("epics query failed", e),
     };
 
-    // Query stories
-    let stories: Vec<serde_json::Value> = {
-        let mut stmt = conn
-            .prepare("SELECT id, epic_id, title, status, requirement_id FROM stories ORDER BY id")
-            .unwrap_or_else(|_| conn.prepare("SELECT 1 WHERE 0").unwrap());
-        stmt.query_map([], |row| {
+    let mut stories_statement = match conn
+        .prepare("SELECT id, epic_id, title, status, requirement_id FROM stories ORDER BY id")
+    {
+        Ok(statement) => statement,
+        Err(e) => return epics_stories_error("stories query failed", e),
+    };
+    let stories = match stories_statement
+        .query_map([], |row| {
             Ok(serde_json::json!({
-                "id": row.get::<_, i64>(0).unwrap_or(0),
-                "epic_id": row.get::<_, Option<i64>>(1).unwrap_or(None),
-                "title": row.get::<_, String>(2).unwrap_or_default(),
-                "status": row.get::<_, String>(3).unwrap_or_default(),
-                "requirement_id": row.get::<_, Option<String>>(4).unwrap_or(None),
+                "id": row.get::<_, i64>(0)?,
+                "epic_id": row.get::<_, Option<i64>>(1)?,
+                "title": row.get::<_, String>(2)?,
+                "status": row.get::<_, String>(3)?,
+                "requirement_id": row.get::<_, Option<String>>(4)?,
             }))
         })
-        .map(|rows| rows.filter_map(|r| r.ok()).collect())
-        .unwrap_or_default()
+        .and_then(Iterator::collect::<Result<Vec<_>, _>>)
+    {
+        Ok(rows) => rows,
+        Err(e) => return epics_stories_error("stories query failed", e),
     };
 
     let epic_count = epics.len();
@@ -524,4 +536,69 @@ pub async fn epics_stories_json() -> impl IntoResponse {
         "story_count": story_count,
         "timestamp": chrono::Utc::now().to_rfc3339(),
     }))
+}
+
+fn epics_stories_error(context: &str, error: rusqlite::Error) -> axum::Json<serde_json::Value> {
+    axum::Json(serde_json::json!({
+        "epics": [],
+        "stories": [],
+        "epic_count": 0,
+        "story_count": 0,
+        "error": format!("{context}: {error}"),
+    }))
+}
+
+#[cfg(test)]
+mod epics_stories_json_tests {
+    use super::*;
+
+    fn temporary_database_path(name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "agileplus-dashboard-{name}-{}-{}.db",
+            std::process::id(),
+            Utc::now().timestamp_nanos_opt().expect("timestamp is representable"),
+        ))
+    }
+
+    #[test]
+    fn schema_failure_is_visible_to_dashboard_clients() {
+        let path = temporary_database_path("missing-schema");
+        let connection = rusqlite::Connection::open(&path).expect("temporary database opens");
+        drop(connection);
+
+        let response = epics_stories_json_for_path(&path).0;
+
+        assert_eq!(response["epics"], serde_json::json!([]));
+        assert_eq!(response["stories"], serde_json::json!([]));
+        assert_eq!(response["epic_count"], 0);
+        assert_eq!(response["story_count"], 0);
+        assert!(response["error"]
+            .as_str()
+            .is_some_and(|error| error.contains("epics query failed")));
+
+        std::fs::remove_file(path).expect("temporary database is removed");
+    }
+
+    #[test]
+    fn valid_empty_schema_is_not_reported_as_an_error() {
+        let path = temporary_database_path("empty-schema");
+        let connection = rusqlite::Connection::open(&path).expect("temporary database opens");
+        connection
+            .execute_batch(
+                "CREATE TABLE epics (id INTEGER, title TEXT, status TEXT, requirement_id TEXT);\
+                 CREATE TABLE stories (id INTEGER, epic_id INTEGER, title TEXT, status TEXT, requirement_id TEXT);",
+            )
+            .expect("dashboard schema is created");
+        drop(connection);
+
+        let response = epics_stories_json_for_path(&path).0;
+
+        assert_eq!(response["epics"], serde_json::json!([]));
+        assert_eq!(response["stories"], serde_json::json!([]));
+        assert_eq!(response["epic_count"], 0);
+        assert_eq!(response["story_count"], 0);
+        assert!(response.get("error").is_none());
+
+        std::fs::remove_file(path).expect("temporary database is removed");
+    }
 }

--- a/crates/agileplus-dashboard/src/routes/dashboard.rs
+++ b/crates/agileplus-dashboard/src/routes/dashboard.rs
@@ -483,9 +483,11 @@ fn epics_stories_json_for_path(db_path: &std::path::Path) -> axum::Json<serde_js
         }
     };
 
-    let mut epics_statement = match conn
-        .prepare("SELECT id, title, status, requirement_id FROM epics ORDER BY id")
-    {
+    let epics_requirement_id = column_expression(&conn, "epics", "requirement_id");
+    let epics_query = format!(
+        "SELECT id, title, status, {epics_requirement_id} AS requirement_id FROM epics ORDER BY id"
+    );
+    let mut epics_statement = match conn.prepare(&epics_query) {
         Ok(statement) => statement,
         Err(e) => return epics_stories_error("epics query failed", e),
     };
@@ -504,9 +506,12 @@ fn epics_stories_json_for_path(db_path: &std::path::Path) -> axum::Json<serde_js
         Err(e) => return epics_stories_error("epics query failed", e),
     };
 
-    let mut stories_statement = match conn
-        .prepare("SELECT id, epic_id, title, status, requirement_id FROM stories ORDER BY id")
-    {
+    let stories_requirement_id = column_expression(&conn, "stories", "requirement_id");
+    let stories_query = format!(
+        "SELECT id, epic_id, title, status, {stories_requirement_id} AS requirement_id \
+         FROM stories ORDER BY id"
+    );
+    let mut stories_statement = match conn.prepare(&stories_query) {
         Ok(statement) => statement,
         Err(e) => return epics_stories_error("stories query failed", e),
     };
@@ -538,6 +543,17 @@ fn epics_stories_json_for_path(db_path: &std::path::Path) -> axum::Json<serde_js
     }))
 }
 
+fn column_expression(conn: &rusqlite::Connection, table: &str, column: &str) -> String {
+    let has_column = conn
+        .prepare(&format!("SELECT {column} FROM {table} LIMIT 0"))
+        .is_ok();
+    if has_column {
+        column.to_owned()
+    } else {
+        "NULL".to_owned()
+    }
+}
+
 fn epics_stories_error(context: &str, error: rusqlite::Error) -> axum::Json<serde_json::Value> {
     axum::Json(serde_json::json!({
         "epics": [],
@@ -556,7 +572,9 @@ mod epics_stories_json_tests {
         std::env::temp_dir().join(format!(
             "agileplus-dashboard-{name}-{}-{}.db",
             std::process::id(),
-            Utc::now().timestamp_nanos_opt().expect("timestamp is representable"),
+            Utc::now()
+                .timestamp_nanos_opt()
+                .expect("timestamp is representable"),
         ))
     }
 
@@ -572,9 +590,11 @@ mod epics_stories_json_tests {
         assert_eq!(response["stories"], serde_json::json!([]));
         assert_eq!(response["epic_count"], 0);
         assert_eq!(response["story_count"], 0);
-        assert!(response["error"]
-            .as_str()
-            .is_some_and(|error| error.contains("epics query failed")));
+        assert!(
+            response["error"]
+                .as_str()
+                .is_some_and(|error| error.contains("epics query failed"))
+        );
 
         std::fs::remove_file(path).expect("temporary database is removed");
     }
@@ -597,6 +617,37 @@ mod epics_stories_json_tests {
         assert_eq!(response["stories"], serde_json::json!([]));
         assert_eq!(response["epic_count"], 0);
         assert_eq!(response["story_count"], 0);
+        assert!(response.get("error").is_none());
+
+        std::fs::remove_file(path).expect("temporary database is removed");
+    }
+
+    #[test]
+    fn legacy_schema_keeps_existing_epics_and_stories_visible() {
+        let path = temporary_database_path("legacy-schema");
+        let connection = rusqlite::Connection::open(&path).expect("temporary database opens");
+        connection
+            .execute_batch(
+                "CREATE TABLE epics (id INTEGER, title TEXT, status TEXT);\
+                 CREATE TABLE stories (id INTEGER, epic_id INTEGER, title TEXT, status TEXT);\
+                 INSERT INTO epics VALUES (7, 'Legacy epic', 'active');\
+                 INSERT INTO stories VALUES (11, 7, 'Legacy story', 'todo');",
+            )
+            .expect("legacy dashboard schema is created");
+        drop(connection);
+
+        let response = epics_stories_json_for_path(&path).0;
+
+        assert_eq!(response["epic_count"], 1);
+        assert_eq!(response["story_count"], 1);
+        assert_eq!(
+            response["epics"][0]["requirement_id"],
+            serde_json::Value::Null
+        );
+        assert_eq!(
+            response["stories"][0]["requirement_id"],
+            serde_json::Value::Null
+        );
         assert!(response.get("error").is_none());
 
         std::fs::remove_file(path).expect("temporary database is removed");

--- a/crates/agileplus-governance/src/scoring_engine.rs
+++ b/crates/agileplus-governance/src/scoring_engine.rs
@@ -108,59 +108,7 @@ pub const SCORING_PROBES: &[ProbeRule] = &[
     },
 ];
 
-/// Result of probing one repo against all enabled probes.
-#[derive(Debug, Clone)]
-pub struct ProbeEvidence {
-    /// `(rule_text, target_file, matched_line_excerpt)`.
-    pub matches: Vec<(&'static str, &'static str, String)>,
-}
-
-impl ProbeEvidence {
-    /// Walk the probe catalog and produce evidence. Missing or
-    /// unreadable files silently count as "not matched" — probes are
-    /// strictly additive over path-presence rules.
-    pub fn collect(repo_root: &Path, probes: &[ProbeRule]) -> Self {
-        let mut matches = Vec::new();
-        for probe in probes {
-            let Ok(compiled) = probe.compiled() else {
-                continue;
-            };
-            let path = repo_root.join(probe.target_file);
-            let Ok(text) = std::fs::read_to_string(&path) else {
-                continue;
-            };
-            if let Some(m) = compiled.find(&text) {
-                let line_no = text[..m.start()].matches('\n').count() + 1;
-                let line_start = text[..m.start()]
-                    .rfind('\n')
-                    .map(|i| i + 1)
-                    .unwrap_or(0);
-                let line_end_rel = text[m.start()..]
-                    .find('\n')
-                    .unwrap_or(text.len() - m.start());
-                let line_end = m.start() + line_end_rel;
-                let excerpt = text[line_start..line_end].trim().to_string();
-                matches.push((probe.rule_text, probe.target_file, format!("{path:?}:{line_no} {excerpt}")));
-            }
-        }
-        Self { matches }
-    }
-
-    /// Number of matches for the given cluster id.
-    pub fn matches_for_cluster(&self, cluster: &str) -> usize {
-        self.matches
-            .iter()
-            .filter(|(_, _, _)| {
-                // We don't have the cluster id directly on the tuple;
-                // tests can use the richer `matches_with_cluster` API.
-                false
-            })
-            .count()
-    }
-}
-
-/// Like [`ProbeEvidence::matches_for_cluster`] but returns the full
-/// triple (cluster_id, rule_text, target_file, evidence_line). The
+/// Evidence tagged with its source cluster so callers can bucket probes.
 /// collector tags each match with its source cluster so callers can
 /// bucket evidence cleanly.
 #[derive(Debug, Clone)]
@@ -324,15 +272,10 @@ fn rules_for(cluster: &str) -> Vec<(&'static str, &'static str, &'static [&'stat
         .collect()
 }
 
-/// Score one cluster against the scan evidence.
-fn score_cluster(pillar: &Pillar, scan: &RepoScan, _repo: &Path) -> ClusterScore {
-    score_cluster_with_probes(pillar, scan, _repo, &TaggedProbeEvidence { matches: vec![] })
-}
-
 /// Score one cluster against path-presence rules + content-probe evidence.
 ///
 /// Backwards-compat: when `probe_evidence` is empty (e.g. probes disabled
-/// by passing `Some(&[])` or the default [`score_cluster`] call), the
+/// by passing `Some(&[])`), the
 /// behavior is identical to the v1 path-presence scoring.
 fn score_cluster_with_probes(
     pillar: &Pillar,

--- a/crates/agileplus-governance/src/scoring_engine.rs
+++ b/crates/agileplus-governance/src/scoring_engine.rs
@@ -274,9 +274,9 @@ fn rules_for(cluster: &str) -> Vec<(&'static str, &'static str, &'static [&'stat
 
 /// Score one cluster against path-presence rules + content-probe evidence.
 ///
-/// Backwards-compat: when `probe_evidence` is empty (e.g. probes disabled
-/// by passing `Some(&[])`), the
-/// behavior is identical to the v1 path-presence scoring.
+/// Backwards-compat: `evaluate_with_probes` converts `Some(&[])` to empty
+/// `TaggedProbeEvidence`; with that empty value, behavior is identical to the
+/// v1 path-presence scoring.
 fn score_cluster_with_probes(
     pillar: &Pillar,
     scan: &RepoScan,

--- a/crates/agileplus-sqlite/src/lib.rs
+++ b/crates/agileplus-sqlite/src/lib.rs
@@ -40,7 +40,7 @@ use agileplus_domain::domain::project::Project;
 use agileplus_domain::domain::sync_mapping::SyncMapping;
 
 use crate::repository::{
-    audit, backlog, cycles, epics, events, evidence, features, governance, metrics, modules,
+    audit, backlog, cycles, epics, evidence, features, governance, metrics, modules,
     projects, stories, sync_mappings, users, work_packages,
 };
 

--- a/crates/agileplus-triage/Cargo.toml
+++ b/crates/agileplus-triage/Cargo.toml
@@ -5,6 +5,16 @@ edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["local", "bloom"]
+local = []
+bloom = ["dep:bitvec"]
+http = ["dep:ureq"]
+oai = ["http"]
+voyage = ["http"]
+sqlite = ["dep:rusqlite"]
+codebert = ["oai"]
+
 [dependencies]
 agileplus-domain = { path = "../agileplus-domain" }
 serde.workspace = true
@@ -15,6 +25,9 @@ anyhow.workspace = true
 thiserror.workspace = true
 clap = { workspace = true, features = ["derive"] }
 tokio.workspace = true
+bitvec = { version = "1.0", optional = true, default-features = false, features = ["alloc"] }
+ureq = { version = "2", optional = true, default-features = false, features = ["tls", "json"] }
+rusqlite = { workspace = true, optional = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/agileplus-triage/src/lib.rs
+++ b/crates/agileplus-triage/src/lib.rs
@@ -32,6 +32,7 @@ use clap::Args;
 pub mod adapter;
 pub mod ast_tokenize;
 pub mod backlog;
+#[cfg(feature = "bloom")]
 pub mod bloom;
 pub mod claim;
 #[cfg(feature = "sqlite")]


### PR DESCRIPTION
spec: eco-044-gate-triage

## Summary

- surface dashboard SQLite/schema query failures instead of silently reporting a valid empty portfolio
- resolve the inherited dashboard manifest conflict while retaining its API dependency
- remove verified non-Plane Rust warnings and restore the declared AgilePlus triage feature graph

## User-facing outcome

Dashboard consumers can distinguish an empty portfolio from a failing data source, and strict non-Plane Rust builds can advance without hiding warnings.

## Validation

- `cargo test -p agileplus-dashboard --lib epics_stories_json_tests --locked` (2 passed)
- `RUSTFLAGS=-D warnings cargo check -p agileplus-sqlite --locked`
- `RUSTFLAGS=-D warnings cargo check -p agileplus-api --locked`
- `RUSTFLAGS=-D warnings cargo test -p agileplus-governance --lib --locked` (37 passed)
- `RUSTFLAGS=-D warnings cargo check -p agileplus-triage --all-features --locked`
- `git diff --check origin/main...HEAD`

## Scope and remaining gates

Plane is intentionally excluded and remains paused by sponsor direction. This PR does not claim release, compliance, or dogfood readiness. The separate MCP deployment/audit-chain provenance gate remains blocked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved dashboard epic and story loading with clearer error reporting when data preparation or retrieval fails.
  - Added compatibility handling for empty, missing, and legacy schemas.
  - Removed unresolved configuration artifacts that could interfere with dashboard builds.

- **Improvements**
  - Added configurable support for optional triage capabilities, including HTTP, SQLite, Bloom filters, and supported model integrations.
  - Streamlined evidence handling in governance scoring for more consistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->