### PR TITLE
fix(python): scope gRPC skip to integration tests

### DIFF
--- a/python/tests/integration/conftest.py
+++ b/python/tests/integration/conftest.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 import pytest
 
 SKIP_REASON = "AGILEPLUS_GRPC_URL not set; skipped outside Docker Compose environment"
+INTEGRATION_TESTS_DIR = Path(__file__).parent.resolve()
 
 
 def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
@@ -14,9 +16,9 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
     if os.environ.get("AGILEPLUS_GRPC_URL"):
         return
 
-    skip_marker = pytest.mark.skip(reason=SKIP_REASON)
     for item in items:
-        item.add_marker(skip_marker)
+        if Path(item.path).resolve().is_relative_to(INTEGRATION_TESTS_DIR):
+            item.add_marker(pytest.mark.skip(reason=SKIP_REASON))
 
 
 @pytest.fixture

--- a/python/tests/test_integration_collection_policy.py
+++ b/python/tests/test_integration_collection_policy.py
@@ -1,0 +1,20 @@
+"""Regression tests for integration-test collection policy."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from tests.integration.conftest import pytest_collection_modifyitems
+
+
+def test_collection_policy_skips_only_integration_tests(monkeypatch) -> None:
+    """A missing gRPC endpoint must not skip regular unit tests."""
+    monkeypatch.delenv("AGILEPLUS_GRPC_URL", raising=False)
+    integration_item = MagicMock(path=Path("tests/integration/test_mcp_workflow.py"))
+    unit_item = MagicMock(path=Path("tests/test_tools.py"))
+
+    pytest_collection_modifyitems([integration_item, unit_item])
+
+    integration_item.add_marker.assert_called_once()
+    unit_item.add_marker.assert_not_called()


### PR DESCRIPTION
## Summary

- restrict the missing-gRPC skip policy to tests under `python/tests/integration/`
- add a regression test proving non-integration tests remain runnable

## Evidence

- `cd python && uv run ruff check tests/integration/conftest.py tests/test_integration_collection_policy.py`
- `cd python && uv run pytest -q -rs` -> 29 passed, 10 expected integration skips
- `cd python && uv run coverage run -m pytest -q` -> suite executes; coverage is 37% (not the prior false 6%).

## Follow-up gate

This change fixes an incorrect global skip policy. The repository still needs a separate, quality-preserving Python coverage expansion plan to meet the configured 80/85% floors; this PR does not lower those gates.