### PR TITLE
fix(cli): restore locked strict-build validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,6 +202,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "agileplus-e2e-roundtrip"
+version = "0.1.0"
+dependencies = [
+ "assert_cmd",
+ "predicates",
+ "tempfile",
+]
+
+[[package]]
 name = "agileplus-fixtures"
 version = "0.2.1"
 dependencies = [
@@ -1938,17 +1947,14 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.20.4"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
+checksum = "ddddbf932745a6be37109b6112d3ee09696106f848449069d3a57bba937ab82e"
 dependencies = [
  "bitflags 2.13.0",
  "libc",
  "libgit2-sys",
  "log",
- "openssl-probe 0.1.6",
- "openssl-sys",
- "url",
 ]
 
 [[package]]
@@ -3523,9 +3529,7 @@ checksum = "005d6ae6eac1912906073e069f7db60b1fa98e052a68227824afe3e3a1c59ca2"
 dependencies = [
  "cc",
  "libc",
- "libssh2-sys",
  "libz-sys",
- "openssl-sys",
  "pkg-config",
 ]
 
@@ -3551,20 +3555,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
  "cc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
-name = "libssh2-sys"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c04141a07bb0c0bc461cb657808764de571702a59bc5c726c400ac9a7625e3ab"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
  "pkg-config",
  "vcpkg",
 ]
@@ -4475,30 +4465,6 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
 ]
 
 [[package]]
@@ -6477,9 +6443,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utoipa"
-version = "4.2.3"
+version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5afb1a60e207dca502682537fefcfd9921e71d0b83e9576060f09abc6efab23"
+checksum = "8bde15df68e80b16c7d16b9616e80770ad158988daa56a27dccd1e55558b0160"
 dependencies = [
  "indexmap",
  "serde",
@@ -6489,11 +6455,10 @@ dependencies = [
 
 [[package]]
 name = "utoipa-gen"
-version = "4.3.1"
+version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20c24e8ab68ff9ee746aad22d39b5535601e6416d1b0feeabf78be986a5c4392"
+checksum = "6ba0b99ee52df3028635d93840c797102da61f8a7bb3cf751032455895b52ef8"
 dependencies = [
- "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/crates/agileplus-cli/src/commands/fix_list.rs
+++ b/crates/agileplus-cli/src/commands/fix_list.rs
@@ -27,7 +27,10 @@ use anyhow::{bail, Context, Result};
 use clap::Args;
 use comfy_table::{Cell, Row, Table};
 
-use agileplus_governance::scoring_engine::{evaluate, ClusterScore, ScoreReport};
+use agileplus_governance::scoring_engine::{evaluate, ScoreReport};
+
+#[cfg(test)]
+use agileplus_governance::scoring_engine::ClusterScore;
 
 use crate::commands::rubric::resolve_default_catalog_for_siblings;
 

--- a/crates/agileplus-cli/src/commands/validate/evidence.rs
+++ b/crates/agileplus-cli/src/commands/validate/evidence.rs
@@ -1,10 +1,8 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
 use anyhow::{Context, Result};
 
-use agileplus_domain::domain::governance::{
-    BuiltinPolicy, Evidence, EvidenceType, GovernanceContract, PolicyCheck,
-};
+use agileplus_domain::domain::governance::{Evidence, EvidenceType, GovernanceContract, PolicyCheck};
 use agileplus_domain::ports::StoragePort;
 
 use super::{EvidenceCheck, PolicyEvalResult};
@@ -76,6 +74,7 @@ pub(crate) async fn evaluate_evidence<S: StoragePort>(
 }
 
 /// Check if evidence meets a threshold defined in metadata.
+#[cfg(test)]
 pub(crate) fn evaluate_threshold(evidence: &[&Evidence], threshold: &serde_json::Value) -> bool {
     if let Some(min_cov) = threshold.get("min_coverage").and_then(|v| v.as_f64()) {
         for ev in evidence {
@@ -101,7 +100,7 @@ pub(crate) fn evaluate_threshold(evidence: &[&Evidence], threshold: &serde_json:
     true
 }
 
-/// Evaluate active policy rules and built-in contract policy refs against stored evidence.
+/// Evaluate the active persisted policy IDs referenced by a contract.
 pub(crate) async fn evaluate_policies<S: StoragePort>(
     storage: &S,
     contract: &GovernanceContract,
@@ -112,29 +111,33 @@ pub(crate) async fn evaluate_policies<S: StoragePort>(
         .await
         .context("loading active policies")?;
 
-    let referenced: BTreeSet<String> = contract
+    let referenced: BTreeSet<i64> = contract
         .rules
         .iter()
-        .flat_map(|r| r.policy_refs.iter().map(std::string::ToString::to_string))
+        .flat_map(|r| r.policy_refs.iter().copied())
         .collect();
 
     if referenced.is_empty() {
         return Ok(Vec::new());
     }
 
+    let active_by_id: BTreeMap<i64, _> = active_policies
+        .iter()
+        .map(|policy| (policy.id, policy))
+        .collect();
     let feature_evidence = load_feature_evidence(storage, feature_id).await?;
     let mut results = Vec::new();
-    let mut handled_refs = BTreeSet::new();
 
-    for policy in &active_policies {
-        let matched_refs: Vec<&String> = referenced
-            .iter()
-            .filter(|policy_ref| policy.matches_reference(policy_ref))
-            .collect();
-
-        if matched_refs.is_empty() {
+    for policy_id in referenced {
+        let Some(policy) = active_by_id.get(&policy_id) else {
+            results.push(PolicyEvalResult {
+                policy_id,
+                domain: "unknown".to_string(),
+                passed: false,
+                message: format!("Referenced policy ID {policy_id} is missing or inactive"),
+            });
             continue;
-        }
+        };
 
         let (passed, message) = match &policy.rule.check {
             PolicyCheck::EvidencePresent { evidence_type } => {
@@ -157,38 +160,12 @@ pub(crate) async fn evaluate_policies<S: StoragePort>(
             ),
         };
 
-        for policy_ref in matched_refs {
-            handled_refs.insert(policy_ref.clone());
-        }
-
         results.push(PolicyEvalResult {
             policy_id: policy.id,
             domain: policy.domain.as_str().to_string(),
             passed,
             message,
         });
-    }
-
-    for policy_ref in referenced.difference(&handled_refs) {
-        if let Some(builtin) = BuiltinPolicy::from_ref(policy_ref) {
-            let (passed, message) =
-                evaluate_evidence_policy(contract, &feature_evidence, builtin.evidence_type);
-            results.push(PolicyEvalResult {
-                policy_id: 0,
-                domain: builtin.domain.as_str().to_string(),
-                passed,
-                message: format!("{}: {message}", builtin.label),
-            });
-        } else {
-            results.push(PolicyEvalResult {
-                policy_id: 0,
-                domain: "custom".to_string(),
-                passed: false,
-                message: format!(
-                    "Policy ref '{policy_ref}' has no active policy rule or built-in evaluator"
-                ),
-            });
-        }
     }
 
     Ok(results)

--- a/crates/agileplus-cli/src/commands/validate/tests.rs
+++ b/crates/agileplus-cli/src/commands/validate/tests.rs
@@ -1,8 +1,8 @@
 use super::*;
 use agileplus_domain::domain::feature::Feature;
 use agileplus_domain::domain::governance::{
-    Evidence, EvidenceRequirement, EvidenceType, GovernanceContract, GovernanceRule, PolicyCheck,
-    PolicyDefinition, PolicyDomain, PolicyRule,
+    Evidence, EvidenceType, GovernanceContract, GovernanceRule, PolicyCheck, PolicyDefinition,
+    PolicyDomain, PolicyRule,
 };
 use agileplus_domain::domain::work_package::WorkPackage;
 use agileplus_domain::ports::StoragePort;
@@ -17,11 +17,7 @@ fn make_contract(feature_id: i64) -> GovernanceContract {
         version: 1,
         rules: vec![GovernanceRule {
             transition: "Implementing -> Validated".to_string(),
-            required_evidence: vec![EvidenceRequirement {
-                fr_id: "FR-001".to_string(),
-                evidence_type: EvidenceType::CiOutput,
-                threshold: None,
-            }],
+            required_evidence: vec!["FR-001:ci_output".to_string()],
             policy_refs: vec![],
         }],
         bound_at: Utc::now(),
@@ -154,14 +150,22 @@ fn evaluate_threshold_max_critical_fail() {
 }
 
 #[tokio::test]
-async fn builtin_ci_policy_fails_without_matching_evidence() {
+async fn persisted_ci_policy_fails_without_matching_evidence() {
     let db = SqliteStorageAdapter::in_memory().unwrap();
     let feature_id = create_feature_with_wp(&db).await.0;
+    let policy_id = create_policy_rule(
+        &db,
+        PolicyDomain::Quality,
+        PolicyCheck::EvidencePresent {
+            evidence_type: EvidenceType::CiOutput,
+        },
+    )
+    .await;
     let contract = contract_with_policy(
         feature_id,
         EvidenceType::CiOutput,
         "FR-CI",
-        "policy:ci-required",
+        policy_id,
     );
 
     let results = super::evidence::evaluate_policies(&db, &contract, feature_id)
@@ -174,14 +178,22 @@ async fn builtin_ci_policy_fails_without_matching_evidence() {
 }
 
 #[tokio::test]
-async fn builtin_ci_policy_ignores_wrong_evidence_type() {
+async fn persisted_ci_policy_ignores_wrong_evidence_type() {
     let db = SqliteStorageAdapter::in_memory().unwrap();
     let (feature_id, wp_id) = create_feature_with_wp(&db).await;
+    let policy_id = create_policy_rule(
+        &db,
+        PolicyDomain::Quality,
+        PolicyCheck::EvidencePresent {
+            evidence_type: EvidenceType::CiOutput,
+        },
+    )
+    .await;
     let contract = contract_with_policy(
         feature_id,
         EvidenceType::CiOutput,
         "FR-CI",
-        "policy:ci-required",
+        policy_id,
     );
     create_evidence(&db, wp_id, "FR-CI", EvidenceType::ReviewApproval).await;
 
@@ -195,14 +207,22 @@ async fn builtin_ci_policy_ignores_wrong_evidence_type() {
 }
 
 #[tokio::test]
-async fn builtin_ci_policy_passes_with_matching_evidence() {
+async fn persisted_ci_policy_passes_with_matching_evidence() {
     let db = SqliteStorageAdapter::in_memory().unwrap();
     let (feature_id, wp_id) = create_feature_with_wp(&db).await;
+    let policy_id = create_policy_rule(
+        &db,
+        PolicyDomain::Quality,
+        PolicyCheck::EvidencePresent {
+            evidence_type: EvidenceType::CiOutput,
+        },
+    )
+    .await;
     let contract = contract_with_policy(
         feature_id,
         EvidenceType::CiOutput,
         "FR-CI",
-        "policy:ci-required",
+        policy_id,
     );
     create_evidence(&db, wp_id, "FR-CI", EvidenceType::CiOutput).await;
 
@@ -231,7 +251,7 @@ async fn active_policy_matches_generated_ci_ref() {
         feature_id,
         EvidenceType::CiOutput,
         "FR-CI",
-        "policy:ci-required",
+        policy_id,
     );
     create_evidence(&db, wp_id, "FR-CI", EvidenceType::CiOutput).await;
 
@@ -256,6 +276,39 @@ async fn empty_policy_refs_do_not_evaluate_active_policies() {
         .unwrap();
 
     assert!(results.is_empty());
+}
+
+#[tokio::test]
+async fn missing_policy_id_fails_closed() {
+    let db = SqliteStorageAdapter::in_memory().unwrap();
+    let feature_id = create_feature_with_wp(&db).await.0;
+    let contract = contract_with_policy(feature_id, EvidenceType::CiOutput, "FR-CI", 999);
+
+    let results = super::evidence::evaluate_policies(&db, &contract, feature_id)
+        .await
+        .unwrap();
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].policy_id, 999);
+    assert!(!results[0].passed);
+    assert!(results[0].message.contains("missing or inactive"));
+}
+
+#[tokio::test]
+async fn inactive_policy_id_fails_closed() {
+    let db = SqliteStorageAdapter::in_memory().unwrap();
+    let feature_id = create_feature_with_wp(&db).await.0;
+    let policy_id = create_inactive_policy_rule(&db).await;
+    let contract = contract_with_policy(feature_id, EvidenceType::CiOutput, "FR-CI", policy_id);
+
+    let results = super::evidence::evaluate_policies(&db, &contract, feature_id)
+        .await
+        .unwrap();
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].policy_id, policy_id);
+    assert!(!results[0].passed);
+    assert!(results[0].message.contains("missing or inactive"));
 }
 
 async fn create_feature_with_wp(db: &SqliteStorageAdapter) -> (i64, i64) {
@@ -315,11 +368,29 @@ async fn create_policy_rule(
     StoragePort::create_policy_rule(db, &rule).await.unwrap()
 }
 
+async fn create_inactive_policy_rule(db: &SqliteStorageAdapter) -> i64 {
+    let now = Utc::now();
+    let rule = PolicyRule {
+        id: 0,
+        domain: PolicyDomain::Quality,
+        rule: PolicyDefinition {
+            description: "inactive test policy".to_string(),
+            check: PolicyCheck::EvidencePresent {
+                evidence_type: EvidenceType::CiOutput,
+            },
+        },
+        active: false,
+        created_at: now,
+        updated_at: now,
+    };
+    StoragePort::create_policy_rule(db, &rule).await.unwrap()
+}
+
 fn contract_with_policy(
     feature_id: i64,
     evidence_type: EvidenceType,
     fr_id: &str,
-    policy_ref: &str,
+    policy_ref: i64,
 ) -> GovernanceContract {
     GovernanceContract {
         id: 1,
@@ -327,12 +398,8 @@ fn contract_with_policy(
         version: 1,
         rules: vec![GovernanceRule {
             transition: "Implementing -> Validated".to_string(),
-            required_evidence: vec![EvidenceRequirement {
-                fr_id: fr_id.to_string(),
-                evidence_type,
-                threshold: None,
-            }],
-            policy_refs: vec![policy_ref.to_string()],
+            required_evidence: vec![format!("{fr_id}:{}", evidence_type.as_str())],
+            policy_refs: vec![policy_ref],
         }],
         bound_at: Utc::now(),
     }


### PR DESCRIPTION
spec: eco-039-release-system - Restore locked Rust CLI build/test validation for the installed-CLI release path.

## Summary
- reconcile Cargo.lock with declared tests/e2e, git2 0.21, and utoipa 5 requirements without a broad resolver refresh
- scope CLI-only production/test symbols correctly under strict warnings
- align validate fixtures to persisted numeric policy IDs and current evidence keys

## Stack Topology
Rust Cargo workspace: Cargo.lock -> agileplus-cli strict build -> governance evidence/policy fixtures -> installed-CLI E2E workspace member.

## Validation
- RUSTFLAGS='-D warnings' cargo check --locked -p agileplus-cli
- cargo test --locked -p agileplus-cli commands::validate::tests:: --lib (14 passed)
- cargo test --locked -p agileplus-cli commands::fix_list --lib (7 passed)
- git diff --check

## Governance
This direct fix branch targets main under layered-pr-exception. No review, CI, coverage, security, or merge protection is bypassed.

## CI Exception
None requested. Current full-workspace cargo fmt reports existing unrelated mainline formatting drift; this PR does not mask or reformat it.