### PR TITLE
fix(cli): restore strict build coverage path

### DIFF
--- a/.github/workflows/memory.yml
+++ b/.github/workflows/memory.yml
@@ -52,21 +52,24 @@ jobs:
       - name: Run dhat heap profiling tests
         id: profile
         run: |
+          set +e
           cargo test \
             --features dhat-heap \
             --manifest-path crates/agileplus-domain/Cargo.toml \
-            -- -Z unstable-options --report-time \
+            -- --test-threads=1 \
             2>&1 | tee memory-profile-output.txt
-          echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+          exit_code=${PIPESTATUS[0]}
+          echo "exit_code=${exit_code}" >> "$GITHUB_OUTPUT"
+          exit "$exit_code"
 
       - name: List dhat heap profile artifacts
         id: artifacts
         if: always()
         run: |
           echo "=== dhat heap profiles ==="
-          ls -lh dhat-heap*.json 2>/dev/null || echo "No dhat-heap*.json files found"
+          find . -maxdepth 1 -type f -name 'dhat-heap*.json' -print
           # Count how many profiles were generated
-          count=$(ls dhat-heap*.json 2>/dev/null | wc -l | tr -d ' ')
+          count=$(find . -maxdepth 1 -type f -name 'dhat-heap*.json' -print | wc -l | tr -d ' ')
           echo "profile_count=${count:-0}" >> "$GITHUB_OUTPUT"
 
       - name: Upload dhat heap profiles

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -168,6 +177,7 @@ dependencies = [
  "async-trait",
  "base64",
  "chrono",
+ "dhat",
  "dirs-next",
  "indexmap",
  "keyring",
@@ -814,6 +824,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1450,6 +1475,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "dhat"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cd11d84628e233de0ce467de10b8633f4ddaecafadefc86e13b84b8739b827"
+dependencies = [
+ "backtrace",
+ "lazy_static",
+ "mintex",
+ "parking_lot",
+ "rustc-hash 1.1.0",
+ "serde",
+ "serde_json",
+ "thousands",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1944,6 +1985,12 @@ dependencies = [
  "opaque-debug",
  "polyval",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "git2"
@@ -3703,6 +3750,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mintex"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c505b3e17ed6b70a7ed2e67fbb2c560ee327353556120d6e72f5232b6880d536"
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3969,6 +4022,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
 dependencies = [
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -4659,7 +4721,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustls",
  "socket2",
  "thiserror 2.0.18",
@@ -4680,7 +4742,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.4",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -5052,6 +5114,18 @@ dependencies = [
  "rand 0.10.2",
  "thiserror 2.0.18",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -5780,6 +5854,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "thousands"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
 name = "thread_local"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,6 +188,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "agileplus-e2e-roundtrip"
+version = "0.1.0"
+dependencies = [
+ "assert_cmd",
+ "predicates",
+ "tempfile",
+]
+
+[[package]]
 name = "agileplus-events"
 version = "0.2.1"
 dependencies = [

--- a/crates/agileplus-cli/src/commands/fix_list.rs
+++ b/crates/agileplus-cli/src/commands/fix_list.rs
@@ -27,7 +27,10 @@ use anyhow::{bail, Context, Result};
 use clap::Args;
 use comfy_table::{Cell, Row, Table};
 
-use agileplus_governance::scoring_engine::{evaluate, ClusterScore, ScoreReport};
+use agileplus_governance::scoring_engine::{evaluate, ScoreReport};
+
+#[cfg(test)]
+use agileplus_governance::scoring_engine::ClusterScore;
 
 use crate::commands::rubric::resolve_default_catalog_for_siblings;
 

--- a/crates/agileplus-cli/src/commands/validate/evidence.rs
+++ b/crates/agileplus-cli/src/commands/validate/evidence.rs
@@ -76,6 +76,7 @@ pub(crate) async fn evaluate_evidence<S: StoragePort>(
 }
 
 /// Check if evidence meets a threshold defined in metadata.
+#[cfg(test)]
 pub(crate) fn evaluate_threshold(evidence: &[&Evidence], threshold: &serde_json::Value) -> bool {
     if let Some(min_cov) = threshold.get("min_coverage").and_then(|v| v.as_f64()) {
         for ev in evidence {

--- a/crates/agileplus-cli/src/commands/validate/tests.rs
+++ b/crates/agileplus-cli/src/commands/validate/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use agileplus_domain::domain::feature::Feature;
 use agileplus_domain::domain::governance::{
-    Evidence, EvidenceRequirement, EvidenceType, GovernanceContract, GovernanceRule, PolicyCheck,
+    Evidence, EvidenceType, GovernanceContract, GovernanceRule, PolicyCheck,
     PolicyDefinition, PolicyDomain, PolicyRule,
 };
 use agileplus_domain::domain::work_package::WorkPackage;
@@ -17,11 +17,7 @@ fn make_contract(feature_id: i64) -> GovernanceContract {
         version: 1,
         rules: vec![GovernanceRule {
             transition: "Implementing -> Validated".to_string(),
-            required_evidence: vec![EvidenceRequirement {
-                fr_id: "FR-001".to_string(),
-                evidence_type: EvidenceType::CiOutput,
-                threshold: None,
-            }],
+            required_evidence: vec!["FR-001:ci_output".to_string()],
             policy_refs: vec![],
         }],
         bound_at: Utc::now(),
@@ -154,14 +150,15 @@ fn evaluate_threshold_max_critical_fail() {
 }
 
 #[tokio::test]
-async fn builtin_ci_policy_fails_without_matching_evidence() {
+async fn stored_ci_policy_fails_without_matching_evidence() {
     let db = SqliteStorageAdapter::in_memory().unwrap();
     let feature_id = create_feature_with_wp(&db).await.0;
+    let policy_id = create_ci_evidence_policy(&db).await;
     let contract = contract_with_policy(
         feature_id,
         EvidenceType::CiOutput,
         "FR-CI",
-        "policy:ci-required",
+        policy_id,
     );
 
     let results = super::evidence::evaluate_policies(&db, &contract, feature_id)
@@ -174,14 +171,15 @@ async fn builtin_ci_policy_fails_without_matching_evidence() {
 }
 
 #[tokio::test]
-async fn builtin_ci_policy_ignores_wrong_evidence_type() {
+async fn stored_ci_policy_ignores_wrong_evidence_type() {
     let db = SqliteStorageAdapter::in_memory().unwrap();
     let (feature_id, wp_id) = create_feature_with_wp(&db).await;
+    let policy_id = create_ci_evidence_policy(&db).await;
     let contract = contract_with_policy(
         feature_id,
         EvidenceType::CiOutput,
         "FR-CI",
-        "policy:ci-required",
+        policy_id,
     );
     create_evidence(&db, wp_id, "FR-CI", EvidenceType::ReviewApproval).await;
 
@@ -195,14 +193,15 @@ async fn builtin_ci_policy_ignores_wrong_evidence_type() {
 }
 
 #[tokio::test]
-async fn builtin_ci_policy_passes_with_matching_evidence() {
+async fn stored_ci_policy_passes_with_matching_evidence() {
     let db = SqliteStorageAdapter::in_memory().unwrap();
     let (feature_id, wp_id) = create_feature_with_wp(&db).await;
+    let policy_id = create_ci_evidence_policy(&db).await;
     let contract = contract_with_policy(
         feature_id,
         EvidenceType::CiOutput,
         "FR-CI",
-        "policy:ci-required",
+        policy_id,
     );
     create_evidence(&db, wp_id, "FR-CI", EvidenceType::CiOutput).await;
 
@@ -231,7 +230,7 @@ async fn active_policy_matches_generated_ci_ref() {
         feature_id,
         EvidenceType::CiOutput,
         "FR-CI",
-        "policy:ci-required",
+        policy_id,
     );
     create_evidence(&db, wp_id, "FR-CI", EvidenceType::CiOutput).await;
 
@@ -315,11 +314,22 @@ async fn create_policy_rule(
     StoragePort::create_policy_rule(db, &rule).await.unwrap()
 }
 
+async fn create_ci_evidence_policy(db: &SqliteStorageAdapter) -> i64 {
+    create_policy_rule(
+        db,
+        PolicyDomain::Quality,
+        PolicyCheck::EvidencePresent {
+            evidence_type: EvidenceType::CiOutput,
+        },
+    )
+    .await
+}
+
 fn contract_with_policy(
     feature_id: i64,
     evidence_type: EvidenceType,
     fr_id: &str,
-    policy_ref: &str,
+    policy_id: i64,
 ) -> GovernanceContract {
     GovernanceContract {
         id: 1,
@@ -327,12 +337,8 @@ fn contract_with_policy(
         version: 1,
         rules: vec![GovernanceRule {
             transition: "Implementing -> Validated".to_string(),
-            required_evidence: vec![EvidenceRequirement {
-                fr_id: fr_id.to_string(),
-                evidence_type,
-                threshold: None,
-            }],
-            policy_refs: vec![policy_ref.to_string()],
+            required_evidence: vec![format!("{fr_id}:{}", evidence_type.as_str())],
+            policy_refs: vec![policy_id],
         }],
         bound_at: Utc::now(),
     }

--- a/crates/agileplus-domain/Cargo.toml
+++ b/crates/agileplus-domain/Cargo.toml
@@ -23,11 +23,13 @@ argon2.workspace = true
 base64.workspace = true
 rand.workspace = true
 keyring = { workspace = true, optional = true }
+dhat = { version = "0.3", optional = true }
 # agileplus-plugin-core = { git = "https://github.com/KooshaPari/agileplus-plugin-core", optional = true }
 
 [features]
 default = ["keychain"]
 keychain = ["dep:keyring"]
+dhat-heap = ["dep:dhat"]
 # plugins = ["agileplus-plugin-core"]  # disabled for standalone build
 
 [dev-dependencies]

--- a/crates/agileplus-domain/tests/memory.rs
+++ b/crates/agileplus-domain/tests/memory.rs
@@ -10,7 +10,7 @@
 //! ```bash
 //! cargo test --features dhat-heap \
 //!   --manifest-path crates/agileplus-domain/Cargo.toml \
-//!   -- --test-threads=1 -Z unstable-options --report-time
+//!   -- --test-threads=1
 //! ```
 //!
 //! Heap profiles are written to `dhat-heap*.json` files in the workspace

--- a/crates/agileplus-domain/tests/memory.rs
+++ b/crates/agileplus-domain/tests/memory.rs
@@ -10,7 +10,7 @@
 //! ```bash
 //! cargo test --features dhat-heap \
 //!   --manifest-path crates/agileplus-domain/Cargo.toml \
-//!   -- -Z unstable-options --report-time
+//!   -- --test-threads=1 -Z unstable-options --report-time
 //! ```
 //!
 //! Heap profiles are written to `dhat-heap*.json` files in the workspace
@@ -39,7 +39,7 @@
 
 #![cfg(feature = "dhat-heap")]
 
-use dhat::{Alloc, Heap};
+use dhat::{Alloc, Profiler};
 
 #[global_allocator]
 static ALLOC: Alloc = Alloc;
@@ -61,7 +61,7 @@ use chrono::Utc;
 /// large batch of [`Feature`] aggregates.
 #[test]
 fn memory_profile_feature_lifecycle() {
-    let _profiler = Heap::new();
+    let _profiler = Profiler::new_heap();
 
     let mut features: Vec<Feature> = (0..10_000)
         .map(|i| {
@@ -97,7 +97,7 @@ fn memory_profile_feature_lifecycle() {
 /// of [`WorkPackage`] values.
 #[test]
 fn memory_profile_work_package_operations() {
-    let _profiler = Heap::new();
+    let _profiler = Profiler::new_heap();
 
     let mut work_packages: Vec<WorkPackage> = (0..10_000)
         .map(|i| {
@@ -132,7 +132,7 @@ fn memory_profile_work_package_operations() {
 /// Profile heap usage during trace-ref linking across many artifacts.
 #[test]
 fn memory_profile_traceability_bridge() {
-    let _profiler = Heap::new();
+    let _profiler = Profiler::new_heap();
     let adapter = NoopTraceAdapter;
 
     let entries: Vec<(TraceRef, String)> = (0..500)
@@ -172,7 +172,7 @@ fn memory_profile_traceability_bridge() {
 /// object graph — a common bottleneck in REST/gRPC handlers.
 #[test]
 fn memory_profile_json_serialization_stress() {
-    let _profiler = Heap::new();
+    let _profiler = Profiler::new_heap();
 
     let features: Vec<Feature> = (0..5_000)
         .map(|i| {


### PR DESCRIPTION
spec: eco-039-release-system - Strict-build and profiling follow-up for current main.

## Summary
Restores strict-build boundaries in the CLI, aligns stale policy fixtures with numeric policy IDs, records the installed-CLI E2E package in Cargo.lock, and restores the documented Dhat heap-profiling feature with its current Profiler API.

## Stack Topology
AgilePlus CLI, domain profiling test, and their lockfile records only; no dashboard, release, or service topology change.

## Validation
- `RUSTFLAGS='-D warnings' cargo check --locked -p agileplus-cli`
- 14 focused CLI unit tests for threshold, stored-policy, and fix-list paths
- `RUSTFLAGS='-D warnings' cargo test --locked -p agileplus-domain --features dhat-heap --test memory --no-run`

## Governance
Concurrent dashboard and unrelated Cargo dependency-refresh work remains excluded and preserved remotely at `wip/20260814T0700-concurrent-dashboard-lock-state`. Clean nested worktrees were verified remote-backed and untouched.

## CI Exception
None requested.
