### PR TITLE
fix(dashboard): restore seeded store invariants

### DIFF
--- a/crates/agileplus-dashboard/src/seed_bridge.rs
+++ b/crates/agileplus-dashboard/src/seed_bridge.rs
@@ -16,13 +16,14 @@
 //!
 //! Each call has a 3-second timeout so a stalled api never blocks dashboard startup.
 
-use std::time::Duration;
+use std::{collections::HashMap, time::Duration};
 
 use agileplus_domain::domain::cycle::Cycle;
 use agileplus_domain::domain::module::Module;
 use agileplus_domain::domain::project::Project;
 
 use crate::app_state::DashboardStore;
+use crate::seed::seed_dogfood_features;
 
 const API_BASE_DEFAULT: &str = "http://127.0.0.1:3000";
 const API_TIMEOUT_SECS: u64 = 3;
@@ -110,5 +111,85 @@ async fn fetch_json_with_header<T: serde::de::DeserializeOwned + Send>(
 /// Used as the default state for the dashboard, plus the fallback when the api is
 /// unreachable.
 pub fn build_dashboard_store() -> DashboardStore {
-    DashboardStore::seeded()
+    let (features, work_packages) = seed_dogfood_features();
+
+    let now = chrono::Utc::now();
+
+    // ---- Seeded modules (native dashboard structure) ----
+    let modules = vec![
+        Module {
+            id: 1,
+            slug: "core".to_string(),
+            friendly_name: "Core".to_string(),
+            description: Some("Core platform functionality".to_string()),
+            parent_module_id: None,
+            created_at: now,
+            updated_at: now,
+        },
+        Module {
+            id: 2,
+            slug: "kitty-specs".to_string(),
+            friendly_name: "Kitty Specs".to_string(),
+            description: Some("Kitty specification suite".to_string()),
+            parent_module_id: None,
+            created_at: now,
+            updated_at: now,
+        },
+        Module {
+            id: 3,
+            slug: "agents".to_string(),
+            friendly_name: "Agents".to_string(),
+            description: Some("Agent infrastructure".to_string()),
+            parent_module_id: None,
+            created_at: now,
+            updated_at: now,
+        },
+    ];
+
+    // ---- Seeded cycles (native dashboard structure) ----
+    let cycles = vec![Cycle {
+        id: 1,
+        name: "Sprint 1".to_string(),
+        description: Some("Initial development sprint".to_string()),
+        start_date: now.date_naive(),
+        end_date: now.date_naive(),
+        state: agileplus_domain::domain::cycle::CycleState::Active,
+        module_scope_id: None,
+        created_at: now,
+        updated_at: now,
+    }];
+
+    // Map feature IDs to cycle 1 (dogfood association)
+    let cycle_features: HashMap<i64, Vec<i64>> = {
+        let mut m = HashMap::new();
+        m.insert(1, features.iter().map(|f| f.id).collect());
+        m
+    };
+
+    // ---- Seeded projects ----
+    let projects = vec![Project {
+        id: 1,
+        slug: "agileplus-internal".to_string(),
+        name: "AgilePlus Internal".to_string(),
+        description: Some("Internal AgilePlus development project".to_string()),
+        created_at: now,
+        updated_at: now,
+    }];
+
+    // ---- Default service health ----
+    let health = crate::app_state::default_health();
+
+    DashboardStore {
+        features,
+        work_packages,
+        modules,
+        cycles,
+        cycle_features,
+        health,
+        projects,
+        active_project_id: Some(1),
+        governance_client: None,
+        plane_daemon: None,
+        plane_client: None,
+    }
 }

--- a/crates/agileplus-dashboard/tests/seed_integration.rs
+++ b/crates/agileplus-dashboard/tests/seed_integration.rs
@@ -99,7 +99,13 @@ fn seed_creates_seeded_dashboard_store() {
 
     let store = DashboardStore::seeded();
     assert_eq!(store.features.len(), 37);
-    assert!(!store.health.is_empty());
+    assert_eq!(store.modules.len(), 3);
+    assert_eq!(store.cycles.len(), 1);
+    assert_eq!(store.cycle_features.get(&1).map(Vec::len), Some(37));
+    assert_eq!(store.projects.len(), 1);
+    assert_eq!(store.active_project_id, Some(1));
+    assert_eq!(store.health.len(), 8);
+    assert_eq!(store.work_packages.len(), 37);
     assert!(store.work_packages.contains_key(&1));
     assert!(store.work_packages.contains_key(&37));
 }


### PR DESCRIPTION
## User-facing outcome

Dashboard startup without a live API restores the complete dogfood store instead of recursing until stack overflow or presenting an empty kanban.

## Scope

- restores the historical non-recursive 37-feature dashboard constructor
- asserts modules, cycle mapping, project, health, and work-package invariants
- excludes the concurrent raw SQLite hydration WIP

## Evidence

- `git diff --check` passed
- red reproduction on the valid resolver candidate: `seed_creates_seeded_dashboard_store` stack-overflowed through `DashboardStore::seeded -> build_dashboard_store`
- green on the same candidate: `cargo test -p agileplus-dashboard --test seed_integration --locked --offline` (8 passed)

## Remaining gates

This PR is draft because current main `Cargo.lock` still rejects `--locked`. The separately preserved resolver candidate is `wip/20260814-lockfile-resolver-integrity`; it requires dependency/security and hosted CI review before this dashboard PR can be considered merge-ready.