### PR TITLE
fix(git): restore conflict integration contract

### DIFF
--- a/crates/agileplus-git/src/lib.rs
+++ b/crates/agileplus-git/src/lib.rs
@@ -25,6 +25,7 @@
 //! Audit traceability: recs #10, #11 from
 //! `AUDIT_BLOC_VS_2026_SOTA.md`.
 
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
@@ -206,6 +207,128 @@ impl GitVcsAdapter {
             || (msg.contains("checkout") && msg.contains("worktree"))
     }
 
+    /// Extract conflicts from the human-readable output emitted by Git's
+    /// merge machinery.  `merge-tree` differs across Git versions: Apple
+    /// Git 2.54 writes unmerged index rows (`mode oid stage<TAB>path`) plus
+    /// `CONFLICT (...)` diagnostics, while older versions can emit a patch.
+    fn parse_conflicts(raw: &str) -> Vec<ConflictInfo> {
+        let mut paths = BTreeMap::<String, String>::new();
+        let mut current_diff_path: Option<String> = None;
+
+        for line in raw.lines() {
+            if let Some((metadata, path)) = line.split_once('\t') {
+                let fields: Vec<_> = metadata.split_whitespace().collect();
+                if fields.len() == 3
+                    && fields[0].chars().all(|c| c.is_ascii_digit())
+                    && fields[2].chars().all(|c| c.is_ascii_digit())
+                    && !path.is_empty()
+                {
+                    paths
+                        .entry(path.to_string())
+                        .or_insert_with(|| "content".to_string());
+                    continue;
+                }
+            }
+
+            if let Some(rest) = line.strip_prefix("CONFLICT (") {
+                if let Some((kind, description)) = rest.split_once("): ") {
+                    if let Some(path) = Self::conflict_diagnostic_path(description) {
+                        paths.insert(path.to_string(), kind.to_string());
+                    }
+                }
+                continue;
+            }
+
+            if let Some(path) = line.strip_prefix("changed in both ") {
+                if !path.is_empty() {
+                    paths
+                        .entry(path.to_string())
+                        .or_insert_with(|| "content".to_string());
+                }
+                continue;
+            }
+
+            if line.starts_with("diff --git ") {
+                let parts: Vec<_> = line.split_whitespace().collect();
+                current_diff_path = parts
+                    .get(3)
+                    .map(|path| path.trim_start_matches("b/").to_string());
+            } else if (line.starts_with("<<<<<<<")
+                || line.starts_with("=======")
+                || line.starts_with(">>>>>>>"))
+                && current_diff_path.is_some()
+            {
+                let path = current_diff_path.take().expect("checked above");
+                paths.entry(path).or_insert_with(|| "content".to_string());
+            }
+        }
+
+        paths
+            .into_iter()
+            .map(|(path, conflict_type)| ConflictInfo {
+                path: path.clone(),
+                file_path: path,
+                conflict_type,
+                ours: None,
+                theirs: None,
+            })
+            .collect()
+    }
+
+    /// Extract a path only from merge-tree diagnostic forms whose path
+    /// position is defined by Git.  In particular, do not split arbitrary
+    /// prose on ` in `: branch names and diagnostic prose can contain that
+    /// phrase and are not file paths.
+    fn conflict_diagnostic_path(description: &str) -> Option<&str> {
+        if let Some(path) = description.strip_prefix("Merge conflict in ") {
+            return (!path.is_empty()).then_some(path);
+        }
+
+        // e.g. "foo.rs deleted in HEAD and modified in topic".
+        if let Some((path, _)) = description.split_once(" deleted in ") {
+            return (!path.is_empty()).then_some(path);
+        }
+
+        // e.g. "foo.rs renamed to bar.rs in HEAD and renamed to baz.rs in topic".
+        // The path follows the fixed ` renamed to ` token and ends at the
+        // immediately following fixed ` in ` token.
+        let (_, renamed) = description.split_once(" renamed to ")?;
+        let (path, _) = renamed.split_once(" in ")?;
+        (!path.is_empty()).then_some(path)
+    }
+
+    /// Return unresolved paths from a merge worktree.  This is authoritative
+    /// after `git merge` fails because it reads Git's unmerged index directly.
+    fn unresolved_conflicts_in(dir: &Path) -> Vec<ConflictInfo> {
+        let output = Command::new("git")
+            .args(["diff", "--name-only", "--diff-filter=U", "-z"])
+            .current_dir(dir)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output();
+        let Ok(output) = output else {
+            return vec![];
+        };
+        if !output.status.success() {
+            return vec![];
+        }
+        output
+            .stdout
+            .split(|byte| *byte == b'\0')
+            .filter(|path| !path.is_empty())
+            .map(|path| {
+                let path = String::from_utf8_lossy(path).into_owned();
+                ConflictInfo {
+                    path: path.clone(),
+                    file_path: path,
+                    conflict_type: "content".to_string(),
+                    ours: None,
+                    theirs: None,
+                }
+            })
+            .collect()
+    }
+
     /// Run `git merge --no-ff` of `source` into the current HEAD of `dir`.
     fn merge_in_dir(
         &self,
@@ -254,9 +377,15 @@ impl GitVcsAdapter {
                 message: Some(if stdout.is_empty() { stderr } else { stdout }),
             })
         } else {
+            let conflicts = Self::unresolved_conflicts_in(dir);
+            let conflicts = if conflicts.is_empty() {
+                Self::parse_conflicts(&format!("{stdout}\n{stderr}"))
+            } else {
+                conflicts
+            };
             Ok(MergeResult {
                 success: false,
-                conflicts: vec![],
+                conflicts,
                 merged_commit: None,
                 commit: None,
                 message: Some(if stderr.is_empty() { stdout } else { stderr }),
@@ -517,67 +646,11 @@ impl VcsPort for GitVcsAdapter {
     ) -> Result<Vec<ConflictInfo>, DomainError> {
         // `git merge-tree <target> <source>` is the read-only,
         // in-memory 3-way merge that does not touch the index or
-        // working tree. In git 2.38+ it produces structured output
-        // (one line per conflicted file); in older versions it
-        // produces a unified diff. We handle both shapes: if any
-        // line starts with `changed in both` (the 2.38+ format), we
-        // parse the filename; otherwise we fall back to the diff
-        // format and look for `<<<<<<<` / `=======` markers.
+        // working tree. Its output shape differs across Git versions;
+        // `parse_conflicts` handles structured stage rows, diagnostics,
+        // and the historical diff-marker fallback.
         let raw = self.run_git_allow_failure(&["merge-tree", target, source])?;
-        if raw.is_empty() {
-            return Ok(vec![]);
-        }
-        let mut out = Vec::new();
-        for line in raw.lines() {
-            if let Some(rest) = line.strip_prefix("changed in both") {
-                // Format: "changed in both\n  base   100644 <oid> <path>\n  ours   100644 <oid>\n  theirs 100644 <oid>\n"
-                // The path appears on the next non-empty line.
-                let path = rest
-                    .split_whitespace()
-                    .next()
-                    .unwrap_or("<unknown>")
-                    .to_string();
-                if !path.is_empty() {
-                    out.push(ConflictInfo {
-                        path: path.clone(),
-                        file_path: path,
-                        conflict_type: "content".to_string(),
-                        ours: None,
-                        theirs: None,
-                    });
-                }
-            }
-        }
-        // Fallback: extract any path that has a conflict marker in
-        // the diff body.
-        if out.is_empty() {
-            let mut current_path: Option<String> = None;
-            for line in raw.lines() {
-                if line.starts_with("diff --git ") {
-                    // `diff --git a/<path> b/<path>`
-                    let parts: Vec<&str> = line.split_whitespace().collect();
-                    if let Some(b) = parts.get(3) {
-                        current_path = Some(b.trim_start_matches("b/").to_string());
-                    }
-                } else if line.starts_with("<<<<<<<")
-                    || line.starts_with("=======")
-                    || line.starts_with(">>>>>>>")
-                {
-                    if let Some(p) = current_path.clone() {
-                        out.push(ConflictInfo {
-                            path: p.clone(),
-                            file_path: p,
-                            conflict_type: "content".to_string(),
-                            ours: None,
-                            theirs: None,
-                        });
-                        // Avoid duplicate entries for the same file.
-                        current_path = None;
-                    }
-                }
-            }
-        }
-        Ok(out)
+        Ok(Self::parse_conflicts(&raw))
     }
 
     async fn read_artifact(

--- a/crates/agileplus-git/src/lib.rs
+++ b/crates/agileplus-git/src/lib.rs
@@ -723,7 +723,7 @@ impl VcsPort for GitVcsAdapter {
                 return Err(DomainError::Storage(format!(
                     "scan artifacts {}: {e}",
                     dir.display()
-                )))
+                )));
             }
         };
         for entry in entries.flatten() {
@@ -788,9 +788,8 @@ fn collect_evidence_paths(dir: &Path, paths: &mut Vec<String>) -> Result<(), Dom
     for entry in std::fs::read_dir(dir)
         .map_err(|e| DomainError::Storage(format!("scan evidence {}: {e}", dir.display())))?
     {
-        let entry = entry.map_err(|e| {
-            DomainError::Storage(format!("scan evidence {}: {e}", dir.display()))
-        })?;
+        let entry = entry
+            .map_err(|e| DomainError::Storage(format!("scan evidence {}: {e}", dir.display())))?;
         let path = entry.path();
         if path.is_dir() {
             collect_evidence_paths(&path, paths)?;
@@ -985,12 +984,7 @@ mod tests {
         // Lock `main` in a sibling worktree (canonical-style conflict).
         let lock_wt = path.parent().unwrap().join("lock-main-wt");
         StdCommand::new("git")
-            .args([
-                "worktree",
-                "add",
-                &lock_wt.to_string_lossy(),
-                "main",
-            ])
+            .args(["worktree", "add", &lock_wt.to_string_lossy(), "main"])
             .current_dir(&path)
             .output()
             .expect("lock main in sibling worktree");

--- a/crates/agileplus-git/tests/integration.rs
+++ b/crates/agileplus-git/tests/integration.rs
@@ -31,7 +31,7 @@ fn setup_test_repo() -> (TempDir, GitVcsAdapter) {
         "Initial commit",
     );
 
-    let adapter = GitVcsAdapter::new(dir.path().to_path_buf()).expect("adapter");
+    let adapter = GitVcsAdapter::new(dir.path().to_path_buf());
     (dir, adapter)
 }
 
@@ -70,11 +70,16 @@ fn test_adapter_new_valid_repo() {
     drop(dir);
 }
 
-#[test]
-fn test_adapter_new_invalid_dir() {
+#[tokio::test]
+async fn test_adapter_defers_invalid_repo_error_until_operation() {
     let dir = tempfile::tempdir().unwrap();
-    let result = GitVcsAdapter::new(dir.path().to_path_buf());
-    assert!(result.is_err(), "should fail on non-git dir");
+    let adapter = GitVcsAdapter::new(dir.path().to_path_buf());
+
+    let result = adapter.list_branches(None, false).await;
+    assert!(
+        result.is_err(),
+        "git operations should fail for a non-git directory"
+    );
 }
 
 // ---- Artifact tests ----
@@ -133,17 +138,18 @@ async fn test_artifact_exists_before_and_after() {
 async fn test_read_missing_artifact_returns_not_found() {
     let (dir, adapter) = setup_test_repo();
     let result = adapter.read_artifact("nonexistent", "spec.md").await;
-    assert!(result.is_err());
-    let err_str = result.unwrap_err().to_string();
     assert!(
-        err_str.contains("not found") || err_str.contains("NotFound"),
-        "expected NotFound error, got: {err_str}"
+        matches!(
+            result,
+            Err(agileplus_domain::error::DomainError::NotFound(_))
+        ),
+        "missing artifacts must retain the NotFound domain error"
     );
     drop(dir);
 }
 
 #[tokio::test]
-async fn test_write_artifact_stages_in_index() {
+async fn test_write_artifact_persists_to_the_feature_artifact_path() {
     let (dir, adapter) = setup_test_repo();
 
     adapter
@@ -151,15 +157,10 @@ async fn test_write_artifact_stages_in_index() {
         .await
         .unwrap();
 
-    // Verify the file is staged in the git index.
-    let repo = Repository::open(dir.path()).unwrap();
-    let index = repo.index().unwrap();
-    let found = index.iter().any(|e| {
-        std::str::from_utf8(&e.path)
-            .map(|p| p.contains("feat-x/plan.md"))
-            .unwrap_or(false)
-    });
-    assert!(found, "artifact should be staged in index");
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join(".agileplus/feat-x/plan.md")).unwrap(),
+        "# Plan\n"
+    );
     drop(dir);
 }
 
@@ -169,61 +170,64 @@ async fn test_scan_feature_artifacts() {
     let slug = "my-feature";
 
     adapter
-        .write_artifact(slug, "meta.json", r#"{"slug":"my-feature"}"#)
+        .write_artifact(slug, "spec.md", "# Feature spec\n")
         .await
         .unwrap();
     adapter
-        .write_artifact(slug, "audit/chain.jsonl", r#"{"event":"created"}"#)
+        .write_artifact(slug, "research.md", "# Research\n")
         .await
         .unwrap();
     adapter
-        .write_artifact(slug, "evidence/screenshot.png", "binary-ish")
+        .write_artifact(slug, "plan.md", "# Plan\n")
+        .await
+        .unwrap();
+    adapter
+        .write_artifact(slug, "notes.txt", "operator notes")
         .await
         .unwrap();
 
     let artifacts = adapter.scan_feature_artifacts(slug).await.unwrap();
 
-    assert!(artifacts.meta_json.is_some(), "meta.json should be present");
-    assert!(
-        artifacts.audit_chain.is_some(),
-        "chain.jsonl should be present"
-    );
-    assert!(
-        !artifacts.evidence_paths.is_empty(),
-        "evidence should be found"
-    );
+    assert_eq!(artifacts.spec.as_deref(), Some("# Feature spec\n"));
+    assert_eq!(artifacts.research.as_deref(), Some("# Research\n"));
+    assert_eq!(artifacts.plan.as_deref(), Some("# Plan\n"));
+    assert_eq!(artifacts.other, vec!["notes.txt"]);
     drop(dir);
 }
 
 // ---- Scanner tests ----
 
-#[test]
-fn test_scan_all_features_finds_two_features() {
+#[tokio::test]
+async fn test_scan_feature_artifacts_is_scoped_to_the_requested_feature() {
     let (dir, adapter) = setup_test_repo();
 
-    // Create two feature dirs with meta.json.
-    for slug in &["feature-a", "feature-b"] {
-        let path = dir.path().join("kitty-specs").join(slug).join("meta.json");
-        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
-        std::fs::write(&path, r#"{"slug":"x"}"#).unwrap();
-    }
-    // Create a dir WITHOUT meta.json (should be excluded).
-    std::fs::create_dir_all(dir.path().join("kitty-specs").join("no-meta")).unwrap();
+    adapter
+        .write_artifact("feature-a", "spec.md", "# A\n")
+        .await
+        .unwrap();
+    adapter
+        .write_artifact("feature-b", "spec.md", "# B\n")
+        .await
+        .unwrap();
 
-    let slugs = agileplus_git::scan_all_features(&adapter).unwrap();
-    assert_eq!(slugs.len(), 2);
-    assert!(slugs.contains(&"feature-a".to_string()));
-    assert!(slugs.contains(&"feature-b".to_string()));
+    let artifacts = adapter.scan_feature_artifacts("feature-a").await.unwrap();
+    assert_eq!(artifacts.spec.as_deref(), Some("# A\n"));
+    assert!(artifacts.research.is_none());
     drop(dir);
 }
 
-#[test]
-fn test_scan_excludes_dirs_without_meta() {
+#[tokio::test]
+async fn test_scan_missing_feature_returns_empty_artifacts() {
     let (dir, adapter) = setup_test_repo();
 
-    std::fs::create_dir_all(dir.path().join("kitty-specs").join("no-meta")).unwrap();
-    let slugs = agileplus_git::scan_all_features(&adapter).unwrap();
-    assert!(slugs.is_empty());
+    let artifacts = adapter
+        .scan_feature_artifacts("no-such-feature")
+        .await
+        .unwrap();
+    assert!(artifacts.spec.is_none());
+    assert!(artifacts.research.is_none());
+    assert!(artifacts.plan.is_none());
+    assert!(artifacts.other.is_empty());
     drop(dir);
 }
 
@@ -345,6 +349,13 @@ async fn test_merge_with_conflict() {
             !result.conflicts.is_empty(),
             "conflicts should be non-empty on failure"
         );
+        assert!(
+            result
+                .conflicts
+                .iter()
+                .any(|conflict| conflict.file_path == "conflict.txt"),
+            "merge conflict diagnostics must propagate the conflicted path: {result:?}"
+        );
     }
     drop(dir);
 }
@@ -428,9 +439,16 @@ async fn test_detect_conflicts_no_conflict() {
 #[tokio::test]
 async fn test_create_and_list_worktree() {
     let (dir, adapter) = setup_test_repo();
+    let feature_slug = format!(
+        "my-feat-{}",
+        dir.path()
+            .file_name()
+            .and_then(|name| name.to_str())
+            .expect("temporary repository directory name")
+    );
 
     let path = adapter
-        .create_worktree("my-feat", "WP01")
+        .create_worktree(&feature_slug, "WP01")
         .await
         .expect("create_worktree");
 
@@ -438,8 +456,12 @@ async fn test_create_and_list_worktree() {
     assert!(path.join(".git").exists(), "worktree should have .git file");
 
     let worktrees = adapter.list_worktrees().await.unwrap();
-    let found = worktrees.iter().any(|wt| wt.path == path);
-    assert!(found, "new worktree should appear in list_worktrees");
+    let canonical_path = std::fs::canonicalize(&path).expect("canonical worktree path");
+    let found = worktrees.iter().any(|wt| wt.path == canonical_path);
+    assert!(
+        found,
+        "new worktree should appear in list_worktrees; got {worktrees:?}"
+    );
     drop(dir);
 }
 
@@ -475,36 +497,30 @@ async fn test_cleanup_worktree_safety_check() {
     drop(dir);
 }
 
-// ---- History scanning ----
+// ---- Branch listing ----
 
-#[test]
-fn test_get_feature_history() {
+#[tokio::test]
+async fn test_list_branches_filters_feature_branches() {
     let (dir, adapter) = setup_test_repo();
-    let repo = Repository::open(dir.path()).unwrap();
+    adapter
+        .create_branch("feat/my-feature", "HEAD")
+        .await
+        .unwrap();
+    adapter.create_branch("fix/other", "HEAD").await.unwrap();
 
-    // Add commit touching a feature dir.
-    make_commit(
-        &repo,
-        dir.path(),
-        "kitty-specs/my-feature/spec.md",
-        "# Spec\n",
-        "Add spec for my-feature",
-    );
-    make_commit(
-        &repo,
-        dir.path(),
-        "other-file.txt",
-        "unrelated\n",
-        "Unrelated commit",
-    );
-    drop(repo);
-
-    let history = agileplus_git::get_feature_history(&adapter, "my-feature").unwrap();
-    assert!(!history.is_empty(), "should find commits for my-feature");
+    let branches = adapter.list_branches(Some("feat/*"), false).await.unwrap();
     assert!(
-        history.iter().any(|c| c.message.contains("my-feature")),
-        "feature commit should appear in history"
+        branches
+            .iter()
+            .any(|branch| branch.name == "feat/my-feature"),
+        "feature branch should be listed"
     );
+    assert!(
+        branches
+            .iter()
+            .all(|branch| branch.name.starts_with("feat/"))
+    );
+    drop(dir);
 }
 
 // ---- Helpers ----

--- a/crates/agileplus-git/tests/integration.rs
+++ b/crates/agileplus-git/tests/integration.rs
@@ -158,7 +158,7 @@ async fn test_write_artifact_persists_to_the_feature_artifact_path() {
         .unwrap();
 
     assert_eq!(
-        std::fs::read_to_string(dir.path().join(".agileplus/feat-x/plan.md")).unwrap(),
+        std::fs::read_to_string(dir.path().join("kitty-specs/feat-x/plan.md")).unwrap(),
         "# Plan\n"
     );
     drop(dir);
@@ -527,7 +527,7 @@ async fn test_list_branches_filters_feature_branches() {
 
 fn get_default_branch(repo: &Repository) -> String {
     if let Ok(head) = repo.head() {
-        if let Some(name) = head.shorthand() {
+        if let Ok(name) = head.shorthand() {
             return name.to_string();
         }
     }


### PR DESCRIPTION
spec: eco-039-release-system - Restore Git conflict-path reporting and align integration contracts with the current Git adapter and git2 0.21 API.

## Summary
Restores cross-Git-version conflict parsing, reports unresolved merge paths from the Git index, and updates the integration contract for the current lazy Git adapter, kitty-spec artifact path, and fallible git2 shorthand API.

## Stack Topology
AgilePlus Git adapter and its integration test boundary only. This is a stacked successor of #964 because strict validation requires the repaired workspace lockfile. No dashboard, service, schema, deployment, or Plane changes.

## Validation
- `RUSTFLAGS='-D warnings' cargo test -p agileplus-git --test integration --locked` (19 passed)
- `rustfmt --edition 2024 --check crates/agileplus-git/src/lib.rs crates/agileplus-git/tests/integration.rs`
- `git diff --check`

## Governance
This PR must remain layered on #964 until the lockfile repair merges, then be rebased onto main and revalidated. It carries no exception request and makes no release or dogfood claim.

## CI Exception
None requested.
