### PR TITLE
ci: restore managed mypy hook environment

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,8 +36,7 @@ repos:
         args: [--ignore-missing-imports, --no-strict-optional]
         additional_dependencies: [types-requests, types-PyYAML]
         pass_filenames: false
-        entry: mypy src/
-        language: system
+        entry: mypy python/src/
 
   # ── Rust ──
   - repo: https://github.com/rust-lang/rust-clippy


### PR DESCRIPTION
spec: eco-044-gate-triage - Repair the pre-commit mypy hook configuration that prevents the Security Guard from initializing.

## Summary
Removes the incompatible system-language override from the mirrors-mypy hook and points its entry at the repository's actual Python source root. The hook can now create the environment required by additional_dependencies.

## Stack Topology
Pre-commit configuration only. No application, service, schema, dashboard, deployment, Plane, or runtime behavior change.

## Validation
- RED: `pre-commit run mypy --all-files` failed because additional_dependencies cannot be used with language: system.
- `pre-commit validate-config` passes after the correction.
- Full mypy hook execution is pending hosted Guard confirmation while local pre-commit initializes third-party hook environments.

## Governance
A dedicated CI configuration repair. Generated Python cache artifacts are untracked and excluded. No CI exception requested.

## CI Exception
None requested.
