### PR TITLE
fix(nightly): use toolchain input instead of @nightly-DATE tag

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -44,11 +44,11 @@ jobs:
         steps:
             - uses: actions/checkout@v7
 
-            - uses: dtolnay/rust-toolchain@nightly-2026-07-31
+            - uses: dtolnay/rust-toolchain@nightly
               with:
+                  toolchain: nightly-2026-07-31
                   targets: ${{ matrix.target }}
                   components: rustfmt, clippy
-
             - uses: Swatinem/rust-cache@v2
 
             - uses: arduino/setup-protoc@v3


### PR DESCRIPTION
## **User description**
## Problem


___

## **CodeAnt-AI Description**
Keep nightly builds pinned to the intended Rust toolchain

### What Changed
- Nightly builds now use the configured Rust toolchain date instead of treating the date as the action version
- Builds continue to install the required target, formatting, and linting components

### Impact
`✅ Reliable nightly toolchain selection`
`✅ Fewer CI build failures from invalid action versions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the nightly build workflow to use the stable nightly Rust toolchain channel.
  * Pinned nightly builds to the July 31, 2026 toolchain version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->