### PR TITLE
fix(events): add PartialEq+Eq derives to domain_event structs

### DIFF
--- a/crates/agileplus-events/src/domain_event.rs
+++ b/crates/agileplus-events/src/domain_event.rs
@@ -37,7 +37,7 @@ impl From<i64> for AggregateId {
 // ──────────────────────────────────────────────────────────────────────────────
 
 /// Project created.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ProjectCreated {
     pub project_id: AggregateId,
     pub slug: String,
@@ -45,7 +45,7 @@ pub struct ProjectCreated {
 }
 
 /// Project renamed.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ProjectRenamed {
     pub project_id: AggregateId,
     pub old_name: String,
@@ -53,13 +53,13 @@ pub struct ProjectRenamed {
 }
 
 /// Project archived (soft-delete).
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ProjectArchived {
     pub project_id: AggregateId,
 }
 
 /// Epic created under a project.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct EpicCreated {
     pub epic_id: AggregateId,
     pub project_id: AggregateId,
@@ -67,7 +67,7 @@ pub struct EpicCreated {
 }
 
 /// Epic status changed (e.g. Backlog → Active).
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct EpicStatusChanged {
     pub epic_id: AggregateId,
     pub project_id: AggregateId,
@@ -76,7 +76,7 @@ pub struct EpicStatusChanged {
 }
 
 /// Story created under an epic.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct StoryCreated {
     pub story_id: AggregateId,
     pub epic_id: AggregateId,
@@ -86,7 +86,7 @@ pub struct StoryCreated {
 }
 
 /// Story status changed.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct StoryStatusChanged {
     pub story_id: AggregateId,
     pub epic_id: AggregateId,
@@ -95,14 +95,14 @@ pub struct StoryStatusChanged {
 }
 
 /// Story assigned to a user (or unassigned).
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct StoryAssigned {
     pub story_id: AggregateId,
     pub assignee_id: Option<AggregateId>,
 }
 
 /// User added to the platform.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct UserAdded {
     pub user_id: AggregateId,
     pub display_name: String,
@@ -111,7 +111,7 @@ pub struct UserAdded {
 }
 
 /// User role changed.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct UserRoleChanged {
     pub user_id: AggregateId,
     pub old_role: UserRole,
@@ -119,7 +119,7 @@ pub struct UserRoleChanged {
 }
 
 /// User status changed (active / inactive / suspended).
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct UserStatusChanged {
     pub user_id: AggregateId,
     pub from: UserStatus,
@@ -127,7 +127,7 @@ pub struct UserStatusChanged {
 }
 
 /// Feature created.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct FeatureCreated {
     pub feature_id: AggregateId,
     pub slug: String,
@@ -136,7 +136,7 @@ pub struct FeatureCreated {
 }
 
 /// Feature state advanced (e.g. Created → Specified).
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct FeatureStateAdvanced {
     pub feature_id: AggregateId,
     pub from: FeatureState,
@@ -144,14 +144,14 @@ pub struct FeatureStateAdvanced {
 }
 
 /// Feature shipped (terminal state reached).
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct FeatureShipped {
     pub feature_id: AggregateId,
     pub slug: String,
 }
 
 /// Work-package created under a feature.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct WorkPackageCreated {
     pub wp_id: AggregateId,
     pub feature_id: AggregateId,
@@ -160,7 +160,7 @@ pub struct WorkPackageCreated {
 }
 
 /// Work-package state changed.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct WorkPackageStateChanged {
     pub wp_id: AggregateId,
     pub feature_id: AggregateId,
@@ -177,7 +177,7 @@ pub struct WorkPackageStateChanged {
 /// Add a variant here when a new aggregate is introduced or an existing one
 /// gains a new observable transition.  Variants are `#[non_exhaustive]` to
 /// allow downstream crates to match without breaking on future additions.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum DomainEvent {
     // --- Project ---
@@ -278,7 +278,7 @@ impl DomainEvent {
 /// The envelope carries the metadata needed by infrastructure (bus routing,
 /// idempotency checks, audit log) without leaking those concerns into the
 /// domain payload.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct EventEnvelope {
     /// Globally unique identifier for this envelope instance.
     pub id: Uuid,


### PR DESCRIPTION
## **User description**
The DomainEvent enum derives PartialEq but the inner structs (ProjectCreated, EpicCreated, etc.) didn't derive PartialEq, causing E0369 comparison errors.


___

## **CodeAnt-AI Description**
Enable reliable equality checks for domain events and event envelopes

### What Changed
- Domain event payloads, event variants, and envelopes can now be compared for exact equality
- Comparisons include event data and envelope metadata such as identifiers, timestamps, and aggregate details
- Removes compilation errors when code compares complete domain events

### Impact
`✅ Event comparisons compile successfully`
`✅ Reliable equality checks in event processing`
`✅ Easier validation of event data and metadata`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved event data comparability, enabling more reliable equality checks for domain events and their payloads.
  * No changes to event fields, variants, methods, or runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->