### PR TITLE
fix(test): case-insensitive Intent parsing, format cfg(test) indentation

### DIFF
--- a/crates/agileplus-application/src/lib.rs
+++ b/crates/agileplus-application/src/lib.rs
@@ -28,7 +28,7 @@ mod tests {
 
     use async_trait::async_trait;
     use tokio::sync::RwLock;
-#[cfg(test)]
+    #[cfg(test)]
     use std::sync::Mutex;
 
     use agileplus_domain::domain::epic::{Epic, EpicStatus};

--- a/crates/agileplus-domain/src/domain/backlog.rs
+++ b/crates/agileplus-domain/src/domain/backlog.rs
@@ -34,7 +34,7 @@ impl fmt::Display for Intent {
 impl FromStr for Intent {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
+        match s.to_lowercase().as_str() {
             "bug" => Ok(Intent::Bug),
             "feature" => Ok(Intent::Feature),
             "idea" => Ok(Intent::Idea),
@@ -83,7 +83,7 @@ impl fmt::Display for BacklogPriority {
 impl FromStr for BacklogPriority {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
+        match s.to_lowercase().as_str() {
             "critical" => Ok(BacklogPriority::Critical),
             "high" => Ok(BacklogPriority::High),
             "medium" => Ok(BacklogPriority::Medium),
@@ -120,7 +120,7 @@ impl fmt::Display for BacklogStatus {
 impl FromStr for BacklogStatus {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
+        match s.to_lowercase().as_str() {
             "new" => Ok(BacklogStatus::New),
             "triaged" => Ok(BacklogStatus::Triaged),
             "in_progress" => Ok(BacklogStatus::InProgress),


### PR DESCRIPTION
## **User description**
Fixes nightly CI: make Intent FromStr case-insensitive (test passes FEATURE, parser only accepted feature) and indent #[cfg(test)] for rustfmt.


___

## **CodeAnt-AI Description**
Accept case-insensitive backlog values and keep test builds correctly formatted

### What Changed
- Intent, priority, and status values can now be parsed regardless of letter casing, such as `FEATURE`, `High`, or `DONE`
- Test-only imports are correctly scoped so formatting and test builds pass consistently

### Impact
`✅ Fewer failures when reading uppercase backlog values`
`✅ More reliable configuration and data parsing`
`✅ Consistent test formatting`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
