### PR TITLE
fix(lock): reconcile generated workspace lockfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,6 +218,7 @@ dependencies = [
  "sha2",
  "thiserror 2.0.20",
  "tokio",
+ "uuid",
 ]
 
 [[package]]
@@ -2868,9 +2869,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.17"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f877e75f39e9827ec50a572dd592684ac28c029578726c85f1b2aa6ab807449"
+checksum = "839c0e8a181239723652be9062bb56ca5bf5f64011f73b623f6f4fc59086a228"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
## Summary

Reconciles the tracked Cargo lockfile with the existing workspace manifests so the M1 release CLI build can run with `--locked`.

## Root cause

`agileplus-api` already declared `uuid`, but its resolved package dependency list in `Cargo.lock` did not. Cargo therefore attempted to rewrite the lockfile during `cargo build --release --locked -p agileplus-cli`, which correctly failed the immutable-build gate. Re-resolving the existing manifests also selects the compatible `h2` 0.4.18 patch release.

## Change

Only `Cargo.lock` changes: add the missing `uuid` edge and the resolver-consistent `h2` patch/checksum. No manifest, workflow, security-policy, or application-code changes are included.

## Validation

- RED: `cargo build --release --locked -p agileplus-cli` failed on the base with `cannot update the lock file`.
- GREEN: `cargo metadata --locked --format-version=1 --no-deps` passed.
- GREEN: `cargo build --release --locked -p agileplus-cli --message-format=short` passed.
- GREEN: `git diff --check` passed.
- Baseline, outside this PR: `cargo test --locked -p agileplus-cli` has one existing help-text assertion mismatch, and `cargo fmt --all -- --check` reports pre-existing formatting drift in six files. Neither file set is modified here.

## Scope

This PR intentionally does not repair the separately tracked infra, Security, nightly, pre-commit, fuzz, or release workflow failures.
