### PR TITLE
test(cli): align help text expectation

### DIFF
--- a/crates/agileplus-cli/tests/cli_integration.rs
+++ b/crates/agileplus-cli/tests/cli_integration.rs
@@ -12,7 +12,7 @@ fn help_prints_usage() {
         .assert()
         .success()
         .stdout(predicates::str::contains(
-            "AgilePlus project management CLI",
+            "Spec-driven development engine",
         ));
 }
 


### PR DESCRIPTION
## Summary

Aligns the CLI integration test with the description the shipped parser already exposes.

## Root cause

`Cli` declares `about = "Spec-driven development engine"`, while `help_prints_usage` still asserted the obsolete `AgilePlus project management CLI` text. The help command itself succeeded; only the stale expectation failed.

## Change

Changes one assertion string in `crates/agileplus-cli/tests/cli_integration.rs`. No CLI source, documentation, lockfile, workflows, formatting cleanup, or dependency policy changes are included.

## Validation

- RED: `cargo test --offline -p agileplus-cli --test cli_integration` reported the exact expected/actual description mismatch.
- GREEN: the same targeted test passed 2/2 after the assertion update.
- GREEN: `git diff --check` passed.
- Baseline blocker: current main cannot run this test with `--locked` until lockfile PR #1024 is merged; `cargo fmt --all -- --check` also reports existing formatting drift in unrelated files and the unchanged pre-existing multiline assertion formatting.
