### PR TITLE
[codex] normalize Rust formatter baseline

### DIFF
--- a/crates/agileplus-cli/src/commands/dag.rs
+++ b/crates/agileplus-cli/src/commands/dag.rs
@@ -29,7 +29,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Mutex;
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use clap::{Args, Subcommand};
 
 use agileplus_application::dto::{
@@ -490,11 +490,7 @@ async fn cmd_add(a: AddArgs) -> Result<()> {
         .split(',')
         .filter_map(|s| {
             let t = s.trim().to_string();
-            if t.is_empty() {
-                None
-            } else {
-                Some(t)
-            }
+            if t.is_empty() { None } else { Some(t) }
         })
         .collect();
     state.wp_repo.items.insert(

--- a/crates/agileplus-cli/src/main.rs
+++ b/crates/agileplus-cli/src/main.rs
@@ -14,9 +14,9 @@ use clap::{Parser, Subcommand};
 
 use agent_adapter::RealAgentAdapter;
 use agileplus_cli::commands::{
-    cockpit::CockpitArgs, cycle::CycleArgs, dashboard::DashboardArgs, list::ListArgs,
-    module::ModuleArgs, queue::QueueArgs, rubric::RubricArgs, specify::SpecifyArgs,
-    dag::DagArgs, okf::OkfArgs, mvp::MvpArgs,
+    cockpit::CockpitArgs, cycle::CycleArgs, dag::DagArgs, dashboard::DashboardArgs, list::ListArgs,
+    module::ModuleArgs, mvp::MvpArgs, okf::OkfArgs, queue::QueueArgs, rubric::RubricArgs,
+    specify::SpecifyArgs,
 };
 #[cfg(feature = "full-deps")]
 use agileplus_cli::commands::{

--- a/crates/agileplus-cli/tests/cli_integration.rs
+++ b/crates/agileplus-cli/tests/cli_integration.rs
@@ -11,9 +11,7 @@ fn help_prints_usage() {
         .arg("--help")
         .assert()
         .success()
-        .stdout(predicates::str::contains(
-            "Spec-driven",
-        ));
+        .stdout(predicates::str::contains("Spec-driven"));
 }
 
 #[test]

--- a/crates/agileplus-events/src/domain_event.rs
+++ b/crates/agileplus-events/src/domain_event.rs
@@ -360,9 +360,7 @@ pub enum EventHandlerError {
     Transient(String),
 }
 
-impl EventHandlerError {
-
-}
+impl EventHandlerError {}
 
 // ──────────────────────────────────────────────────────────────────────────────
 // EventBus port — dispatches to registered handlers (no concrete impl here)
@@ -715,5 +713,4 @@ mod tests {
             assert_eq!(ev.wire_code(), ev.event_type());
         }
     }
-
 }

--- a/crates/agileplus-events/src/lib.rs
+++ b/crates/agileplus-events/src/lib.rs
@@ -15,11 +15,11 @@ pub mod store;
 pub use bus::{DomainEvent, EventBus, EventSubscriber};
 
 pub use domain_event::{
-    AggregateId, AsyncEventBus, AsyncEventHandler, EpicCreated, EpicStatusChanged,
-    EventHandler, EventHandlerError, EventEnvelope, FeatureCreated, FeatureShipped,
-    FeatureStateAdvanced, ProjectArchived, ProjectCreated, ProjectRenamed,
-    StoryAssigned, StoryCreated, StoryStatusChanged, UserAdded, UserRoleChanged,
-    UserStatusChanged, WorkPackageCreated, WorkPackageStateChanged,
+    AggregateId, AsyncEventBus, AsyncEventHandler, EpicCreated, EpicStatusChanged, EventEnvelope,
+    EventHandler, EventHandlerError, FeatureCreated, FeatureShipped, FeatureStateAdvanced,
+    ProjectArchived, ProjectCreated, ProjectRenamed, StoryAssigned, StoryCreated,
+    StoryStatusChanged, UserAdded, UserRoleChanged, UserStatusChanged, WorkPackageCreated,
+    WorkPackageStateChanged,
 };
 
 pub use hash::{HashError, compute_hash, verify_chain};

--- a/crates/agileplus-events/tests/events_smoke_test.rs
+++ b/crates/agileplus-events/tests/events_smoke_test.rs
@@ -9,8 +9,8 @@ use agileplus_domain::domain::work_package::WpState;
 use agileplus_events::domain_event::DomainEvent;
 use agileplus_events::{
     AggregateId, EpicCreated, EpicStatusChanged, EventEnvelope, FeatureCreated, FeatureShipped,
-    FeatureStateAdvanced, ProjectArchived, ProjectCreated, ProjectRenamed,
-    StoryAssigned, StoryCreated, StoryStatusChanged, UserAdded, UserRoleChanged, UserStatusChanged,
+    FeatureStateAdvanced, ProjectArchived, ProjectCreated, ProjectRenamed, StoryAssigned,
+    StoryCreated, StoryStatusChanged, UserAdded, UserRoleChanged, UserStatusChanged,
     WorkPackageCreated, WorkPackageStateChanged,
 };
 use uuid::Uuid;


### PR DESCRIPTION
## Summary

Normalizes the Rust formatter baseline at current `main` without changing product behavior. The PR contains only rustfmt output in the six files reported by `cargo fmt --all -- --check`; the sixth file is the formatter hunk introduced by newly merged PR #1027.

## Cause and effect

The repository's full formatter gate was red because these tracked Rust files did not match the configured rustfmt output. That blocks contributors even when their functional changes are correct.

## Fix

Applied rustfmt mechanical output only: import ordering and wrapping, a closure expression layout, an empty impl layout, and blank-line removal. No lockfiles, manifests, workflows, documentation, or behavioral code changed.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test --offline -p agileplus-events` (41 unit tests and 25 smoke tests)
- `cargo test --offline -p agileplus-cli --lib` (186 tests)

Full hosted CI and required review remain promotion gates; this PR does not claim release readiness.
