### PR TITLE
fix(git): report exact merge conflict paths

### DIFF
--- a/crates/agileplus-git/src/lib.rs
+++ b/crates/agileplus-git/src/lib.rs
@@ -25,6 +25,7 @@
 //! Audit traceability: recs #10, #11 from
 //! `AUDIT_BLOC_VS_2026_SOTA.md`.
 
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
@@ -206,6 +207,213 @@ impl GitVcsAdapter {
             || (msg.contains("checkout") && msg.contains("worktree"))
     }
 
+    /// Extract conflicts from the human-readable output emitted by Git's
+    /// merge machinery.  `merge-tree` differs across Git versions: Apple
+    /// Git 2.54 writes unmerged index rows (`mode oid stage<TAB>path`) plus
+    /// `CONFLICT (...)` diagnostics, while older versions can emit a patch.
+    fn parse_conflicts(raw: &str) -> Vec<ConflictInfo> {
+        let mut paths = BTreeMap::<String, String>::new();
+        let mut current_diff_path: Option<String> = None;
+        let mut legacy_conflict_heading = false;
+
+        for line in raw.lines() {
+            if line.trim_end() == "changed in both" {
+                legacy_conflict_heading = true;
+                continue;
+            }
+
+            if legacy_conflict_heading {
+                if let Some(path) = Self::legacy_merge_tree_path(line) {
+                    paths
+                        .entry(path.to_string())
+                        .or_insert_with(|| "content".to_string());
+                    legacy_conflict_heading = false;
+                    continue;
+                }
+                if !line.starts_with(char::is_whitespace) {
+                    legacy_conflict_heading = false;
+                }
+            }
+
+            if let Some((metadata, path)) = line.split_once('\t') {
+                let fields: Vec<_> = metadata.split_whitespace().collect();
+                if fields.len() == 3
+                    && fields[0].chars().all(|c| c.is_ascii_digit())
+                    && fields[2].chars().all(|c| c.is_ascii_digit())
+                    && !path.is_empty()
+                {
+                    paths
+                        .entry(path.to_string())
+                        .or_insert_with(|| "content".to_string());
+                    continue;
+                }
+            }
+
+            if let Some(rest) = line.strip_prefix("CONFLICT (") {
+                if let Some((kind, description)) = rest.split_once("): ") {
+                    if let Some(path) = Self::conflict_diagnostic_path(description) {
+                        paths.insert(path.to_string(), kind.to_string());
+                    }
+                }
+                continue;
+            }
+
+            if let Some(path) = line.strip_prefix("changed in both ") {
+                if !path.is_empty() {
+                    paths
+                        .entry(path.to_string())
+                        .or_insert_with(|| "content".to_string());
+                }
+                continue;
+            }
+
+            if line.starts_with("diff --git ") {
+                current_diff_path = Self::diff_header_destination_path(line);
+            } else if (line.starts_with("<<<<<<<")
+                || line.starts_with("=======")
+                || line.starts_with(">>>>>>>"))
+                && current_diff_path.is_some()
+            {
+                let path = current_diff_path.take().expect("checked above");
+                paths.entry(path).or_insert_with(|| "content".to_string());
+            }
+        }
+
+        paths
+            .into_iter()
+            .map(|(path, conflict_type)| ConflictInfo {
+                path: path.clone(),
+                file_path: path,
+                conflict_type,
+                ours: None,
+                theirs: None,
+            })
+            .collect()
+    }
+
+    /// Extract the path from the `base <mode> <oid> <path>` row following a
+    /// legacy `changed in both` merge-tree heading without losing spaces in
+    /// the path itself.
+    fn legacy_merge_tree_path(line: &str) -> Option<&str> {
+        let mut remainder = line.trim_start();
+        for _ in 0..3 {
+            let delimiter = remainder.find(char::is_whitespace)?;
+            remainder = remainder[delimiter..].trim_start();
+        }
+        (!remainder.is_empty()).then_some(remainder)
+    }
+
+    /// Return the destination path from a `diff --git` header. Git quotes
+    /// paths containing whitespace, so splitting the header on whitespace
+    /// would truncate a valid conflicted path.
+    fn diff_header_destination_path(line: &str) -> Option<String> {
+        let input = line.strip_prefix("diff --git ")?;
+        let (_, remainder) = Self::git_path_token(input)?;
+        let (destination, _) = Self::git_path_token(remainder.trim_start())?;
+        Some(
+            destination
+                .strip_prefix("b/")
+                .unwrap_or(&destination)
+                .to_string(),
+        )
+    }
+
+    /// Parse one Git diff header path token, including Git's C-style quoting
+    /// for whitespace and special characters.
+    fn git_path_token(input: &str) -> Option<(String, &str)> {
+        if !input.starts_with('"') {
+            let end = input.find(char::is_whitespace).unwrap_or(input.len());
+            return (!input[..end].is_empty()).then(|| (input[..end].to_string(), &input[end..]));
+        }
+
+        let mut decoded = Vec::new();
+        let mut chars = input[1..].chars();
+        while let Some(character) = chars.next() {
+            match character {
+                '"' => return Some((String::from_utf8(decoded).ok()?, chars.as_str())),
+                '\\' => {
+                    let escaped = chars.next()?;
+                    match escaped {
+                        'n' => decoded.push(b'\n'),
+                        'r' => decoded.push(b'\r'),
+                        't' => decoded.push(b'\t'),
+                        '"' | '\\' => decoded.push(escaped as u8),
+                        '0'..='7' => {
+                            let second = chars.next()?;
+                            let third = chars.next()?;
+                            let octal = [escaped, second, third].iter().collect::<String>();
+                            let byte = u8::from_str_radix(&octal, 8).ok()?;
+                            decoded.push(byte);
+                        }
+                        other => {
+                            let mut buffer = [0; 4];
+                            decoded.extend_from_slice(other.encode_utf8(&mut buffer).as_bytes());
+                        }
+                    }
+                }
+                other => {
+                    let mut buffer = [0; 4];
+                    decoded.extend_from_slice(other.encode_utf8(&mut buffer).as_bytes());
+                }
+            }
+        }
+        None
+    }
+
+    /// Extract a path only from merge-tree diagnostic forms whose path
+    /// position is defined by Git.  In particular, do not split arbitrary
+    /// prose on ` in `: branch names and diagnostic prose can contain that
+    /// phrase and are not file paths.
+    fn conflict_diagnostic_path(description: &str) -> Option<&str> {
+        if let Some(path) = description.strip_prefix("Merge conflict in ") {
+            return (!path.is_empty()).then_some(path);
+        }
+
+        // e.g. "foo.rs deleted in HEAD and modified in topic".
+        if let Some((path, _)) = description.split_once(" deleted in ") {
+            return (!path.is_empty()).then_some(path);
+        }
+
+        // e.g. "foo.rs renamed to bar.rs in HEAD and renamed to baz.rs in topic".
+        // The path follows the fixed ` renamed to ` token and ends at the
+        // immediately following fixed ` in ` token.
+        let (_, renamed) = description.split_once(" renamed to ")?;
+        let (path, _) = renamed.split_once(" in ")?;
+        (!path.is_empty()).then_some(path)
+    }
+
+    /// Return unresolved paths from a merge worktree.  This is authoritative
+    /// after `git merge` fails because it reads Git's unmerged index directly.
+    fn unresolved_conflicts_in(dir: &Path) -> Vec<ConflictInfo> {
+        let output = Command::new("git")
+            .args(["diff", "--name-only", "--diff-filter=U", "-z"])
+            .current_dir(dir)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output();
+        let Ok(output) = output else {
+            return vec![];
+        };
+        if !output.status.success() {
+            return vec![];
+        }
+        output
+            .stdout
+            .split(|byte| *byte == b'\0')
+            .filter(|path| !path.is_empty())
+            .map(|path| {
+                let path = String::from_utf8_lossy(path).into_owned();
+                ConflictInfo {
+                    path: path.clone(),
+                    file_path: path,
+                    conflict_type: "content".to_string(),
+                    ours: None,
+                    theirs: None,
+                }
+            })
+            .collect()
+    }
+
     /// Run `git merge --no-ff` of `source` into the current HEAD of `dir`.
     fn merge_in_dir(
         &self,
@@ -254,9 +462,15 @@ impl GitVcsAdapter {
                 message: Some(if stdout.is_empty() { stderr } else { stdout }),
             })
         } else {
+            let conflicts = Self::unresolved_conflicts_in(dir);
+            let conflicts = if conflicts.is_empty() {
+                Self::parse_conflicts(&format!("{stdout}\n{stderr}"))
+            } else {
+                conflicts
+            };
             Ok(MergeResult {
                 success: false,
-                conflicts: vec![],
+                conflicts,
                 merged_commit: None,
                 commit: None,
                 message: Some(if stderr.is_empty() { stdout } else { stderr }),
@@ -517,67 +731,11 @@ impl VcsPort for GitVcsAdapter {
     ) -> Result<Vec<ConflictInfo>, DomainError> {
         // `git merge-tree <target> <source>` is the read-only,
         // in-memory 3-way merge that does not touch the index or
-        // working tree. In git 2.38+ it produces structured output
-        // (one line per conflicted file); in older versions it
-        // produces a unified diff. We handle both shapes: if any
-        // line starts with `changed in both` (the 2.38+ format), we
-        // parse the filename; otherwise we fall back to the diff
-        // format and look for `<<<<<<<` / `=======` markers.
+        // working tree. Its output shape differs across Git versions;
+        // `parse_conflicts` handles structured stage rows, diagnostics,
+        // and the historical diff-marker fallback.
         let raw = self.run_git_allow_failure(&["merge-tree", target, source])?;
-        if raw.is_empty() {
-            return Ok(vec![]);
-        }
-        let mut out = Vec::new();
-        for line in raw.lines() {
-            if let Some(rest) = line.strip_prefix("changed in both") {
-                // Format: "changed in both\n  base   100644 <oid> <path>\n  ours   100644 <oid>\n  theirs 100644 <oid>\n"
-                // The path appears on the next non-empty line.
-                let path = rest
-                    .split_whitespace()
-                    .next()
-                    .unwrap_or("<unknown>")
-                    .to_string();
-                if !path.is_empty() {
-                    out.push(ConflictInfo {
-                        path: path.clone(),
-                        file_path: path,
-                        conflict_type: "content".to_string(),
-                        ours: None,
-                        theirs: None,
-                    });
-                }
-            }
-        }
-        // Fallback: extract any path that has a conflict marker in
-        // the diff body.
-        if out.is_empty() {
-            let mut current_path: Option<String> = None;
-            for line in raw.lines() {
-                if line.starts_with("diff --git ") {
-                    // `diff --git a/<path> b/<path>`
-                    let parts: Vec<&str> = line.split_whitespace().collect();
-                    if let Some(b) = parts.get(3) {
-                        current_path = Some(b.trim_start_matches("b/").to_string());
-                    }
-                } else if line.starts_with("<<<<<<<")
-                    || line.starts_with("=======")
-                    || line.starts_with(">>>>>>>")
-                {
-                    if let Some(p) = current_path.clone() {
-                        out.push(ConflictInfo {
-                            path: p.clone(),
-                            file_path: p,
-                            conflict_type: "content".to_string(),
-                            ours: None,
-                            theirs: None,
-                        });
-                        // Avoid duplicate entries for the same file.
-                        current_path = None;
-                    }
-                }
-            }
-        }
-        Ok(out)
+        Ok(Self::parse_conflicts(&raw))
     }
 
     async fn read_artifact(
@@ -831,6 +989,62 @@ mod tests {
         assert!(!glob_match("feat/*/wp-1", "feat/login/wp-2"));
         assert!(glob_match("literal", "literal"));
         assert!(!glob_match("literal", "other"));
+    }
+
+    #[test]
+    fn parse_conflicts_reads_legacy_merge_tree_paths_with_spaces() {
+        let raw = "changed in both\n  base   100644 abcdef docs/legacy conflict.txt\n  our    100644 012345 docs/legacy conflict.txt\n  their  100644 6789ab docs/legacy conflict.txt\n";
+
+        let conflicts = GitVcsAdapter::parse_conflicts(raw);
+
+        assert_eq!(conflicts.len(), 1);
+        assert_eq!(conflicts[0].file_path, "docs/legacy conflict.txt");
+        assert_eq!(conflicts[0].conflict_type, "content");
+    }
+
+    #[test]
+    fn parse_conflicts_reads_quoted_diff_paths_with_spaces() {
+        let raw = format!(
+            "diff --git \"a/docs/space conflict.txt\" \"b/docs/space conflict.txt\"\n{} HEAD\nours\n{}\ntheirs\n{} topic\n",
+            "<".repeat(7),
+            "=".repeat(7),
+            ">".repeat(7),
+        );
+
+        let conflicts = GitVcsAdapter::parse_conflicts(&raw);
+
+        assert_eq!(conflicts.len(), 1);
+        assert_eq!(conflicts[0].file_path, "docs/space conflict.txt");
+    }
+
+    #[test]
+    fn parse_conflicts_decodes_quoted_diff_path_escapes() {
+        let raw = format!(
+            "diff --git \"a/docs/quote\\\"name.txt\" \"b/docs/quote\\\"name.txt\"\n{} HEAD\nours\n{}\ntheirs\n{} topic\n",
+            "<".repeat(7),
+            "=".repeat(7),
+            ">".repeat(7),
+        );
+
+        let conflicts = GitVcsAdapter::parse_conflicts(&raw);
+
+        assert_eq!(conflicts.len(), 1);
+        assert_eq!(conflicts[0].file_path, "docs/quote\"name.txt");
+    }
+
+    #[test]
+    fn parse_conflicts_decodes_utf8_octal_quoted_paths() {
+        let raw = format!(
+            "diff --git \"a/docs/caf\\303\\251.txt\" \"b/docs/caf\\303\\251.txt\"\n{} HEAD\nours\n{}\ntheirs\n{} topic\n",
+            "<".repeat(7),
+            "=".repeat(7),
+            ">".repeat(7),
+        );
+
+        let conflicts = GitVcsAdapter::parse_conflicts(&raw);
+
+        assert_eq!(conflicts.len(), 1);
+        assert_eq!(conflicts[0].file_path, "docs/café.txt");
     }
 
     #[tokio::test]

--- a/crates/agileplus-git/tests/integration.rs
+++ b/crates/agileplus-git/tests/integration.rs
@@ -339,15 +339,17 @@ async fn test_merge_with_conflict() {
         .await
         .unwrap();
 
-    // May be a conflict OR a successful fast-forward in some edge cases depending on git state.
-    // Either way, result should not panic. Conflicts should be detected.
-    // Since both branches divergently edited conflict.txt from same base, we expect conflicts.
-    if !result.success {
-        assert!(
-            !result.conflicts.is_empty(),
-            "conflicts should be non-empty on failure"
-        );
-    }
+    assert!(
+        !result.success,
+        "divergent edits must not merge successfully"
+    );
+    assert!(
+        result
+            .conflicts
+            .iter()
+            .any(|conflict| conflict.file_path == "conflict.txt"),
+        "merge conflict diagnostics must propagate the conflicted path: {result:?}"
+    );
     drop(dir);
 }
 

--- a/docs/superpowers/plans/2026-08-22-git-conflict-contract-recovery.md
+++ b/docs/superpowers/plans/2026-08-22-git-conflict-contract-recovery.md
@@ -1,0 +1,108 @@
+# Git Conflict Contract Recovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Recover exact Git merge-conflict paths from preserved PR #1022 without carrying unrelated configuration or lockfile churn.
+
+**Architecture:** `GitVcsAdapter` has a pure parser for version-dependent
+`git merge-tree` output. The live merge path uses unresolved index entries when
+they exist, then uses the parser as a fallback. The parser is unit-tested; a
+real divergent merge verifies the observable `MergeResult` contract.
+
+**Tech Stack:** Rust, Cargo, Git CLI, git2, tokio, GitHub Actions.
+
+---
+
+### Task 1: Define exact conflict-path behavior
+
+**Files:**
+- Modify: `crates/agileplus-git/src/lib.rs`
+- Test: `crates/agileplus-git/src/lib.rs`
+
+- [x] **Step 1: Write failing parser tests**
+
+```rust
+assert_eq!(conflicts[0].file_path, "docs/legacy conflict.txt");
+assert_eq!(conflicts[0].file_path, "docs/space conflict.txt");
+assert_eq!(conflicts[0].file_path, "docs/quote\"name.txt");
+assert_eq!(conflicts[0].file_path, "docs/café.txt");
+```
+
+- [x] **Step 2: Confirm the old adapter has no parser contract**
+
+Run: `cargo test -p agileplus-git --lib parse_conflicts`
+
+Expected: the new test cannot compile until `GitVcsAdapter::parse_conflicts` exists.
+
+- [x] **Step 3: Implement the minimum parser**
+
+```rust
+fn parse_conflicts(raw: &str) -> Vec<ConflictInfo> {
+    // Deduplicate exact paths from legacy rows, structured rows,
+    // diagnostics, and quoted diff headers.
+}
+```
+
+- [x] **Step 4: Verify the parser cases**
+
+Run: `cargo test -p agileplus-git --lib parse_conflicts`
+
+Expected: four passing tests.
+
+### Task 2: Verify the live failed-merge contract
+
+**Files:**
+- Modify: `crates/agileplus-git/src/lib.rs`
+- Modify: `crates/agileplus-git/tests/integration.rs`
+
+- [x] **Step 1: Strengthen the divergent merge assertion**
+
+```rust
+assert!(result.conflicts.iter().any(|conflict| {
+    conflict.file_path == "conflict.txt"
+}));
+```
+
+- [x] **Step 2: Prefer the unresolved Git index after merge failure**
+
+```rust
+let conflicts = Self::unresolved_conflicts_in(dir);
+let conflicts = if conflicts.is_empty() {
+    Self::parse_conflicts(&format!("{stdout}\n{stderr}"))
+} else {
+    conflicts
+};
+```
+
+- [x] **Step 3: Run the live flows**
+
+Run: `cargo test -p agileplus-git test_merge_with_conflict` and
+`cargo test -p agileplus-git test_detect_conflicts_divergent_branches`
+
+Expected: both pass and report exact conflicted paths.
+
+### Task 3: Promotion evidence and isolation
+
+**Files:**
+- Create: `kitty-specs/eco-048-git-conflict-contract-recovery/{spec.md,plan.md,tasks.md,meta.json}`
+- Modify: `kitty-specs/INDEX.md`
+
+- [x] **Step 1: Record scope and excluded deltas**
+
+The spec must name #1022 as preserved evidence and explicitly exclude the
+hook/configuration and lockfile changes.
+
+- [ ] **Step 2: Resolve external baseline gates in separate semantic PRs**
+
+Run: `cargo fmt --all -- --check`, `cargo test -p agileplus-git`, and
+`cargo clippy -p agileplus-git --all-targets --all-features -- -D warnings`.
+
+Expected: current failures are classified and repaired without broadening this
+parser PR.
+
+- [ ] **Step 3: Complete PR review and hosted gates**
+
+Run: `gh pr checks 1030 --repo KooshaPari/AgilePlus`.
+
+Expected: only after all required checks are green and review threads are
+resolved may the PR be made ready and merged.

--- a/kitty-specs/INDEX.md
+++ b/kitty-specs/INDEX.md
@@ -46,3 +46,4 @@
 | eco-045 | eco-045-gitleaks-baseline | active | 2026-06-25T00:00:00Z | - | - | [eco-045-gitleaks-baseline](eco-045-gitleaks-baseline/spec.md) |
 | eco-046 | eco-046-pr-governance-compliance | active | 2026-06-25T00:00:00Z | - | - | [eco-046-pr-governance-compliance](eco-046-pr-governance-compliance/spec.md) |
 | eco-047 | eco-047-toml-codeql-hygiene | active | 2026-06-25T00:00:00Z | - | - | [eco-047-toml-codeql-hygiene](eco-047-toml-codeql-hygiene/spec.md) |
+| eco-048 | eco-048-git-conflict-contract-recovery | active | 2026-08-22T00:00:00Z | - | - | [eco-048-git-conflict-contract-recovery](eco-048-git-conflict-contract-recovery/spec.md) |

--- a/kitty-specs/eco-048-git-conflict-contract-recovery/meta.json
+++ b/kitty-specs/eco-048-git-conflict-contract-recovery/meta.json
@@ -1,0 +1,8 @@
+{
+  "spec_id": "eco-048",
+  "slug": "eco-048-git-conflict-contract-recovery",
+  "title": "Git Conflict Contract Recovery",
+  "status": "active",
+  "created_at": "2026-08-22T00:00:00Z",
+  "type": "remediation"
+}

--- a/kitty-specs/eco-048-git-conflict-contract-recovery/plan.md
+++ b/kitty-specs/eco-048-git-conflict-contract-recovery/plan.md
@@ -1,0 +1,16 @@
+# Plan: Git Conflict Contract Recovery
+
+1. Preserve the original PR #1022 and classify its four file deltas.
+2. Recompose only the conflict-parser and exact-path test contract from current
+   `main` in an additive worktree.
+3. Prove the parser against the four output encodings and the real divergent
+   merge flow.
+4. Record unrelated baseline failures as distinct repair lanes.
+5. Publish a draft PR, complete semantic review, then require hosted CI and
+   governance gates before promotion.
+
+## Scope Decision
+
+The hook/configuration and lockfile deltas were intentionally excluded because
+they do not establish a causal dependency on conflict reporting. The original
+branch remains reachable evidence for later review.

--- a/kitty-specs/eco-048-git-conflict-contract-recovery/spec.md
+++ b/kitty-specs/eco-048-git-conflict-contract-recovery/spec.md
@@ -1,0 +1,46 @@
+# eco-048: Git Conflict Contract Recovery
+
+## Intent
+
+Recover the source-bearing merge-conflict diagnostics from preserved PR #1022
+onto current `main` without rebasing, rewriting, or closing the preserved
+source branch.
+
+## Problem
+
+`GitVcsAdapter` previously returned no exact conflict paths after a failed
+merge and could parse only one fragile `git merge-tree` output form. Git
+output differs by version and may contain stage rows, diagnostics, or quoted
+diff paths. Operators need exact paths to resolve conflicts safely.
+
+## Functional Requirements
+
+- Parse legacy `changed in both` output, including paths containing spaces.
+- Parse structured stage rows and `CONFLICT (...)` diagnostics.
+- Parse quoted diff destination paths, including escaped quotes and octal
+  UTF-8 escapes.
+- After an actual failed merge, prefer the authoritative unresolved index paths
+  reported by `git diff --name-only --diff-filter=U -z`.
+- Preserve the original #1022 ref as evidence; do not mutate it.
+
+## Non-Goals
+
+- No `.pre-commit-config.yaml` change.
+- No `Cargo.lock` change.
+- No unrelated artifact, branch-listing, or formatting rewrite.
+- No claim that a baseline CI failure is caused by this recovery.
+
+## Acceptance Criteria
+
+- Parser tests cover legacy-space, quoted-space, quote-escaped, and UTF-8
+  octal paths.
+- The real divergent-merge test requires the exact `conflict.txt` path.
+- Focused crate tests and clippy are recorded with their outcomes.
+- The recovery PR is independently reviewed, required hosted checks are green,
+  and all review threads are resolved before merge.
+
+## Governance
+
+`#1022` at `3ca2caab` is immutable recovery evidence. The additive recovery
+branch is the only promotion candidate. Baseline formatter, test-isolation,
+and cross-crate clippy defects must be repaired in separate semantic PRs.

--- a/kitty-specs/eco-048-git-conflict-contract-recovery/tasks.md
+++ b/kitty-specs/eco-048-git-conflict-contract-recovery/tasks.md
@@ -1,0 +1,16 @@
+# Tasks: eco-048-git-conflict-contract-recovery
+
+| ID | Work package | State | Evidence |
+|---|---|---|---|
+| WP01 | Preserve and classify #1022 | complete | Preserved ref `3ca2caab`; recovery ledger records each delta. |
+| WP02 | Recompose parser contract | complete | Additive commit `cef5ee3b`; only `agileplus-git` source and merge test changed. |
+| WP03 | Focused test and lint evidence | in_progress | Four parser tests and two merge flows pass; full baseline gates remain separately red. |
+| WP04 | Governance, review, and hosted CI | blocked | Draft PR #1030 needs spec/governance metadata, review, and green broad gates. |
+
+## Gate Ledger
+
+- Focused parser tests: pass.
+- Focused divergent merge tests: pass.
+- Full formatter: blocked by preserved formatter-only lane #1028.
+- Full crate test: blocked by leaked global temporary worktree path.
+- Clippy: blocked by existing warnings outside `agileplus-git`.

--- a/kitty-specs/eco-048-git-conflict-contract-recovery/tasks.md
+++ b/kitty-specs/eco-048-git-conflict-contract-recovery/tasks.md
@@ -14,3 +14,8 @@
 - Full formatter: blocked by preserved formatter-only lane #1028.
 - Full crate test: blocked by leaked global temporary worktree path.
 - Clippy: blocked by existing warnings outside `agileplus-git`.
+- Hosted core `ci / test`, `ci / lint`, coverage, and Snyk passed on PR #1030;
+  broader quality gates remain separate baseline blockers and are not waived.
+- The PR body declares `spec: eco-048-git-conflict-contract-recovery` and all
+  required governance sections; the next synchronize event is the first one
+  whose `spec-first` payload contains that updated metadata.


### PR DESCRIPTION
## Summary

spec: eco-048-git-conflict-contract-recovery

Recover exact Git merge-conflict paths from preserved PR #1022 on an additive branch. The parser handles legacy, structured, diagnostic, and quoted `git merge-tree` output; failed live merges prefer unresolved index paths.

## Stack Topology

`main@40d53e8c` -> additive recovery branch -> `agileplus-git` adapter and integration tests. Preserved source evidence remains `#1022@3ca2caab`; it is neither rebased nor altered.

## Validation

- Four parser edge-case tests pass: legacy-space, quoted-space, quote-escaped, and octal UTF-8 paths.
- `test_merge_with_conflict` and `test_detect_conflicts_divergent_branches` pass.
- Dedicated intent, plan, task ledger, and implementation plan are in `kitty-specs/eco-048-git-conflict-contract-recovery/` and `docs/superpowers/plans/`.

## Governance

Included scope is the Git conflict-path contract only. `.pre-commit-config.yaml`, `Cargo.lock`, and unrelated test/format changes from #1022 are excluded. The PR remains draft until semantic review, all review threads, and required hosted quality gates are complete.

## CI Exception

None. Current formatter, test-isolation, clippy, security/lock, and broader QE failures are recorded as baseline repair lanes, not waived or attributed to this recovery diff.