### PR TITLE
fix(git): report exact merge conflict paths

### DIFF
--- a/crates/agileplus-git/src/lib.rs
+++ b/crates/agileplus-git/src/lib.rs
@@ -25,6 +25,7 @@
 //! Audit traceability: recs #10, #11 from
 //! `AUDIT_BLOC_VS_2026_SOTA.md`.
 
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
@@ -206,6 +207,213 @@ impl GitVcsAdapter {
             || (msg.contains("checkout") && msg.contains("worktree"))
     }
 
+    /// Extract conflicts from the human-readable output emitted by Git's
+    /// merge machinery.  `merge-tree` differs across Git versions: Apple
+    /// Git 2.54 writes unmerged index rows (`mode oid stage<TAB>path`) plus
+    /// `CONFLICT (...)` diagnostics, while older versions can emit a patch.
+    fn parse_conflicts(raw: &str) -> Vec<ConflictInfo> {
+        let mut paths = BTreeMap::<String, String>::new();
+        let mut current_diff_path: Option<String> = None;
+        let mut legacy_conflict_heading = false;
+
+        for line in raw.lines() {
+            if line.trim_end() == "changed in both" {
+                legacy_conflict_heading = true;
+                continue;
+            }
+
+            if legacy_conflict_heading {
+                if let Some(path) = Self::legacy_merge_tree_path(line) {
+                    paths
+                        .entry(path.to_string())
+                        .or_insert_with(|| "content".to_string());
+                    legacy_conflict_heading = false;
+                    continue;
+                }
+                if !line.starts_with(char::is_whitespace) {
+                    legacy_conflict_heading = false;
+                }
+            }
+
+            if let Some((metadata, path)) = line.split_once('\t') {
+                let fields: Vec<_> = metadata.split_whitespace().collect();
+                if fields.len() == 3
+                    && fields[0].chars().all(|c| c.is_ascii_digit())
+                    && fields[2].chars().all(|c| c.is_ascii_digit())
+                    && !path.is_empty()
+                {
+                    paths
+                        .entry(path.to_string())
+                        .or_insert_with(|| "content".to_string());
+                    continue;
+                }
+            }
+
+            if let Some(rest) = line.strip_prefix("CONFLICT (") {
+                if let Some((kind, description)) = rest.split_once("): ") {
+                    if let Some(path) = Self::conflict_diagnostic_path(description) {
+                        paths.insert(path.to_string(), kind.to_string());
+                    }
+                }
+                continue;
+            }
+
+            if let Some(path) = line.strip_prefix("changed in both ") {
+                if !path.is_empty() {
+                    paths
+                        .entry(path.to_string())
+                        .or_insert_with(|| "content".to_string());
+                }
+                continue;
+            }
+
+            if line.starts_with("diff --git ") {
+                current_diff_path = Self::diff_header_destination_path(line);
+            } else if (line.starts_with("<<<<<<<")
+                || line.starts_with("=======")
+                || line.starts_with(">>>>>>>"))
+                && current_diff_path.is_some()
+            {
+                let path = current_diff_path.take().expect("checked above");
+                paths.entry(path).or_insert_with(|| "content".to_string());
+            }
+        }
+
+        paths
+            .into_iter()
+            .map(|(path, conflict_type)| ConflictInfo {
+                path: path.clone(),
+                file_path: path,
+                conflict_type,
+                ours: None,
+                theirs: None,
+            })
+            .collect()
+    }
+
+    /// Extract the path from the `base <mode> <oid> <path>` row following a
+    /// legacy `changed in both` merge-tree heading without losing spaces in
+    /// the path itself.
+    fn legacy_merge_tree_path(line: &str) -> Option<&str> {
+        let mut remainder = line.trim_start();
+        for _ in 0..3 {
+            let delimiter = remainder.find(char::is_whitespace)?;
+            remainder = remainder[delimiter..].trim_start();
+        }
+        (!remainder.is_empty()).then_some(remainder)
+    }
+
+    /// Return the destination path from a `diff --git` header. Git quotes
+    /// paths containing whitespace, so splitting the header on whitespace
+    /// would truncate a valid conflicted path.
+    fn diff_header_destination_path(line: &str) -> Option<String> {
+        let input = line.strip_prefix("diff --git ")?;
+        let (_, remainder) = Self::git_path_token(input)?;
+        let (destination, _) = Self::git_path_token(remainder.trim_start())?;
+        Some(
+            destination
+                .strip_prefix("b/")
+                .unwrap_or(&destination)
+                .to_string(),
+        )
+    }
+
+    /// Parse one Git diff header path token, including Git's C-style quoting
+    /// for whitespace and special characters.
+    fn git_path_token(input: &str) -> Option<(String, &str)> {
+        if !input.starts_with('"') {
+            let end = input.find(char::is_whitespace).unwrap_or(input.len());
+            return (!input[..end].is_empty()).then(|| (input[..end].to_string(), &input[end..]));
+        }
+
+        let mut decoded = Vec::new();
+        let mut chars = input[1..].chars();
+        while let Some(character) = chars.next() {
+            match character {
+                '"' => return Some((String::from_utf8(decoded).ok()?, chars.as_str())),
+                '\\' => {
+                    let escaped = chars.next()?;
+                    match escaped {
+                        'n' => decoded.push(b'\n'),
+                        'r' => decoded.push(b'\r'),
+                        't' => decoded.push(b'\t'),
+                        '"' | '\\' => decoded.push(escaped as u8),
+                        '0'..='7' => {
+                            let second = chars.next()?;
+                            let third = chars.next()?;
+                            let octal = [escaped, second, third].iter().collect::<String>();
+                            let byte = u8::from_str_radix(&octal, 8).ok()?;
+                            decoded.push(byte);
+                        }
+                        other => {
+                            let mut buffer = [0; 4];
+                            decoded.extend_from_slice(other.encode_utf8(&mut buffer).as_bytes());
+                        }
+                    }
+                }
+                other => {
+                    let mut buffer = [0; 4];
+                    decoded.extend_from_slice(other.encode_utf8(&mut buffer).as_bytes());
+                }
+            }
+        }
+        None
+    }
+
+    /// Extract a path only from merge-tree diagnostic forms whose path
+    /// position is defined by Git.  In particular, do not split arbitrary
+    /// prose on ` in `: branch names and diagnostic prose can contain that
+    /// phrase and are not file paths.
+    fn conflict_diagnostic_path(description: &str) -> Option<&str> {
+        if let Some(path) = description.strip_prefix("Merge conflict in ") {
+            return (!path.is_empty()).then_some(path);
+        }
+
+        // e.g. "foo.rs deleted in HEAD and modified in topic".
+        if let Some((path, _)) = description.split_once(" deleted in ") {
+            return (!path.is_empty()).then_some(path);
+        }
+
+        // e.g. "foo.rs renamed to bar.rs in HEAD and renamed to baz.rs in topic".
+        // The path follows the fixed ` renamed to ` token and ends at the
+        // immediately following fixed ` in ` token.
+        let (_, renamed) = description.split_once(" renamed to ")?;
+        let (path, _) = renamed.split_once(" in ")?;
+        (!path.is_empty()).then_some(path)
+    }
+
+    /// Return unresolved paths from a merge worktree.  This is authoritative
+    /// after `git merge` fails because it reads Git's unmerged index directly.
+    fn unresolved_conflicts_in(dir: &Path) -> Vec<ConflictInfo> {
+        let output = Command::new("git")
+            .args(["diff", "--name-only", "--diff-filter=U", "-z"])
+            .current_dir(dir)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output();
+        let Ok(output) = output else {
+            return vec![];
+        };
+        if !output.status.success() {
+            return vec![];
+        }
+        output
+            .stdout
+            .split(|byte| *byte == b'\0')
+            .filter(|path| !path.is_empty())
+            .map(|path| {
+                let path = String::from_utf8_lossy(path).into_owned();
+                ConflictInfo {
+                    path: path.clone(),
+                    file_path: path,
+                    conflict_type: "content".to_string(),
+                    ours: None,
+                    theirs: None,
+                }
+            })
+            .collect()
+    }
+
     /// Run `git merge --no-ff` of `source` into the current HEAD of `dir`.
     fn merge_in_dir(
         &self,
@@ -254,9 +462,15 @@ impl GitVcsAdapter {
                 message: Some(if stdout.is_empty() { stderr } else { stdout }),
             })
         } else {
+            let conflicts = Self::unresolved_conflicts_in(dir);
+            let conflicts = if conflicts.is_empty() {
+                Self::parse_conflicts(&format!("{stdout}\n{stderr}"))
+            } else {
+                conflicts
+            };
             Ok(MergeResult {
                 success: false,
-                conflicts: vec![],
+                conflicts,
                 merged_commit: None,
                 commit: None,
                 message: Some(if stderr.is_empty() { stdout } else { stderr }),
@@ -517,67 +731,11 @@ impl VcsPort for GitVcsAdapter {
     ) -> Result<Vec<ConflictInfo>, DomainError> {
         // `git merge-tree <target> <source>` is the read-only,
         // in-memory 3-way merge that does not touch the index or
-        // working tree. In git 2.38+ it produces structured output
-        // (one line per conflicted file); in older versions it
-        // produces a unified diff. We handle both shapes: if any
-        // line starts with `changed in both` (the 2.38+ format), we
-        // parse the filename; otherwise we fall back to the diff
-        // format and look for `<<<<<<<` / `=======` markers.
+        // working tree. Its output shape differs across Git versions;
+        // `parse_conflicts` handles structured stage rows, diagnostics,
+        // and the historical diff-marker fallback.
         let raw = self.run_git_allow_failure(&["merge-tree", target, source])?;
-        if raw.is_empty() {
-            return Ok(vec![]);
-        }
-        let mut out = Vec::new();
-        for line in raw.lines() {
-            if let Some(rest) = line.strip_prefix("changed in both") {
-                // Format: "changed in both\n  base   100644 <oid> <path>\n  ours   100644 <oid>\n  theirs 100644 <oid>\n"
-                // The path appears on the next non-empty line.
-                let path = rest
-                    .split_whitespace()
-                    .next()
-                    .unwrap_or("<unknown>")
-                    .to_string();
-                if !path.is_empty() {
-                    out.push(ConflictInfo {
-                        path: path.clone(),
-                        file_path: path,
-                        conflict_type: "content".to_string(),
-                        ours: None,
-                        theirs: None,
-                    });
-                }
-            }
-        }
-        // Fallback: extract any path that has a conflict marker in
-        // the diff body.
-        if out.is_empty() {
-            let mut current_path: Option<String> = None;
-            for line in raw.lines() {
-                if line.starts_with("diff --git ") {
-                    // `diff --git a/<path> b/<path>`
-                    let parts: Vec<&str> = line.split_whitespace().collect();
-                    if let Some(b) = parts.get(3) {
-                        current_path = Some(b.trim_start_matches("b/").to_string());
-                    }
-                } else if line.starts_with("<<<<<<<")
-                    || line.starts_with("=======")
-                    || line.starts_with(">>>>>>>")
-                {
-                    if let Some(p) = current_path.clone() {
-                        out.push(ConflictInfo {
-                            path: p.clone(),
-                            file_path: p,
-                            conflict_type: "content".to_string(),
-                            ours: None,
-                            theirs: None,
-                        });
-                        // Avoid duplicate entries for the same file.
-                        current_path = None;
-                    }
-                }
-            }
-        }
-        Ok(out)
+        Ok(Self::parse_conflicts(&raw))
     }
 
     async fn read_artifact(
@@ -831,6 +989,62 @@ mod tests {
         assert!(!glob_match("feat/*/wp-1", "feat/login/wp-2"));
         assert!(glob_match("literal", "literal"));
         assert!(!glob_match("literal", "other"));
+    }
+
+    #[test]
+    fn parse_conflicts_reads_legacy_merge_tree_paths_with_spaces() {
+        let raw = "changed in both\n  base   100644 abcdef docs/legacy conflict.txt\n  our    100644 012345 docs/legacy conflict.txt\n  their  100644 6789ab docs/legacy conflict.txt\n";
+
+        let conflicts = GitVcsAdapter::parse_conflicts(raw);
+
+        assert_eq!(conflicts.len(), 1);
+        assert_eq!(conflicts[0].file_path, "docs/legacy conflict.txt");
+        assert_eq!(conflicts[0].conflict_type, "content");
+    }
+
+    #[test]
+    fn parse_conflicts_reads_quoted_diff_paths_with_spaces() {
+        let raw = format!(
+            "diff --git \"a/docs/space conflict.txt\" \"b/docs/space conflict.txt\"\n{} HEAD\nours\n{}\ntheirs\n{} topic\n",
+            "<".repeat(7),
+            "=".repeat(7),
+            ">".repeat(7),
+        );
+
+        let conflicts = GitVcsAdapter::parse_conflicts(&raw);
+
+        assert_eq!(conflicts.len(), 1);
+        assert_eq!(conflicts[0].file_path, "docs/space conflict.txt");
+    }
+
+    #[test]
+    fn parse_conflicts_decodes_quoted_diff_path_escapes() {
+        let raw = format!(
+            "diff --git \"a/docs/quote\\\"name.txt\" \"b/docs/quote\\\"name.txt\"\n{} HEAD\nours\n{}\ntheirs\n{} topic\n",
+            "<".repeat(7),
+            "=".repeat(7),
+            ">".repeat(7),
+        );
+
+        let conflicts = GitVcsAdapter::parse_conflicts(&raw);
+
+        assert_eq!(conflicts.len(), 1);
+        assert_eq!(conflicts[0].file_path, "docs/quote\"name.txt");
+    }
+
+    #[test]
+    fn parse_conflicts_decodes_utf8_octal_quoted_paths() {
+        let raw = format!(
+            "diff --git \"a/docs/caf\\303\\251.txt\" \"b/docs/caf\\303\\251.txt\"\n{} HEAD\nours\n{}\ntheirs\n{} topic\n",
+            "<".repeat(7),
+            "=".repeat(7),
+            ">".repeat(7),
+        );
+
+        let conflicts = GitVcsAdapter::parse_conflicts(&raw);
+
+        assert_eq!(conflicts.len(), 1);
+        assert_eq!(conflicts[0].file_path, "docs/café.txt");
     }
 
     #[tokio::test]

--- a/crates/agileplus-git/tests/integration.rs
+++ b/crates/agileplus-git/tests/integration.rs
@@ -339,15 +339,17 @@ async fn test_merge_with_conflict() {
         .await
         .unwrap();
 
-    // May be a conflict OR a successful fast-forward in some edge cases depending on git state.
-    // Either way, result should not panic. Conflicts should be detected.
-    // Since both branches divergently edited conflict.txt from same base, we expect conflicts.
-    if !result.success {
-        assert!(
-            !result.conflicts.is_empty(),
-            "conflicts should be non-empty on failure"
-        );
-    }
+    assert!(
+        !result.success,
+        "divergent edits must not merge successfully"
+    );
+    assert!(
+        result
+            .conflicts
+            .iter()
+            .any(|conflict| conflict.file_path == "conflict.txt"),
+        "merge conflict diagnostics must propagate the conflicted path: {result:?}"
+    );
     drop(dir);
 }
 


### PR DESCRIPTION
## Summary

Recompose the existing Git conflict-path contract from preserved PR #1030 / PR #1022 onto current `main`. The adapter reports exact conflicted paths across Git output formats and after real failed merges.

## Stack Topology

- Layer: `agileplus-git` adapter and integration contract.
- Base: current `main` `40d53e8c3d9421df7b5e637b0d077d0e4e487f7c`.
- Provenance: existing source commit `cef5ee3b9e1cd67254c9d842e56ee63698f2d0b2` from PR #1030.
- Original PR #1030 remains unchanged and preserved as evidence.

## Validation

- `cargo fmt --package agileplus-git -- --check`: pass.
- `git diff --check`: pass.
- `cargo test --offline -p agileplus-git --lib parse_conflicts`: 4 passed.
- `cargo test --offline -p agileplus-git`: 18 passed, 2 pre-existing worktree-concurrency failures (`index.lock` / worktree path).
- `cargo check --offline -p agileplus-git`: pass.
- `cargo clippy --offline -p agileplus-git --all-targets --all-features -- -D warnings`: blocked by 3 pre-existing `agileplus-triage` warnings outside this PR.
- `--locked` Cargo commands are blocked by current `main`'s stale lock edge; resolution adds only `uuid` under `agileplus-api`, despite no manifest change in this PR. The generated lock was not retained; `Cargo.lock` is byte-identical to `main` (SHA-256 `51c1ed5714a2bce2ef6525069ef7a4986c2e811f49cf38dc6411bd0282f7bfe1`).

## Governance

- Source-only: exactly two files changed: `crates/agileplus-git/src/lib.rs` and `crates/agileplus-git/tests/integration.rs`.
- No docs/spec/index, `.pre-commit-config.yaml`, `Cargo.lock`, or unrelated recovery churn.
- PR #1022 and PR #1030 remain immutable evidence; no force-push or rewrite performed.
- Focused source review is required before merge.

## CI Exception

- Full-repository CI remains blocked by existing baseline failures (lockfile/dependency policy, pre-commit hook schema, security/SAST configuration, and hosted environment checks).
- This PR intentionally does not absorb those unrelated repairs.
- The repository `spec-first` gate currently requires `eco-048` files intentionally excluded from this source-only PR; this is recorded as a baseline governance dependency, not silently waived.
