### PR TITLE
fix(lock): record agileplus-api uuid dependency edge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,6 +218,7 @@ dependencies = [
  "sha2",
  "thiserror 2.0.20",
  "tokio",
+ "uuid",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Record the dependency edge that Cargo 1.99-nightly reproducibly requires for the current `main` workspace lockfile: `agileplus-api -> uuid`.

## Stack Topology
- Baseline-only lock consistency lane.
- Base: `main` at `40d53e8c3d9421df7b5e637b0d077d0e4e487f7c`.
- Independent of PR #1034 and preserved PR #1030.

## Validation
- `cargo metadata --locked --no-deps --format-version 1`: pass.
- `cargo check --locked -p agileplus-git`: pass.
- `cargo check --locked --workspace`: pass (1m09s).
- `git diff --check`: pass.
- Generated by Cargo offline resolution; exact diff is one lock edge under `agileplus-api`:
  `+ "uuid",`

## Governance
- Exactly one file changed: `Cargo.lock`.
- No source, docs, specs, index, pre-commit, or recovery changes.
- PR #1030 and PR #1034 remain unchanged.

## CI Exception
- This is a baseline repair only. It does not claim the repository is fully green; unrelated security, dependency-policy, pre-commit, and hosted governance failures remain tracked separately.
