### PR TITLE
fix: restore AgilePlus Rust core runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,6 +342,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "agileplus-grpc"
+version = "0.2.1"
+dependencies = [
+ "agileplus-domain",
+ "agileplus-git",
+ "agileplus-proto",
+ "agileplus-sqlite",
+ "chrono",
+ "futures",
+ "prost 0.14.4",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "agileplus-plane"
 version = "0.2.1"
 dependencies = [
@@ -368,9 +388,10 @@ dependencies = [
 name = "agileplus-proto"
 version = "0.2.1"
 dependencies = [
- "prost",
+ "prost 0.14.4",
+ "prost-build 0.13.5",
+ "tokio-stream",
  "tonic",
- "tonic-build",
  "tonic-prost",
  "tonic-prost-build",
 ]
@@ -4538,7 +4559,7 @@ dependencies = [
  "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry_sdk",
- "prost",
+ "prost 0.14.4",
  "reqwest 0.13.4",
  "thiserror 2.0.20",
  "tokio",
@@ -4554,7 +4575,7 @@ checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
- "prost",
+ "prost 0.14.4",
  "tonic",
  "tonic-prost",
 ]
@@ -4719,6 +4740,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e04d3a0849e241d7dfce834c83b1c5edc8622009e8dd51a12ba1927c32f05496"
 dependencies = [
  "pest",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
 ]
 
 [[package]]
@@ -5013,12 +5044,42 @@ dependencies = [
 
 [[package]]
 name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive 0.13.5",
+]
+
+[[package]]
+name = "prost"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.14.4",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+dependencies = [
+ "heck",
+ "itertools 0.14.0",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph 0.7.1",
+ "prettyplease",
+ "prost 0.13.5",
+ "prost-types 0.13.5",
+ "regex",
+ "syn 2.0.119",
+ "tempfile",
 ]
 
 [[package]]
@@ -5031,15 +5092,28 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "multimap",
- "petgraph",
+ "petgraph 0.8.3",
  "prettyplease",
- "prost",
- "prost-types",
+ "prost 0.14.4",
+ "prost-types 0.14.4",
  "pulldown-cmark",
  "pulldown-cmark-to-cmark",
  "regex",
  "syn 2.0.119",
  "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5057,11 +5131,20 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+dependencies = [
+ "prost 0.13.5",
+]
+
+[[package]]
+name = "prost-types"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
 dependencies = [
- "prost",
+ "prost 0.14.4",
 ]
 
 [[package]]
@@ -6551,7 +6634,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
  "bytes",
- "prost",
+ "prost 0.14.4",
  "tonic",
 ]
 
@@ -6563,8 +6646,8 @@ checksum = "654e5643eff75d7f8c99197ce1440ed19a3474eada74c12bbac488b2cafdae27"
 dependencies = [
  "prettyplease",
  "proc-macro2",
- "prost-build",
- "prost-types",
+ "prost-build 0.14.4",
+ "prost-types 0.14.4",
  "quote",
  "syn 2.0.119",
  "tempfile",
@@ -6577,8 +6660,8 @@ version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ab1b02061f83d519bba3caa167f88f261ef05720ab8ebc954ade70de3348e8"
 dependencies = [
- "prost",
- "prost-types",
+ "prost 0.14.4",
+ "prost-types 0.14.4",
  "tonic",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,8 @@ resolver = "2"
 # workspace until source is implemented. See: kitty-specs/003-agileplus-platform-completion.
 members = [
   "tests/e2e", # installed-CLI round-trip; workflow runs this crate from its manifest directory
-  "rust", # agileplus-proto: tonic/prost gRPC stubs (buf-generated)
+  "crates/agileplus-proto", # canonical tonic/prost gRPC contract
+  "crates/agileplus-grpc", # loopback Rust core consumed by the MCP bridge
   "crates/agileplus-cli", # agileplus: spec-first CLI binary
   "crates/agileplus-subcmds", # platform/dashboard CLI subcommands (platform health)
   "crates/agileplus-api", # HTTP API binary (default port 3000)

--- a/crates/agileplus-api/src/api_key.rs
+++ b/crates/agileplus-api/src/api_key.rs
@@ -56,10 +56,10 @@ pub async fn ensure_api_key(
 ) -> Result<bool, Box<dyn std::error::Error + Send + Sync>> {
     // Check if a key already exists.
     let existing = creds.get("agileplus", keys::API_KEYS);
-    if let Ok(val) = existing {
-        if !val.trim().is_empty() {
-            return Ok(false);
-        }
+    if let Ok(val) = existing
+        && !val.trim().is_empty()
+    {
+        return Ok(false);
     }
 
     // Generate new key.

--- a/crates/agileplus-api/src/middleware/auth.rs
+++ b/crates/agileplus-api/src/middleware/auth.rs
@@ -26,15 +26,14 @@ const PUBLIC_PATHS: &[&str] = &["/health", "/info", "/webhooks"];
 
 /// Extract a candidate token from `Authorization: Bearer`, `X-API-Key`, or `?api_key=`.
 fn extract_token(headers: &HeaderMap, request: &Request) -> Result<String, ApiError> {
-    if let Some(auth) = headers.get("Authorization").and_then(|v| v.to_str().ok()) {
-        if let Some(token) = auth
+    if let Some(auth) = headers.get("Authorization").and_then(|v| v.to_str().ok())
+        && let Some(token) = auth
             .strip_prefix("Bearer ")
             .or_else(|| auth.strip_prefix("bearer "))
-        {
-            let token = token.trim();
-            if !token.is_empty() {
-                return Ok(token.to_string());
-            }
+    {
+        let token = token.trim();
+        if !token.is_empty() {
+            return Ok(token.to_string());
         }
     }
 
@@ -42,13 +41,13 @@ fn extract_token(headers: &HeaderMap, request: &Request) -> Result<String, ApiEr
         return Ok(header_val.to_string());
     }
 
-    if let Some(query) = request.uri().query() {
-        if let Some(v) = query.split('&').find_map(|pair| {
+    if let Some(query) = request.uri().query()
+        && let Some(v) = query.split('&').find_map(|pair| {
             let (k, v) = pair.split_once('=')?;
             (k == "api_key").then(|| v.to_string())
-        }) {
-            return Ok(v);
-        }
+        })
+    {
+        return Ok(v);
     }
 
     Err(ApiError::Unauthorized(

--- a/crates/agileplus-api/src/routes/events.rs
+++ b/crates/agileplus-api/src/routes/events.rs
@@ -151,39 +151,37 @@ where
     let filtered: Vec<EventResponse> = events
         .into_iter()
         .filter(|e| {
-            if let Some(et) = &params.entity_type {
-                if &e.entity_type != et {
-                    return false;
-                }
+            if let Some(et) = &params.entity_type
+                && &e.entity_type != et
+            {
+                return false;
             }
-            if let Some(eid) = params.entity_id {
-                if e.entity_id != eid {
-                    return false;
-                }
+            if let Some(eid) = params.entity_id
+                && e.entity_id != eid
+            {
+                return false;
             }
-            if let Some(ev_type) = &params.event_type {
-                if &e.event_type != ev_type {
-                    return false;
-                }
+            if let Some(ev_type) = &params.event_type
+                && &e.event_type != ev_type
+            {
+                return false;
             }
-            if let Some(actor) = &params.actor {
-                if &e.actor != actor {
-                    return false;
-                }
+            if let Some(actor) = &params.actor
+                && &e.actor != actor
+            {
+                return false;
             }
-            if let Some(since) = since_dt {
-                if let Ok(ts) = e.timestamp.parse::<DateTime<Utc>>() {
-                    if ts < since {
-                        return false;
-                    }
-                }
+            if let Some(since) = since_dt
+                && let Ok(ts) = e.timestamp.parse::<DateTime<Utc>>()
+                && ts < since
+            {
+                return false;
             }
-            if let Some(until) = until_dt {
-                if let Ok(ts) = e.timestamp.parse::<DateTime<Utc>>() {
-                    if ts > until {
-                        return false;
-                    }
-                }
+            if let Some(until) = until_dt
+                && let Ok(ts) = e.timestamp.parse::<DateTime<Utc>>()
+                && ts > until
+            {
+                return false;
             }
             true
         })

--- a/crates/agileplus-api/tests/api_integration.rs
+++ b/crates/agileplus-api/tests/api_integration.rs
@@ -14,7 +14,6 @@
 mod support;
 
 use axum::http::StatusCode;
-use serde_json;
 
 use support::{TEST_API_KEY, setup_test_server};
 // ── Tests ─────────────────────────────────────────────────────────────────────

--- a/crates/agileplus-api/tests/api_integration/support/storage_port_impl/audit.rs
+++ b/crates/agileplus-api/tests/api_integration/support/storage_port_impl/audit.rs
@@ -38,8 +38,7 @@ pub(crate) fn get_latest_audit_entry(
         .lock()
         .expect("audit lock poisoned")
         .iter()
-        .filter(|e| e.feature_id == feature_id)
-        .last()
+        .rfind(|e| e.feature_id == feature_id)
         .cloned();
     async move { Ok(entry) }
 }

--- a/crates/agileplus-api/tests/api_integration/support/storage_port_impl/backlog.rs
+++ b/crates/agileplus-api/tests/api_integration/support/storage_port_impl/backlog.rs
@@ -64,7 +64,7 @@ pub(crate) fn list_backlog_items(
     }
 
     match filters.sort {
-        BacklogSort::Age => items.sort_by(|a, b| a.created_at.cmp(&b.created_at)),
+        BacklogSort::Age => items.sort_by_key(|a| a.created_at),
         BacklogSort::Priority | BacklogSort::Impact => items.sort_by(|a, b| {
             (priority_rank(a.priority), a.created_at)
                 .cmp(&(priority_rank(b.priority), b.created_at))
@@ -135,13 +135,12 @@ pub(crate) fn pop_next_backlog_item(
         })
         .cloned();
 
-    if let Some(item) = next.clone() {
-        if let Some(id) = item.id {
-            if let Some(existing) = backlog.iter_mut().find(|entry| entry.id == Some(id)) {
-                existing.status = BacklogStatus::Triaged;
-                existing.updated_at = chrono::Utc::now();
-            }
-        }
+    if let Some(item) = next.clone()
+        && let Some(id) = item.id
+        && let Some(existing) = backlog.iter_mut().find(|entry| entry.id == Some(id))
+    {
+        existing.status = BacklogStatus::Triaged;
+        existing.updated_at = chrono::Utc::now();
     }
 
     async move { Ok(next) }

--- a/crates/agileplus-api/tests/api_integration/support/storage_port_impl/evidence.rs
+++ b/crates/agileplus-api/tests/api_integration/support/storage_port_impl/evidence.rs
@@ -1,27 +1,25 @@
-use std::future::Future;
-
 use agileplus_domain::domain::governance::Evidence;
 use agileplus_domain::error::DomainError;
 
 use super::MockStorage;
 
-pub(crate) fn create_evidence(
+pub(crate) async fn create_evidence(
     _storage: &MockStorage,
     _evidence: &Evidence,
-) -> impl Future<Output = Result<i64, DomainError>> + Send {
-    async move { Ok(1) }
+) -> Result<i64, DomainError> {
+    Ok(1)
 }
 
-pub(crate) fn get_evidence_by_wp(
+pub(crate) async fn get_evidence_by_wp(
     _storage: &MockStorage,
     _wp_id: i64,
-) -> impl Future<Output = Result<Vec<Evidence>, DomainError>> + Send {
-    async move { Ok(vec![]) }
+) -> Result<Vec<Evidence>, DomainError> {
+    Ok(vec![])
 }
 
-pub(crate) fn get_evidence_by_fr(
+pub(crate) async fn get_evidence_by_fr(
     _storage: &MockStorage,
     _fr_id: &str,
-) -> impl Future<Output = Result<Vec<Evidence>, DomainError>> + Send {
-    async move { Ok(vec![]) }
+) -> Result<Vec<Evidence>, DomainError> {
+    Ok(vec![])
 }

--- a/crates/agileplus-api/tests/api_integration/support/storage_port_impl/metrics.rs
+++ b/crates/agileplus-api/tests/api_integration/support/storage_port_impl/metrics.rs
@@ -1,20 +1,18 @@
-use std::future::Future;
-
 use agileplus_domain::domain::metric::Metric;
 use agileplus_domain::error::DomainError;
 
 use super::MockStorage;
 
-pub(crate) fn record_metric(
+pub(crate) async fn record_metric(
     _storage: &MockStorage,
     _metric: &Metric,
-) -> impl Future<Output = Result<i64, DomainError>> + Send {
-    async move { Ok(1) }
+) -> Result<i64, DomainError> {
+    Ok(1)
 }
 
-pub(crate) fn get_metrics_by_feature(
+pub(crate) async fn get_metrics_by_feature(
     _storage: &MockStorage,
     _feature_id: i64,
-) -> impl Future<Output = Result<Vec<Metric>, DomainError>> + Send {
-    async move { Ok(vec![]) }
+) -> Result<Vec<Metric>, DomainError> {
+    Ok(vec![])
 }

--- a/crates/agileplus-api/tests/api_integration/support/storage_port_impl/policy.rs
+++ b/crates/agileplus-api/tests/api_integration/support/storage_port_impl/policy.rs
@@ -1,19 +1,17 @@
-use std::future::Future;
-
 use agileplus_domain::domain::governance::PolicyRule;
 use agileplus_domain::error::DomainError;
 
 use super::MockStorage;
 
-pub(crate) fn create_policy_rule(
+pub(crate) async fn create_policy_rule(
     _storage: &MockStorage,
     _rule: &PolicyRule,
-) -> impl Future<Output = Result<i64, DomainError>> + Send {
-    async move { Ok(1) }
+) -> Result<i64, DomainError> {
+    Ok(1)
 }
 
-pub(crate) fn list_active_policies(
+pub(crate) async fn list_active_policies(
     _storage: &MockStorage,
-) -> impl Future<Output = Result<Vec<PolicyRule>, DomainError>> + Send {
-    async move { Ok(vec![]) }
+) -> Result<Vec<PolicyRule>, DomainError> {
+    Ok(vec![])
 }

--- a/crates/agileplus-api/tests/api_integration/support/storage_port_impl/sync_mapping.rs
+++ b/crates/agileplus-api/tests/api_integration/support/storage_port_impl/sync_mapping.rs
@@ -1,37 +1,35 @@
-use std::future::Future;
-
 use agileplus_domain::domain::sync_mapping::SyncMapping;
 use agileplus_domain::error::DomainError;
 
 use super::MockStorage;
 
-pub(crate) fn get_sync_mapping(
+pub(crate) async fn get_sync_mapping(
     _storage: &MockStorage,
     _entity_type: &str,
     _entity_id: i64,
-) -> impl Future<Output = Result<Option<SyncMapping>, DomainError>> + Send {
-    async move { Ok(None) }
+) -> Result<Option<SyncMapping>, DomainError> {
+    Ok(None)
 }
 
-pub(crate) fn upsert_sync_mapping(
+pub(crate) async fn upsert_sync_mapping(
     _storage: &MockStorage,
     _mapping: &SyncMapping,
-) -> impl Future<Output = Result<(), DomainError>> + Send {
-    async move { Ok(()) }
+) -> Result<(), DomainError> {
+    Ok(())
 }
 
-pub(crate) fn get_sync_mapping_by_plane_id(
+pub(crate) async fn get_sync_mapping_by_plane_id(
     _storage: &MockStorage,
     _entity_type: &str,
     _plane_issue_id: &str,
-) -> impl Future<Output = Result<Option<SyncMapping>, DomainError>> + Send {
-    async move { Ok(None) }
+) -> Result<Option<SyncMapping>, DomainError> {
+    Ok(None)
 }
 
-pub(crate) fn delete_sync_mapping(
+pub(crate) async fn delete_sync_mapping(
     _storage: &MockStorage,
     _entity_type: &str,
     _entity_id: i64,
-) -> impl Future<Output = Result<(), DomainError>> + Send {
-    async move { Ok(()) }
+) -> Result<(), DomainError> {
+    Ok(())
 }

--- a/crates/agileplus-api/tests/api_integration/support/storage_port_impl/work_package.rs
+++ b/crates/agileplus-api/tests/api_integration/support/storage_port_impl/work_package.rs
@@ -93,18 +93,18 @@ pub(crate) fn list_wps_by_feature(
     async move { Ok(wps) }
 }
 
-pub(crate) fn add_wp_dependency(
+pub(crate) async fn add_wp_dependency(
     _storage: &MockStorage,
     _dep: &WpDependency,
-) -> impl Future<Output = Result<(), DomainError>> + Send {
-    async move { Ok(()) }
+) -> Result<(), DomainError> {
+    Ok(())
 }
 
-pub(crate) fn get_wp_dependencies(
+pub(crate) async fn get_wp_dependencies(
     _storage: &MockStorage,
     _wp_id: i64,
-) -> impl Future<Output = Result<Vec<WpDependency>, DomainError>> + Send {
-    async move { Ok(vec![]) }
+) -> Result<Vec<WpDependency>, DomainError> {
+    Ok(vec![])
 }
 
 pub(crate) fn get_ready_wps(
@@ -155,65 +155,61 @@ pub(crate) fn get_latest_audit_entry(
         .lock()
         .expect("audit lock poisoned")
         .iter()
-        .filter(|e| e.feature_id == feature_id)
-        .last()
+        .rfind(|e| e.feature_id == feature_id)
         .cloned();
     async move { Ok(entry) }
 }
 
-pub(crate) fn create_evidence(
+pub(crate) async fn create_evidence(
     _storage: &MockStorage,
     _e: &Evidence,
-) -> impl Future<Output = Result<i64, DomainError>> + Send {
-    async move { Ok(1) }
+) -> Result<i64, DomainError> {
+    Ok(1)
 }
 
-pub(crate) fn get_evidence_by_wp(
+pub(crate) async fn get_evidence_by_wp(
     _storage: &MockStorage,
     _wp_id: i64,
-) -> impl Future<Output = Result<Vec<Evidence>, DomainError>> + Send {
-    async move { Ok(vec![]) }
+) -> Result<Vec<Evidence>, DomainError> {
+    Ok(vec![])
 }
 
-pub(crate) fn get_evidence_by_fr(
+pub(crate) async fn get_evidence_by_fr(
     _storage: &MockStorage,
     _fr_id: &str,
-) -> impl Future<Output = Result<Vec<Evidence>, DomainError>> + Send {
-    async move { Ok(vec![]) }
+) -> Result<Vec<Evidence>, DomainError> {
+    Ok(vec![])
 }
 
-pub(crate) fn create_policy_rule(
+pub(crate) async fn create_policy_rule(
     _storage: &MockStorage,
     _r: &PolicyRule,
-) -> impl Future<Output = Result<i64, DomainError>> + Send {
-    async move { Ok(1) }
+) -> Result<i64, DomainError> {
+    Ok(1)
 }
 
-pub(crate) fn list_active_policies(
+pub(crate) async fn list_active_policies(
     _storage: &MockStorage,
-) -> impl Future<Output = Result<Vec<PolicyRule>, DomainError>> + Send {
-    async move { Ok(vec![]) }
+) -> Result<Vec<PolicyRule>, DomainError> {
+    Ok(vec![])
 }
 
-pub(crate) fn record_metric(
-    _storage: &MockStorage,
-    _m: &Metric,
-) -> impl Future<Output = Result<i64, DomainError>> + Send {
-    async move { Ok(1) }
+pub(crate) async fn record_metric(_storage: &MockStorage, _m: &Metric) -> Result<i64, DomainError> {
+    Ok(1)
 }
 
-pub(crate) fn get_metrics_by_feature(
+pub(crate) async fn get_metrics_by_feature(
     _storage: &MockStorage,
     _feature_id: i64,
-) -> impl Future<Output = Result<Vec<Metric>, DomainError>> + Send {
-    async move { Ok(vec![]) }
+) -> Result<Vec<Metric>, DomainError> {
+    Ok(vec![])
 }
 
-pub(crate) fn create_governance_contract(
+pub(crate) async fn create_governance_contract(
     _storage: &MockStorage,
     _c: &GovernanceContract,
-) -> impl Future<Output = Result<i64, DomainError>> + Send {
-    async move { Ok(1) }
+) -> Result<i64, DomainError> {
+    Ok(1)
 }
 
 pub(crate) fn get_governance_contract(

--- a/crates/agileplus-application/src/lib.rs
+++ b/crates/agileplus-application/src/lib.rs
@@ -89,8 +89,8 @@ mod tests {
 
         async fn update_feature(&self, feature: &Feature) -> Result<(), DomainError> {
             let mut store = self.store.write().await;
-            if store.contains_key(&feature.id) {
-                store.insert(feature.id, feature.clone());
+            if let std::collections::hash_map::Entry::Occupied(mut e) = store.entry(feature.id) {
+                e.insert(feature.clone());
                 Ok(())
             } else {
                 Err(DomainError::FeatureNotFound(feature.id.to_string()))

--- a/crates/agileplus-cli/src/commands/cockpit.rs
+++ b/crates/agileplus-cli/src/commands/cockpit.rs
@@ -154,7 +154,7 @@ pub fn run(args: &CockpitArgs, global_repo: Option<&Path>) -> Result<()> {
             let report = evaluate(repo, &catalog_path, &cluster_filter)
                 .with_context(|| format!("scoring {}", repo.display()))?;
 
-            let log_path = output.clone().map(PathBuf::from).unwrap_or_else(|| {
+            let log_path = output.clone().unwrap_or_else(|| {
                 // SAFETY: default_log_path() only errors on home-dir failure;
                 // the cockpit subcommand runs after we've already exercised
                 // dirs via the rubric CLI, so this is essentially infallible.
@@ -237,11 +237,11 @@ fn iso8601_now() -> String {
 }
 
 fn append_ndjson(path: &Path, records: &[CockpitRecord]) -> Result<()> {
-    if let Some(parent) = path.parent() {
-        if !parent.exists() {
-            std::fs::create_dir_all(parent)
-                .with_context(|| format!("creating log directory {}", parent.display()))?;
-        }
+    if let Some(parent) = path.parent()
+        && !parent.exists()
+    {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating log directory {}", parent.display()))?;
     }
     let f = OpenOptions::new()
         .create(true)

--- a/crates/agileplus-cli/src/commands/fix_list.rs
+++ b/crates/agileplus-cli/src/commands/fix_list.rs
@@ -189,9 +189,7 @@ fn parse_effort(gap: &str) -> (String, char) {
     let lower = gap.to_ascii_lowercase();
     let needle = "effort:";
     if let Some(idx) = lower.rfind(needle) {
-        let head = gap[..idx]
-            .trim_end_matches(|c: char| c == '—' || c == '-' || c == ' ')
-            .trim();
+        let head = gap[..idx].trim_end_matches(['—', '-', ' ']).trim();
         let tail = &gap[idx + needle.len()..];
         let ch = tail
             .trim()

--- a/crates/agileplus-cli/src/commands/list_tests.rs
+++ b/crates/agileplus-cli/src/commands/list_tests.rs
@@ -222,8 +222,7 @@ impl StoragePort for MemStore {
             .lock()
             .unwrap()
             .iter()
-            .filter(|e| e.feature_id == feature_id)
-            .last()
+            .rfind(|e| e.feature_id == feature_id)
             .cloned())
     }
 

--- a/crates/agileplus-cli/src/commands/mvp.rs
+++ b/crates/agileplus-cli/src/commands/mvp.rs
@@ -400,7 +400,7 @@ pub async fn next_ready<S: StoragePort>(args: &NextReadyArgs, storage: &S) -> Re
         return Ok(());
     }
 
-    println!("{:<6}  {:<8}  {:<8}  {}", "ID", "FEATURE", "STATE", "TITLE");
+    println!("{:<6}  {:<8}  {:<8}  TITLE", "ID", "FEATURE", "STATE");
     println!("{}", "-".repeat(70));
     for wp in &wps {
         println!(

--- a/crates/agileplus-cli/src/commands/okf.rs
+++ b/crates/agileplus-cli/src/commands/okf.rs
@@ -339,7 +339,7 @@ fn summarize_cmd(path: &Path, top: usize) -> Result<i32> {
     // longest entity labels (per spec, operators often ask: "what's the
     // longest acceptance signal / constraint in this bundle?")
     let mut longest: Vec<&OkfEntity> = doc.entities.iter().collect();
-    longest.sort_by(|a, b| b.label.len().cmp(&a.label.len()));
+    longest.sort_by_key(|entity| std::cmp::Reverse(entity.label.len()));
     let top = top.min(longest.len());
     if top > 0 {
         println!("\ntop {top} longest entity labels:");

--- a/crates/agileplus-cli/src/commands/research.rs
+++ b/crates/agileplus-cli/src/commands/research.rs
@@ -90,11 +90,11 @@ where
 
             // Governance checks before transition
             let constitution = load_constitution(vcs).await;
-            if let Some(ref c) = constitution {
-                if let Ok(spec) = vcs.read_artifact(slug, "spec.md").await {
-                    let violations = validate_spec_consistency(&spec, c);
-                    enforce_governance(&violations)?;
-                }
+            if let Some(ref c) = constitution
+                && let Ok(spec) = vcs.read_artifact(slug, "spec.md").await
+            {
+                let violations = validate_spec_consistency(&spec, c);
+                enforce_governance(&violations)?;
             }
 
             research_post_specify(feature, slug, storage, vcs).await?;

--- a/crates/agileplus-cli/src/commands/rubric.rs
+++ b/crates/agileplus-cli/src/commands/rubric.rs
@@ -134,11 +134,7 @@ pub fn run(args: &RubricArgs) -> Result<()> {
             let total_points: u32 = report.clusters.iter().map(|c| c.total_points).sum();
             let max_points: u32 = report.clusters.iter().map(|c| c.max_points).sum();
             let pillars: usize = report.clusters.iter().map(|c| c.pillars.len()).sum();
-            let pct: u32 = if max_points == 0 {
-                0
-            } else {
-                (total_points * 100) / max_points
-            };
+            let pct = percentage(total_points, max_points);
             let grade = grade_for_pct(pct);
             println!(
                 "scored {} clusters across {} pillars (total {}/{}, grade {})",
@@ -198,6 +194,13 @@ fn grade_for_pct(pct: u32) -> &'static str {
     }
 }
 
+fn percentage(points: u32, maximum: u32) -> u32 {
+    if maximum == 0 {
+        return 0;
+    }
+    u32::try_from(u64::from(points) * 100 / u64::from(maximum)).unwrap_or(u32::MAX)
+}
+
 // ── Tests ────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -213,6 +216,14 @@ mod tests {
         assert_eq!(grade_for_pct(60), "C");
         assert_eq!(grade_for_pct(40), "D");
         assert_eq!(grade_for_pct(0), "F");
+    }
+
+    #[test]
+    fn percentage_handles_zero_and_large_values() {
+        assert_eq!(percentage(50, 100), 50);
+        assert_eq!(percentage(1, 0), 0);
+        assert_eq!(percentage(u32::MAX, u32::MAX), 100);
+        assert_eq!(percentage(u32::MAX, 1), u32::MAX);
     }
 
     #[test]

--- a/crates/agileplus-cli/src/commands/validate/evidence.rs
+++ b/crates/agileplus-cli/src/commands/validate/evidence.rs
@@ -80,12 +80,11 @@ pub(crate) async fn evaluate_evidence<S: StoragePort>(
 pub(crate) fn evaluate_threshold(evidence: &[&Evidence], threshold: &serde_json::Value) -> bool {
     if let Some(min_cov) = threshold.get("min_coverage").and_then(|v| v.as_f64()) {
         for ev in evidence {
-            if let Some(meta) = &ev.metadata {
-                if let Some(cov) = meta.get("coverage").and_then(|v| v.as_f64()) {
-                    if cov >= min_cov {
-                        return true;
-                    }
-                }
+            if let Some(meta) = &ev.metadata
+                && let Some(cov) = meta.get("coverage").and_then(|v| v.as_f64())
+                && cov >= min_cov
+            {
+                return true;
             }
         }
         return false;

--- a/crates/agileplus-cli/src/commands/worklog.rs
+++ b/crates/agileplus-cli/src/commands/worklog.rs
@@ -525,10 +525,10 @@ pub fn validate_payload(payload: &WorklogPayload) -> Result<()> {
     if payload.agent_id.trim().is_empty() {
         bail!("agent_id must be a non-empty string");
     }
-    if let Some(ref sha) = payload.commit_sha {
-        if !is_valid_sha(sha) {
-            bail!("commit_sha '{sha}' is not a 7-40 char hex string and is not null");
-        }
+    if let Some(ref sha) = payload.commit_sha
+        && !is_valid_sha(sha)
+    {
+        bail!("commit_sha '{sha}' is not a 7-40 char hex string and is not null");
     }
     if !CANONICAL_VERIFICATION_STATUSES.contains(&payload.verification_result.status.as_str()) {
         bail!(
@@ -553,10 +553,10 @@ pub fn validate_payload(payload: &WorklogPayload) -> Result<()> {
             s = payload.started_at
         );
     }
-    if let Some(ref c) = payload.completed_at {
-        if !is_iso8601_like(c) {
-            bail!("completed_at '{c}' is not an ISO-8601-like string");
-        }
+    if let Some(ref c) = payload.completed_at
+        && !is_iso8601_like(c)
+    {
+        bail!("completed_at '{c}' is not an ISO-8601-like string");
     }
     // files_changed: unique, non-empty
     let mut seen = std::collections::HashSet::new();

--- a/crates/agileplus-cli/src/main.rs
+++ b/crates/agileplus-cli/src/main.rs
@@ -127,11 +127,12 @@ fn open_vcs(repo: &Option<PathBuf>) -> Result<GitVcsAdapter> {
 
 async fn run(cli: Cli) -> Result<()> {
     // Ensure DB directory exists for storage-backed commands
-    if let Some(parent) = cli.db.parent() {
-        if !parent.as_os_str().is_empty() && !parent.exists() {
-            std::fs::create_dir_all(parent)
-                .with_context(|| format!("creating directory {}", parent.display()))?;
-        }
+    if let Some(parent) = cli.db.parent()
+        && !parent.as_os_str().is_empty()
+        && !parent.exists()
+    {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating directory {}", parent.display()))?;
     }
 
     match cli.command {

--- a/crates/agileplus-dashboard/src/app_state.rs
+++ b/crates/agileplus-dashboard/src/app_state.rs
@@ -175,18 +175,6 @@ impl DashboardStore {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::DashboardStore;
-
-    #[test]
-    fn cycle_without_feature_scope_is_not_shippable() {
-        let store = DashboardStore::seeded();
-
-        assert!(!store.cycle_is_shippable(999));
-    }
-}
-
 impl DashboardStore {
     /// Install the live governance client (after with_defaults())
     pub fn with_governance(mut self, client: agileplus_governance::GovernanceClient) -> Self {
@@ -272,4 +260,16 @@ pub fn default_health() -> Vec<ServiceHealth> {
             last_check: now,
         },
     ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DashboardStore;
+
+    #[test]
+    fn cycle_without_feature_scope_is_not_shippable() {
+        let store = DashboardStore::seeded();
+
+        assert!(!store.cycle_is_shippable(999));
+    }
 }

--- a/crates/agileplus-dashboard/src/routes/settings.rs
+++ b/crates/agileplus-dashboard/src/routes/settings.rs
@@ -564,6 +564,155 @@ fn persist_plane_settings(
     Ok(())
 }
 
+/// POST /api/settings/agents
+/// Persists agent configuration (pool_size, retry_budget, dispatch_mode, default_provider).
+pub async fn save_agent_settings(axum::Form(form): axum::Form<AgentSettingsForm>) -> Response {
+    let mut config = match Config::load() {
+        Ok(c) => c,
+        Err(error) => {
+            return render(ToastPartial {
+                message: format!("Failed to load settings safely: {error}"),
+                success: false,
+            });
+        }
+    };
+
+    config.agents = Some(AgentConfig {
+        pool_size: form.pool_size,
+        retry_budget: form.retry_budget,
+        dispatch_mode: form.dispatch_mode.trim().to_string(),
+        default_provider: form.default_provider.trim().to_string(),
+    });
+
+    match config.save() {
+        Ok(_) => render(ToastPartial {
+            message: "Agent settings saved successfully".to_string(),
+            success: true,
+        }),
+        Err(e) => render(ToastPartial {
+            message: format!("Failed to save settings: {e}"),
+            success: false,
+        }),
+    }
+}
+
+/// POST /api/settings/dashboard
+/// Persists dashboard UI configuration (theme, log_level, data_directory).
+pub async fn save_dashboard_settings(
+    axum::Form(form): axum::Form<DashboardSettingsForm>,
+) -> Response {
+    let mut config = match Config::load() {
+        Ok(c) => c,
+        Err(error) => {
+            return render(ToastPartial {
+                message: format!("Failed to load settings safely: {error}"),
+                success: false,
+            });
+        }
+    };
+
+    config.dashboard = Some(DashboardConfig {
+        theme: form.theme.trim().to_string(),
+        log_level: form.log_level.trim().to_string(),
+        data_directory: form.data_directory.trim().to_string(),
+    });
+
+    match config.save() {
+        Ok(_) => render(ToastPartial {
+            message: "Dashboard settings saved successfully".to_string(),
+            success: true,
+        }),
+        Err(e) => render(ToastPartial {
+            message: format!("Failed to save settings: {e}"),
+            success: false,
+        }),
+    }
+}
+
+/// POST /api/settings/services
+/// Persists custom service endpoint configuration.
+pub async fn save_services_settings(axum::Form(form): axum::Form<ServiceSettingsForm>) -> Response {
+    let mut config = match Config::load() {
+        Ok(c) => c,
+        Err(error) => {
+            return render(ToastPartial {
+                message: format!("Failed to load settings safely: {error}"),
+                success: false,
+            });
+        }
+    };
+
+    let mut services = Vec::new();
+    for (name, url) in form.names.into_iter().zip(form.endpoint_urls) {
+        if !name.trim().is_empty() {
+            services.push(ServiceConfig {
+                name: name.trim().to_string(),
+                endpoint_url: url.trim().to_string(),
+                enabled: default_service_enabled(),
+                timeout_ms: None,
+                max_retries: None,
+            });
+        }
+    }
+    config.services = Some(services);
+
+    match config.save() {
+        Ok(_) => render(ToastPartial {
+            message: "Service settings saved successfully".to_string(),
+            success: true,
+        }),
+        Err(e) => render(ToastPartial {
+            message: format!("Failed to save settings: {e}"),
+            success: false,
+        }),
+    }
+}
+
+// ── Connection Testing Handlers ────────────────────────────────────────────
+
+/// POST /api/settings/services/test
+/// Validates a single service endpoint (basic URL format check).
+pub async fn test_service_connection(
+    axum::Form(form): axum::Form<SingleServiceTestForm>,
+) -> Response {
+    let is_valid = !form.endpoint_url.trim().is_empty() && form.endpoint_url.starts_with("http");
+
+    if is_valid {
+        render(ToastPartial {
+            message: format!("Connection to {} successful (mock)", form.name),
+            success: true,
+        })
+    } else {
+        render(ToastPartial {
+            message: format!("Invalid endpoint for {}: {}", form.name, form.endpoint_url),
+            success: false,
+        })
+    }
+}
+
+/// POST /api/settings/plane/test
+/// Validates plane connection (checks required fields and URL format).
+pub async fn test_plane_connection(axum::Form(form): axum::Form<PlaneSettingsForm>) -> Response {
+    // Simple validation: check that required fields are filled and api_url looks like a URL
+    let is_valid = !form.api_url.trim().is_empty()
+        && !form.api_key.trim().is_empty()
+        && !form.workspace_slug.trim().is_empty()
+        && form.api_url.starts_with("http");
+
+    if is_valid {
+        // In a real implementation, you would make an HTTP request to verify connectivity
+        render(ToastPartial {
+            message: "Plane connection test passed (mock)".to_string(),
+            success: true,
+        })
+    } else {
+        render(ToastPartial {
+            message: "Plane settings are incomplete or invalid".to_string(),
+            success: false,
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -748,154 +897,5 @@ mod tests {
         assert_eq!(store.get("agileplus", PLANESO_KEY).unwrap(), "old-secret");
         assert_eq!(std::fs::read_to_string(&parent_file).unwrap(), "sentinel");
         std::fs::remove_dir_all(root).unwrap();
-    }
-}
-
-/// POST /api/settings/agents
-/// Persists agent configuration (pool_size, retry_budget, dispatch_mode, default_provider).
-pub async fn save_agent_settings(axum::Form(form): axum::Form<AgentSettingsForm>) -> Response {
-    let mut config = match Config::load() {
-        Ok(c) => c,
-        Err(error) => {
-            return render(ToastPartial {
-                message: format!("Failed to load settings safely: {error}"),
-                success: false,
-            });
-        }
-    };
-
-    config.agents = Some(AgentConfig {
-        pool_size: form.pool_size,
-        retry_budget: form.retry_budget,
-        dispatch_mode: form.dispatch_mode.trim().to_string(),
-        default_provider: form.default_provider.trim().to_string(),
-    });
-
-    match config.save() {
-        Ok(_) => render(ToastPartial {
-            message: "Agent settings saved successfully".to_string(),
-            success: true,
-        }),
-        Err(e) => render(ToastPartial {
-            message: format!("Failed to save settings: {e}"),
-            success: false,
-        }),
-    }
-}
-
-/// POST /api/settings/dashboard
-/// Persists dashboard UI configuration (theme, log_level, data_directory).
-pub async fn save_dashboard_settings(
-    axum::Form(form): axum::Form<DashboardSettingsForm>,
-) -> Response {
-    let mut config = match Config::load() {
-        Ok(c) => c,
-        Err(error) => {
-            return render(ToastPartial {
-                message: format!("Failed to load settings safely: {error}"),
-                success: false,
-            });
-        }
-    };
-
-    config.dashboard = Some(DashboardConfig {
-        theme: form.theme.trim().to_string(),
-        log_level: form.log_level.trim().to_string(),
-        data_directory: form.data_directory.trim().to_string(),
-    });
-
-    match config.save() {
-        Ok(_) => render(ToastPartial {
-            message: "Dashboard settings saved successfully".to_string(),
-            success: true,
-        }),
-        Err(e) => render(ToastPartial {
-            message: format!("Failed to save settings: {e}"),
-            success: false,
-        }),
-    }
-}
-
-/// POST /api/settings/services
-/// Persists custom service endpoint configuration.
-pub async fn save_services_settings(axum::Form(form): axum::Form<ServiceSettingsForm>) -> Response {
-    let mut config = match Config::load() {
-        Ok(c) => c,
-        Err(error) => {
-            return render(ToastPartial {
-                message: format!("Failed to load settings safely: {error}"),
-                success: false,
-            });
-        }
-    };
-
-    let mut services = Vec::new();
-    for (name, url) in form.names.into_iter().zip(form.endpoint_urls) {
-        if !name.trim().is_empty() {
-            services.push(ServiceConfig {
-                name: name.trim().to_string(),
-                endpoint_url: url.trim().to_string(),
-                enabled: default_service_enabled(),
-                timeout_ms: None,
-                max_retries: None,
-            });
-        }
-    }
-    config.services = Some(services);
-
-    match config.save() {
-        Ok(_) => render(ToastPartial {
-            message: "Service settings saved successfully".to_string(),
-            success: true,
-        }),
-        Err(e) => render(ToastPartial {
-            message: format!("Failed to save settings: {e}"),
-            success: false,
-        }),
-    }
-}
-
-// ── Connection Testing Handlers ────────────────────────────────────────────
-
-/// POST /api/settings/services/test
-/// Validates a single service endpoint (basic URL format check).
-pub async fn test_service_connection(
-    axum::Form(form): axum::Form<SingleServiceTestForm>,
-) -> Response {
-    let is_valid = !form.endpoint_url.trim().is_empty() && form.endpoint_url.starts_with("http");
-
-    if is_valid {
-        render(ToastPartial {
-            message: format!("Connection to {} successful (mock)", form.name),
-            success: true,
-        })
-    } else {
-        render(ToastPartial {
-            message: format!("Invalid endpoint for {}: {}", form.name, form.endpoint_url),
-            success: false,
-        })
-    }
-}
-
-/// POST /api/settings/plane/test
-/// Validates plane connection (checks required fields and URL format).
-pub async fn test_plane_connection(axum::Form(form): axum::Form<PlaneSettingsForm>) -> Response {
-    // Simple validation: check that required fields are filled and api_url looks like a URL
-    let is_valid = !form.api_url.trim().is_empty()
-        && !form.api_key.trim().is_empty()
-        && !form.workspace_slug.trim().is_empty()
-        && form.api_url.starts_with("http");
-
-    if is_valid {
-        // In a real implementation, you would make an HTTP request to verify connectivity
-        render(ToastPartial {
-            message: "Plane connection test passed (mock)".to_string(),
-            success: true,
-        })
-    } else {
-        render(ToastPartial {
-            message: "Plane settings are incomplete or invalid".to_string(),
-            success: false,
-        })
     }
 }

--- a/crates/agileplus-domain/src/intent_graph.rs
+++ b/crates/agileplus-domain/src/intent_graph.rs
@@ -762,6 +762,9 @@ impl IntentGraph {
     }
 }
 
+// Re-export builder types so that intent_graph.rs satisfies the "Builder module" requirement.
+pub use crate::builder::{EdgeBuilder, NodeBuilder};
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1140,6 +1143,3 @@ mod tests {
         );
     }
 }
-
-// Re-export builder types so that intent_graph.rs satisfies the "Builder module" requirement.
-pub use crate::builder::{EdgeBuilder, NodeBuilder};

--- a/crates/agileplus-domain/src/ports/mod.rs
+++ b/crates/agileplus-domain/src/ports/mod.rs
@@ -4,6 +4,7 @@ pub mod agent;
 pub mod epic;
 pub mod events;
 pub mod observability;
+pub mod review;
 pub mod storage;
 pub mod story;
 pub mod traceability_port;
@@ -12,6 +13,7 @@ pub mod vcs;
 pub use agent::AgentPort;
 pub use epic::EpicRepository;
 pub use observability::ObservabilityPort;
+pub use review::ReviewPort;
 pub use story::StoryRepository;
 pub use vcs::{BranchInfo, ConflictInfo, FeatureArtifacts, MergeResult, VcsPort, WorktreeInfo};
 

--- a/crates/agileplus-domain/tests/acceptance_traceability_integration_test.rs
+++ b/crates/agileplus-domain/tests/acceptance_traceability_integration_test.rs
@@ -237,7 +237,7 @@ fn test_unverified_criterion_with_trace_ref_not_counted_as_done() {
 fn test_trace_ref_artifact_type_preserved_in_contract() {
     let entity_id = Uuid::new_v4();
 
-    let artifact_types = vec![
+    let artifact_types = [
         "requirement",
         "test_case",
         "evidence",

--- a/crates/agileplus-domain/tests/memory.rs
+++ b/crates/agileplus-domain/tests/memory.rs
@@ -111,7 +111,7 @@ fn memory_profile_work_package_operations() {
             WorkPackage::new(
                 i as i64 % 100,
                 &format!("WP-{i}"),
-                i as i32,
+                i,
                 "User can perform the specified operation successfully",
             )
         })

--- a/crates/agileplus-events/src/query.rs
+++ b/crates/agileplus-events/src/query.rs
@@ -78,45 +78,45 @@ impl EventQuery {
         events
             .iter()
             .filter(|e| {
-                if let Some(ref et) = self.entity_type {
-                    if &e.entity_type != et {
-                        return false;
-                    }
+                if let Some(ref et) = self.entity_type
+                    && &e.entity_type != et
+                {
+                    return false;
                 }
-                if let Some(id) = self.entity_id {
-                    if e.entity_id != id {
-                        return false;
-                    }
+                if let Some(id) = self.entity_id
+                    && e.entity_id != id
+                {
+                    return false;
                 }
-                if let Some(ref et) = self.event_type {
-                    if &e.event_type != et {
-                        return false;
-                    }
+                if let Some(ref et) = self.event_type
+                    && &e.event_type != et
+                {
+                    return false;
                 }
-                if let Some(ref a) = self.actor {
-                    if &e.actor != a {
-                        return false;
-                    }
+                if let Some(ref a) = self.actor
+                    && &e.actor != a
+                {
+                    return false;
                 }
-                if let Some(from) = self.from_time {
-                    if e.timestamp < from {
-                        return false;
-                    }
+                if let Some(from) = self.from_time
+                    && e.timestamp < from
+                {
+                    return false;
                 }
-                if let Some(to) = self.to_time {
-                    if e.timestamp > to {
-                        return false;
-                    }
+                if let Some(to) = self.to_time
+                    && e.timestamp > to
+                {
+                    return false;
                 }
-                if let Some(from) = self.from_sequence {
-                    if e.sequence < from {
-                        return false;
-                    }
+                if let Some(from) = self.from_sequence
+                    && e.sequence < from
+                {
+                    return false;
                 }
-                if let Some(to) = self.to_sequence {
-                    if e.sequence > to {
-                        return false;
-                    }
+                if let Some(to) = self.to_sequence
+                    && e.sequence > to
+                {
+                    return false;
                 }
                 true
             })

--- a/crates/agileplus-git/src/lib.rs
+++ b/crates/agileplus-git/src/lib.rs
@@ -250,10 +250,10 @@ impl GitVcsAdapter {
             }
 
             if let Some(rest) = line.strip_prefix("CONFLICT (") {
-                if let Some((kind, description)) = rest.split_once("): ") {
-                    if let Some(path) = Self::conflict_diagnostic_path(description) {
-                        paths.insert(path.to_string(), kind.to_string());
-                    }
+                if let Some((kind, description)) = rest.split_once("): ")
+                    && let Some(path) = Self::conflict_diagnostic_path(description)
+                {
+                    paths.insert(path.to_string(), kind.to_string());
                 }
                 continue;
             }

--- a/crates/agileplus-git/tests/integration.rs
+++ b/crates/agileplus-git/tests/integration.rs
@@ -482,10 +482,10 @@ async fn test_cleanup_worktree_safety_check() {
 // ---- Helpers ----
 
 fn get_default_branch(repo: &Repository) -> String {
-    if let Ok(head) = repo.head() {
-        if let Ok(name) = head.shorthand() {
-            return name.to_string();
-        }
+    if let Ok(head) = repo.head()
+        && let Ok(name) = head.shorthand()
+    {
+        return name.to_string();
     }
     "main".to_string()
 }

--- a/crates/agileplus-github/src/sync.rs
+++ b/crates/agileplus-github/src/sync.rs
@@ -142,10 +142,10 @@ impl GitHubSyncAdapter {
         let body_hash = hash_content(&body);
 
         // Check if unchanged
-        if let Some(existing_hash) = state.content_hashes.get(&item_id) {
-            if *existing_hash == body_hash {
-                return Ok(SyncOutcome::Skipped);
-            }
+        if let Some(existing_hash) = state.content_hashes.get(&item_id)
+            && *existing_hash == body_hash
+        {
+            return Ok(SyncOutcome::Skipped);
         }
 
         let labels = vec![
@@ -162,17 +162,18 @@ impl GitHubSyncAdapter {
 
         let outcome = if let Some(&issue_number) = state.issue_mappings.get(&item_id) {
             // Conflict check: fetch remote and compare hashes
-            if let Ok(remote) = self.client.get_issue(issue_number).await {
-                if let Some(ref remote_body) = remote.body {
-                    let remote_hash = hash_content(remote_body);
-                    if let Some(our_hash) = state.content_hashes.get(&item_id) {
-                        if remote_hash != *our_hash && body_hash != remote_hash {
-                            return Ok(SyncOutcome::Conflict {
-                                issue_number,
-                                reason: "Remote issue body was modified externally".to_string(),
-                            });
-                        }
-                    }
+            if let Ok(remote) = self.client.get_issue(issue_number).await
+                && let Some(ref remote_body) = remote.body
+            {
+                let remote_hash = hash_content(remote_body);
+                if let Some(our_hash) = state.content_hashes.get(&item_id)
+                    && remote_hash != *our_hash
+                    && body_hash != remote_hash
+                {
+                    return Ok(SyncOutcome::Conflict {
+                        issue_number,
+                        reason: "Remote issue body was modified externally".to_string(),
+                    });
                 }
             }
 

--- a/crates/agileplus-grpc/Cargo.toml
+++ b/crates/agileplus-grpc/Cargo.toml
@@ -7,9 +7,11 @@ rust-version.workspace = true
 
 [dependencies]
 agileplus-domain = { path = "../agileplus-domain" }
+agileplus-git = { path = "../agileplus-git" }
 agileplus-proto = { path = "../agileplus-proto" }
+agileplus-sqlite = { path = "../agileplus-sqlite" }
 tonic = { workspace = true }
-prost = "0.13"
+prost.workspace = true
 tokio.workspace = true
 tokio-stream = { version = "0.1", features = ["sync"] }
 futures = "0.3"
@@ -17,9 +19,7 @@ tracing.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 chrono.workspace = true
-
-[build-dependencies]
-tonic-build = { workspace = true }
+tracing-subscriber.workspace = true
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full", "test-util"] }

--- a/crates/agileplus-grpc/build.rs
+++ b/crates/agileplus-grpc/build.rs
@@ -1,4 +1,10 @@
 fn main() {
+    println!("cargo::rustc-check-cfg=cfg(agileplus_proto_stubs)");
+    println!("cargo:rerun-if-env-changed=SKIP_PROTO_BUILD");
+    if std::env::var_os("SKIP_PROTO_BUILD").is_some() {
+        println!("cargo:rustc-cfg=agileplus_proto_stubs");
+    }
+
     let protos = &[
         "../../proto/agileplus/v1/core.proto",
         "../../proto/agileplus/v1/agents.proto",

--- a/crates/agileplus-grpc/build.rs
+++ b/crates/agileplus-grpc/build.rs
@@ -1,4 +1,4 @@
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() {
     let protos = &[
         "../../proto/agileplus/v1/core.proto",
         "../../proto/agileplus/v1/agents.proto",
@@ -6,16 +6,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "../../proto/agileplus/v1/integrations.proto",
     ];
 
-    let includes = &["../../proto"];
-
-    tonic_build::configure()
-        .build_server(true)
-        .build_client(true)
-        .compile_protos(protos, includes)?;
-
     for proto in protos {
         println!("cargo:rerun-if-changed={proto}");
     }
-
-    Ok(())
 }

--- a/crates/agileplus-grpc/src/lib.rs
+++ b/crates/agileplus-grpc/src/lib.rs
@@ -5,5 +5,6 @@
 pub mod conversions;
 pub mod event_bus;
 pub mod proxy;
+pub mod runtime;
 pub mod server;
 pub mod streaming;

--- a/crates/agileplus-grpc/src/main.rs
+++ b/crates/agileplus-grpc/src/main.rs
@@ -1,0 +1,119 @@
+use std::sync::Arc;
+
+use agileplus_domain::error::DomainError;
+use agileplus_domain::ports::agent::{AgentConfig, AgentResult, AgentStatus, AgentTask};
+use agileplus_domain::ports::observability::{LogEntry, ObservabilityPort, SpanContext};
+use agileplus_domain::ports::review::{CiStatus, PrInfo, ReviewComment, ReviewStatus};
+use agileplus_domain::ports::{AgentPort, ReviewPort};
+use agileplus_git::GitVcsAdapter;
+use agileplus_grpc::event_bus::EventBus;
+use agileplus_grpc::proxy::ProxyRouter;
+use agileplus_grpc::runtime::CoreConfig;
+use agileplus_sqlite::SqliteStorageAdapter;
+
+#[derive(Debug, Default)]
+struct UnavailableAgent;
+
+impl AgentPort for UnavailableAgent {
+    async fn dispatch(&self, _: AgentTask, _: &AgentConfig) -> Result<AgentResult, DomainError> {
+        Err(DomainError::NotImplemented)
+    }
+    async fn dispatch_async(&self, _: AgentTask, _: &AgentConfig) -> Result<String, DomainError> {
+        Err(DomainError::NotImplemented)
+    }
+    async fn query_status(&self, _: &str) -> Result<AgentStatus, DomainError> {
+        Err(DomainError::NotImplemented)
+    }
+    async fn cancel(&self, _: &str) -> Result<(), DomainError> {
+        Err(DomainError::NotImplemented)
+    }
+    async fn send_instruction(&self, _: &str, _: &str) -> Result<(), DomainError> {
+        Err(DomainError::NotImplemented)
+    }
+}
+
+#[derive(Debug, Default)]
+struct UnavailableReview;
+
+impl ReviewPort for UnavailableReview {
+    async fn get_review_status(&self, _: &str) -> Result<ReviewStatus, DomainError> {
+        Err(DomainError::NotImplemented)
+    }
+    async fn get_review_comments(&self, _: &str) -> Result<Vec<ReviewComment>, DomainError> {
+        Err(DomainError::NotImplemented)
+    }
+    async fn get_actionable_comments(&self, _: &str) -> Result<Vec<ReviewComment>, DomainError> {
+        Err(DomainError::NotImplemented)
+    }
+    async fn get_ci_status(&self, _: &str) -> Result<CiStatus, DomainError> {
+        Err(DomainError::NotImplemented)
+    }
+    async fn get_pr_info(&self, _: &str) -> Result<PrInfo, DomainError> {
+        Err(DomainError::NotImplemented)
+    }
+    async fn await_review(&self, _: &str, _: u64) -> Result<ReviewStatus, DomainError> {
+        Err(DomainError::NotImplemented)
+    }
+    async fn await_ci(&self, _: &str, _: u64) -> Result<CiStatus, DomainError> {
+        Err(DomainError::NotImplemented)
+    }
+}
+
+#[derive(Debug, Default)]
+struct LogOnlyObservability;
+
+impl ObservabilityPort for LogOnlyObservability {
+    fn start_span(&self, _: &str, _: Option<&SpanContext>) -> SpanContext {
+        SpanContext {
+            trace_id: String::new(),
+            span_id: String::new(),
+            parent_span_id: None,
+        }
+    }
+    fn end_span(&self, _: &SpanContext) {}
+    fn add_span_event(&self, _: &SpanContext, _: &str, _: &[(&str, &str)]) {}
+    fn set_span_error(&self, _: &SpanContext, error: &str) {
+        tracing::error!(%error);
+    }
+    fn record_counter(&self, _: &str, _: u64, _: &[(&str, &str)]) {}
+    fn record_histogram(&self, _: &str, _: f64, _: &[(&str, &str)]) {}
+    fn record_gauge(&self, _: &str, _: f64, _: &[(&str, &str)]) {}
+    fn log(&self, entry: &LogEntry) {
+        tracing::info!(message = %entry.message);
+    }
+    fn log_info(&self, message: &str) {
+        tracing::info!(%message);
+    }
+    fn log_warn(&self, message: &str) {
+        tracing::warn!(%message);
+    }
+    fn log_error(&self, message: &str) {
+        tracing::error!(%message);
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt::init();
+    let config = CoreConfig::from_env()?;
+    if let Some(parent) = config.database.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    let storage = Arc::new(SqliteStorageAdapter::new(&config.database)?);
+    let vcs = Arc::new(GitVcsAdapter::from_current_dir()?);
+    let proxy = Arc::new(ProxyRouter::new(None, None).await);
+    tracing::info!(bind = %config.bind, database = %config.database.display(), "starting AgilePlus core");
+
+    agileplus_grpc::server::start_server(
+        config.bind,
+        storage,
+        vcs,
+        Arc::new(UnavailableAgent),
+        Arc::new(UnavailableReview),
+        Arc::new(LogOnlyObservability),
+        Arc::new(EventBus::new(256)),
+        proxy,
+    )
+    .await
+}

--- a/crates/agileplus-grpc/src/proxy.rs
+++ b/crates/agileplus-grpc/src/proxy.rs
@@ -1,5 +1,5 @@
 //! gRPC proxy/router — forwards agent and integration requests to downstream
-//! services when available, and falls back to stubs otherwise.
+//! services when available, and reports explicit unavailability otherwise.
 //!
 //! Traceability: WP14-T080b
 
@@ -82,7 +82,7 @@ impl ProxyRouter {
     /// Dispatch an agent-related command.
     ///
     /// If `agileplus-agents` is reachable, the request is forwarded; otherwise
-    /// a stub response is returned indicating the service is unavailable.
+    /// an unsuccessful response is returned indicating the service is unavailable.
     pub async fn dispatch_agent_command(
         &self,
         command: &str,
@@ -147,7 +147,10 @@ impl ProxyResult {
     pub fn is_success(&self) -> bool {
         match self {
             ProxyResult::Forwarded { success, .. } => *success,
-            ProxyResult::Stub { .. } => true, // Stubs succeed for development purposes
+            // A stub proves only that no downstream service handled the request.  It
+            // must never acknowledge a mutating command (notably `implement`) as
+            // successful.
+            ProxyResult::Stub { .. } => false,
         }
     }
 
@@ -171,12 +174,12 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn proxy_stub_mode_succeeds() {
+    async fn proxy_stub_mode_rejects_mutating_command() {
         let router = ProxyRouter::new(None, None).await;
         let result = router
             .dispatch_agent_command("implement", "feat-a", &Default::default())
             .await;
-        assert!(result.is_success());
+        assert!(!result.is_success());
         assert!(result.message().contains("stub"));
     }
 

--- a/crates/agileplus-grpc/src/runtime.rs
+++ b/crates/agileplus-grpc/src/runtime.rs
@@ -17,15 +17,31 @@ impl CoreConfig {
             return Err("plaintext AgilePlus core must bind to a loopback address".to_owned());
         }
 
+        let database = database.unwrap_or(".agileplus/agileplus.db").trim();
+        if database.is_empty() {
+            return Err("AgilePlus core database path must not be empty".to_owned());
+        }
+
         Ok(Self {
             bind,
-            database: PathBuf::from(database.unwrap_or(".agileplus/agileplus.db")),
+            database: PathBuf::from(database),
         })
     }
 
+    pub fn from_env_values(
+        bind: Option<&str>,
+        core_database: Option<&str>,
+        legacy_database: Option<&str>,
+    ) -> Result<Self, String> {
+        Self::from_values(bind, core_database.or(legacy_database))
+    }
+
     pub fn from_env() -> Result<Self, String> {
-        Self::from_values(
+        Self::from_env_values(
             std::env::var("AGILEPLUS_GRPC_BIND").ok().as_deref(),
+            std::env::var("AGILEPLUS_CORE_DATABASE_PATH")
+                .ok()
+                .as_deref(),
             std::env::var("AGILEPLUS_DB_PATH").ok().as_deref(),
         )
     }

--- a/crates/agileplus-grpc/src/runtime.rs
+++ b/crates/agileplus-grpc/src/runtime.rs
@@ -1,0 +1,32 @@
+use std::net::SocketAddr;
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CoreConfig {
+    pub bind: SocketAddr,
+    pub database: PathBuf,
+}
+
+impl CoreConfig {
+    pub fn from_values(bind: Option<&str>, database: Option<&str>) -> Result<Self, String> {
+        let bind = bind
+            .unwrap_or("127.0.0.1:50051")
+            .parse::<SocketAddr>()
+            .map_err(|error| format!("invalid core bind address: {error}"))?;
+        if !bind.ip().is_loopback() {
+            return Err("plaintext AgilePlus core must bind to a loopback address".to_owned());
+        }
+
+        Ok(Self {
+            bind,
+            database: PathBuf::from(database.unwrap_or(".agileplus/agileplus.db")),
+        })
+    }
+
+    pub fn from_env() -> Result<Self, String> {
+        Self::from_values(
+            std::env::var("AGILEPLUS_GRPC_BIND").ok().as_deref(),
+            std::env::var("AGILEPLUS_DB_PATH").ok().as_deref(),
+        )
+    }
+}

--- a/crates/agileplus-grpc/src/server/mod.rs
+++ b/crates/agileplus-grpc/src/server/mod.rs
@@ -300,7 +300,9 @@ where
         let mut violations = Vec::new();
         let feature_slug = req.feature_slug;
         for rule in &relevant_rules {
-            let satisfied = evidence.iter().any(|candidate| candidate.fr_id == feature_slug);
+            let satisfied = evidence
+                .iter()
+                .any(|candidate| candidate.fr_id == feature_slug);
             if !satisfied {
                 violations.push(ProtoGateViolation {
                     fr_id: feature_slug.clone(),

--- a/crates/agileplus-grpc/src/server/mod.rs
+++ b/crates/agileplus-grpc/src/server/mod.rs
@@ -2,18 +2,22 @@
 //!
 //! Traceability: WP14-T079, T080
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::net::SocketAddr;
 use std::pin::Pin;
 use std::sync::Arc;
 
+#[cfg(not(agileplus_proto_stubs))]
 use tonic::transport::Server;
 use tonic::{Request, Response, Status};
 use tracing::info;
 
 use agileplus_domain::domain::audit::AuditChain;
+use agileplus_domain::domain::governance::{Evidence, EvidenceType, GovernanceRule};
 use agileplus_domain::domain::state_machine::FeatureState;
 use agileplus_domain::ports::{AgentPort, ObservabilityPort, ReviewPort, StoragePort, VcsPort};
+#[cfg(not(agileplus_proto_stubs))]
+use agileplus_proto::agileplus::v1::agile_plus_core_service_server::AgilePlusCoreServiceServer;
 use agileplus_proto::agileplus::v1::{
     CheckGovernanceGateRequest, CheckGovernanceGateResponse, CommandResponse,
     DispatchCommandRequest, DispatchCommandResponse, GateViolation as ProtoGateViolation,
@@ -21,8 +25,7 @@ use agileplus_proto::agileplus::v1::{
     GetFeatureStateRequest, GetFeatureStateResponse, GetWorkPackageStatusRequest,
     GetWorkPackageStatusResponse, ListFeaturesRequest, ListFeaturesResponse,
     ListWorkPackagesRequest, ListWorkPackagesResponse, VerifyAuditChainRequest,
-    VerifyAuditChainResponse,
-    agile_plus_core_service_server::{AgilePlusCoreService, AgilePlusCoreServiceServer},
+    VerifyAuditChainResponse, agile_plus_core_service_server::AgilePlusCoreService,
 };
 
 use crate::conversions::{audit_entry_to_proto, feature_to_proto, wp_to_proto};
@@ -40,6 +43,51 @@ pub fn domain_error_to_status(e: agileplus_domain::error::DomainError) -> Status
         DomainError::Conflict(msg) => Status::already_exists(msg),
         DomainError::NotImplemented => Status::unimplemented("not implemented"),
         other => Status::internal(other.to_string()),
+    }
+}
+
+/// Parse the contract representation `FR-ID` or `FR-ID:evidence_type`.
+fn parse_evidence_requirement(raw: &str) -> (&str, Option<EvidenceType>, bool) {
+    let (fr_id, evidence_type) = raw
+        .split_once(':')
+        .map_or((raw, None), |(fr_id, kind)| (fr_id, Some(kind)));
+    let had_type = evidence_type.is_some();
+    let evidence_type = evidence_type.and_then(|kind| match kind {
+        "test_result" => Some(EvidenceType::TestResult),
+        "ci_output" => Some(EvidenceType::CiOutput),
+        "review_approval" => Some(EvidenceType::ReviewApproval),
+        "security_scan" => Some(EvidenceType::SecurityScan),
+        "lint_result" => Some(EvidenceType::LintResult),
+        "manual_attestation" => Some(EvidenceType::ManualAttestation),
+        _ => None,
+    });
+    let recognized = !had_type || evidence_type.is_some();
+    (fr_id, evidence_type, recognized)
+}
+
+fn evidence_satisfies_requirement(
+    evidence: &[Evidence],
+    feature_wp_ids: &HashSet<i64>,
+    fr_id: &str,
+    expected_type: Option<EvidenceType>,
+) -> bool {
+    evidence.iter().any(|candidate| {
+        candidate.fr_id == fr_id
+            && feature_wp_ids.contains(&candidate.wp_id)
+            && expected_type.is_none_or(|kind| candidate.evidence_type == kind)
+    })
+}
+
+fn missing_evidence_violation(
+    rule: &GovernanceRule,
+    fr_id: &str,
+    requirement: &str,
+) -> ProtoGateViolation {
+    ProtoGateViolation {
+        fr_id: fr_id.to_owned(),
+        rule_id: rule.transition.clone(),
+        message: format!("Missing required evidence for {requirement}"),
+        remediation: format!("Provide evidence linked to {requirement}"),
     }
 }
 
@@ -290,26 +338,35 @@ where
             .filter(|r| r.transition.is_empty() || r.transition == req.transition)
             .collect();
 
-        // Collect evidence — a production impl would filter by feature/rule
-        let evidence = self
-            .storage
-            .get_evidence_by_fr("")
-            .await
-            .unwrap_or_default();
-
         let mut violations = Vec::new();
-        let feature_slug = req.feature_slug;
+        let feature_wp_ids: HashSet<i64> = self
+            .storage
+            .list_wps_by_feature(feature.id)
+            .await
+            .map_err(domain_error_to_status)?
+            .into_iter()
+            .map(|wp| wp.id)
+            .collect();
+
         for rule in &relevant_rules {
-            let satisfied = evidence
-                .iter()
-                .any(|candidate| candidate.fr_id == feature_slug);
-            if !satisfied {
-                violations.push(ProtoGateViolation {
-                    fr_id: feature_slug.clone(),
-                    rule_id: rule.transition.clone(),
-                    message: format!("Missing required evidence for FR {}", feature_slug),
-                    remediation: format!("Provide evidence linked to FR {}", feature_slug),
-                });
+            for raw_requirement in &rule.required_evidence {
+                let (fr_id, expected_type, recognized) =
+                    parse_evidence_requirement(raw_requirement);
+                let evidence = self
+                    .storage
+                    .get_evidence_by_fr(fr_id)
+                    .await
+                    .map_err(domain_error_to_status)?;
+                if !recognized
+                    || !evidence_satisfies_requirement(
+                        &evidence,
+                        &feature_wp_ids,
+                        fr_id,
+                        expected_type,
+                    )
+                {
+                    violations.push(missing_evidence_violation(rule, fr_id, raw_requirement));
+                }
             }
         }
 
@@ -498,6 +555,7 @@ where
 }
 
 /// Start the gRPC server, binding to the given address.
+#[cfg(not(agileplus_proto_stubs))]
 #[allow(clippy::too_many_arguments)] // Server bootstrap requires all service ports
 pub async fn start_server<S, V, A, R, O>(
     addr: SocketAddr,
@@ -530,7 +588,34 @@ where
     Ok(())
 }
 
+/// Report a clear runtime error when the crate was built without generated tonic services.
+#[cfg(agileplus_proto_stubs)]
+#[allow(clippy::too_many_arguments)]
+pub async fn start_server<S, V, A, R, O>(
+    _addr: SocketAddr,
+    _storage: Arc<S>,
+    _vcs: Arc<V>,
+    _agents: Arc<A>,
+    _review: Arc<R>,
+    _telemetry: Arc<O>,
+    _event_bus: Arc<EventBus>,
+    _proxy: Arc<ProxyRouter>,
+) -> Result<(), Box<dyn std::error::Error>>
+where
+    S: StoragePort + 'static,
+    V: VcsPort + 'static,
+    A: AgentPort + 'static,
+    R: ReviewPort + 'static,
+    O: ObservabilityPort + 'static,
+{
+    Err(
+        "AgilePlus gRPC network server is unavailable because protobuf generation was skipped"
+            .into(),
+    )
+}
+
 /// Listens for SIGTERM / SIGINT and resolves when either is received.
+#[cfg(not(agileplus_proto_stubs))]
 async fn shutdown_signal() {
     use tokio::signal;
 
@@ -562,6 +647,7 @@ async fn shutdown_signal() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::Utc;
 
     #[test]
     fn domain_error_mapping() {
@@ -578,5 +664,65 @@ mod tests {
 
         let s = domain_error_to_status(DomainError::Conflict("x".into()));
         assert_eq!(s.code(), tonic::Code::AlreadyExists);
+    }
+
+    #[test]
+    fn governance_requirement_uses_fr_id_and_optional_type() {
+        assert_eq!(
+            parse_evidence_requirement("FR-053:ci_output"),
+            ("FR-053", Some(EvidenceType::CiOutput), true)
+        );
+        assert_eq!(parse_evidence_requirement("FR-054"), ("FR-054", None, true));
+        assert_eq!(
+            parse_evidence_requirement("FR-055:unknown"),
+            ("FR-055", None, false)
+        );
+    }
+
+    #[test]
+    fn governance_evidence_must_belong_to_feature_and_match_type() {
+        let evidence = vec![Evidence {
+            id: 1,
+            wp_id: 7,
+            fr_id: "FR-053".to_owned(),
+            evidence_type: EvidenceType::CiOutput,
+            artifact_path: "ci://run/1".to_owned(),
+            metadata: None,
+            created_at: Utc::now(),
+        }];
+
+        assert!(evidence_satisfies_requirement(
+            &evidence,
+            &HashSet::from([7]),
+            "FR-053",
+            Some(EvidenceType::CiOutput),
+        ));
+        assert!(!evidence_satisfies_requirement(
+            &evidence,
+            &HashSet::from([8]),
+            "FR-053",
+            Some(EvidenceType::CiOutput),
+        ));
+        assert!(!evidence_satisfies_requirement(
+            &evidence,
+            &HashSet::from([7]),
+            "FR-053",
+            Some(EvidenceType::SecurityScan),
+        ));
+    }
+
+    #[test]
+    fn governance_violation_reports_requirement_not_feature_slug() {
+        let rule = GovernanceRule {
+            transition: "validate".to_owned(),
+            required_evidence: vec!["FR-053:ci_output".to_owned()],
+            policy_refs: Vec::new(),
+        };
+        let violation = missing_evidence_violation(&rule, "FR-053", "FR-053:ci_output");
+
+        assert_eq!(violation.fr_id, "FR-053");
+        assert_eq!(violation.rule_id, "validate");
+        assert!(violation.message.contains("FR-053:ci_output"));
+        assert!(!violation.message.contains("feature"));
     }
 }

--- a/crates/agileplus-grpc/tests/grpc_integration.rs
+++ b/crates/agileplus-grpc/tests/grpc_integration.rs
@@ -137,7 +137,7 @@ async fn proxy_router_stub_mode() {
     let result = router
         .dispatch_agent_command("implement", "test-feat", &Default::default())
         .await;
-    assert!(result.is_success());
+    assert!(!result.is_success());
     assert!(result.message().contains("stub"));
 }
 
@@ -153,5 +153,5 @@ async fn proxy_router_unreachable_address_falls_back_to_stub() {
     let result = router
         .dispatch_agent_command("implement", "feat-x", &Default::default())
         .await;
-    assert!(result.is_success()); // Stubs always succeed
+    assert!(!result.is_success());
 }

--- a/crates/agileplus-grpc/tests/runtime_config.rs
+++ b/crates/agileplus-grpc/tests/runtime_config.rs
@@ -16,3 +16,32 @@ fn rejects_non_loopback_bindings() {
 
     assert!(error.to_string().contains("loopback"));
 }
+
+#[test]
+fn rejects_empty_or_whitespace_database_paths() {
+    for database in ["", "  \t "] {
+        let error = CoreConfig::from_values(None, Some(database))
+            .expect_err("empty database path must be rejected");
+        assert!(error.contains("must not be empty"));
+    }
+}
+
+#[test]
+fn canonical_database_environment_value_takes_precedence() {
+    let config = CoreConfig::from_env_values(
+        None,
+        Some("/canonical/agileplus.db"),
+        Some("/legacy/agileplus.db"),
+    )
+    .expect("canonical database config");
+
+    assert_eq!(config.database.to_string_lossy(), "/canonical/agileplus.db");
+}
+
+#[test]
+fn legacy_database_environment_value_remains_a_fallback() {
+    let config = CoreConfig::from_env_values(None, None, Some("/legacy/agileplus.db"))
+        .expect("legacy database config");
+
+    assert_eq!(config.database.to_string_lossy(), "/legacy/agileplus.db");
+}

--- a/crates/agileplus-grpc/tests/runtime_config.rs
+++ b/crates/agileplus-grpc/tests/runtime_config.rs
@@ -1,0 +1,18 @@
+use agileplus_grpc::runtime::CoreConfig;
+
+#[test]
+fn defaults_to_loopback_and_a_stable_database_path() {
+    let config = CoreConfig::from_values(None, None).expect("default config");
+
+    assert!(config.bind.ip().is_loopback());
+    assert_eq!(config.bind.port(), 50051);
+    assert_eq!(config.database.to_string_lossy(), ".agileplus/agileplus.db");
+}
+
+#[test]
+fn rejects_non_loopback_bindings() {
+    let error = CoreConfig::from_values(Some("0.0.0.0:50051"), None)
+        .expect_err("public plaintext bind must be rejected");
+
+    assert!(error.to_string().contains("loopback"));
+}

--- a/crates/agileplus-proto/Cargo.toml
+++ b/crates/agileplus-proto/Cargo.toml
@@ -12,12 +12,13 @@ categories = ["development-tools"]
 authors = ["kooshapari"]
 
 [build-dependencies]
-tonic-build.workspace = true
+tonic-prost-build.workspace = true
 prost-build.workspace = true
 
 [dependencies]
 tonic.workspace = true
 prost.workspace = true
+tonic-prost.workspace = true
 tokio-stream.workspace = true
 
 [features]

--- a/crates/agileplus-proto/build.rs
+++ b/crates/agileplus-proto/build.rs
@@ -27,7 +27,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     ];
     let includes = &["../../agileplus-agents/proto"];
 
-    tonic_build::configure()
+    tonic_prost_build::configure()
         .build_server(true)
         .build_client(true)
         .compile_protos(protos, includes)?;

--- a/crates/agileplus-proto/src/lib.rs
+++ b/crates/agileplus-proto/src/lib.rs
@@ -40,9 +40,11 @@ mod tests {
             state: "InProgress".to_string(),
             next_command: "continue".to_string(),
             blockers: vec!["blocker1".to_string()],
-            governance: Some(GovernanceSummary {
-                gate_passed: true,
-                violations_count: 0,
+            governance: Some(GovernanceStatus {
+                all_gates_passed: true,
+                total_rules: 0,
+                passed_rules: 0,
+                outstanding: Vec::new(),
             }),
         };
         assert_eq!(state.state, "InProgress");
@@ -132,27 +134,24 @@ mod tests {
 
         #[test]
         fn test_backlog_item_roundtrip() {
-            let item = BacklogItemProto {
+            let item = BacklogItem {
                 id: 100,
-                title: "Backlog Item".to_string(),
-                description: "Description here".to_string(),
                 r#type: "Story".to_string(),
+                title: "Backlog Item".to_string(),
+                body: "Description here".to_string(),
                 priority: "High".to_string(),
-                status: "Open".to_string(),
-                source: "github".to_string(),
-                feature_slug: "feature-x".to_string(),
-                tags: vec!["tag1".to_string(), "tag2".to_string()],
+                state: "Open".to_string(),
+                external_ref: "github:100".to_string(),
                 created_at: "2024-01-01T00:00:00Z".to_string(),
-                updated_at: "2024-01-01T00:00:00Z".to_string(),
             };
 
             let mut buf = Vec::new();
             item.encode(&mut buf).expect("encoding should succeed");
-            let decoded = BacklogItemProto::decode(&buf[..]).expect("decoding should succeed");
+            let decoded = BacklogItem::decode(&buf[..]).expect("decoding should succeed");
 
             assert_eq!(item, decoded);
             assert_eq!(decoded.id, 100);
-            assert_eq!(decoded.tags.len(), 2);
+            assert_eq!(decoded.external_ref, "github:100");
         }
 
         #[test]

--- a/crates/agileplus-sqlite/src/bin/migrate.rs
+++ b/crates/agileplus-sqlite/src/bin/migrate.rs
@@ -18,10 +18,11 @@ fn main() -> anyhow::Result<()> {
         .map(PathBuf::from)
         .unwrap_or_else(|| PathBuf::from(".agileplus/agileplus.db"));
 
-    if let Some(parent) = db_path.parent() {
-        if !parent.as_os_str().is_empty() && !parent.exists() {
-            std::fs::create_dir_all(parent)?;
-        }
+    if let Some(parent) = db_path.parent()
+        && !parent.as_os_str().is_empty()
+        && !parent.exists()
+    {
+        std::fs::create_dir_all(parent)?;
     }
 
     println!("Migrating database at: {}", db_path.display());

--- a/crates/agileplus-sqlite/src/seed/catalog.rs
+++ b/crates/agileplus-sqlite/src/seed/catalog.rs
@@ -67,18 +67,20 @@ pub fn parse_catalog(markdown: &str) -> Vec<CatalogEntry> {
         }
 
         // Inside an entry — look for **Title:** line (Authvault style)
-        if current_id.is_some() && current_title.as_deref().map(str::is_empty).unwrap_or(false) {
-            if let Some(t) = extract_title_field(trimmed) {
-                current_title = Some(t);
-                continue;
-            }
+        if current_id.is_some()
+            && current_title.as_deref().map(str::is_empty).unwrap_or(false)
+            && let Some(t) = extract_title_field(trimmed)
+        {
+            current_title = Some(t);
+            continue;
         }
 
         // Look for Status table cell
-        if current_id.is_some() && current_status.is_none() {
-            if let Some(s) = extract_status_cell(trimmed) {
-                current_status = Some(s);
-            }
+        if current_id.is_some()
+            && current_status.is_none()
+            && let Some(s) = extract_status_cell(trimmed)
+        {
+            current_status = Some(s);
         }
     }
 

--- a/crates/agileplus-subcmds/src/events.rs
+++ b/crates/agileplus-subcmds/src/events.rs
@@ -90,20 +90,20 @@ pub fn parse_since(since: &str) -> Option<DateTime<Utc>> {
     let now = Utc::now();
     let s = since.trim();
     // Try duration shorthand.
-    if let Some(rest) = s.strip_suffix('m') {
-        if let Ok(mins) = rest.parse::<i64>() {
-            return Some(now - chrono::Duration::minutes(mins));
-        }
+    if let Some(rest) = s.strip_suffix('m')
+        && let Ok(mins) = rest.parse::<i64>()
+    {
+        return Some(now - chrono::Duration::minutes(mins));
     }
-    if let Some(rest) = s.strip_suffix('h') {
-        if let Ok(hours) = rest.parse::<i64>() {
-            return Some(now - chrono::Duration::hours(hours));
-        }
+    if let Some(rest) = s.strip_suffix('h')
+        && let Ok(hours) = rest.parse::<i64>()
+    {
+        return Some(now - chrono::Duration::hours(hours));
     }
-    if let Some(rest) = s.strip_suffix('d') {
-        if let Ok(days) = rest.parse::<i64>() {
-            return Some(now - chrono::Duration::days(days));
-        }
+    if let Some(rest) = s.strip_suffix('d')
+        && let Ok(days) = rest.parse::<i64>()
+    {
+        return Some(now - chrono::Duration::days(days));
     }
     // Try ISO date.
     if let Ok(dt) = chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d") {
@@ -121,25 +121,25 @@ pub fn filter_events(events: &[EventRecord], args: &EventsArgs) -> Vec<EventReco
     events
         .iter()
         .filter(|e| {
-            if let Some(ref cutoff_dt) = cutoff {
-                if e.timestamp < *cutoff_dt {
-                    return false;
-                }
+            if let Some(ref cutoff_dt) = cutoff
+                && e.timestamp < *cutoff_dt
+            {
+                return false;
             }
-            if let Some(ref et) = args.event_type {
-                if &e.event_type != et {
-                    return false;
-                }
+            if let Some(ref et) = args.event_type
+                && &e.event_type != et
+            {
+                return false;
             }
-            if let Some(ref actor) = args.actor {
-                if &e.actor != actor {
-                    return false;
-                }
+            if let Some(ref actor) = args.actor
+                && &e.actor != actor
+            {
+                return false;
             }
-            if let Some(ref ent) = args.entity_type {
-                if &e.entity_type != ent {
-                    return false;
-                }
+            if let Some(ref ent) = args.entity_type
+                && &e.entity_type != ent
+            {
+                return false;
             }
             if let Some(ref feat) = args.feature {
                 // Match entity_type == "feature" and entity_id or summary containing slug.

--- a/crates/agileplus-subcmds/src/platform/process_compose.rs
+++ b/crates/agileplus-subcmds/src/platform/process_compose.rs
@@ -12,12 +12,12 @@ pub(crate) fn find_process_compose() -> Option<PathBuf> {
 fn which_process_compose() -> Option<PathBuf> {
     // Try `which` / `where` via std
     let output = Command::new("which").arg("process-compose").output();
-    if let Ok(out) = output {
-        if out.status.success() {
-            let path_str = String::from_utf8_lossy(&out.stdout).trim().to_string();
-            if !path_str.is_empty() {
-                return Some(PathBuf::from(path_str));
-            }
+    if let Ok(out) = output
+        && out.status.success()
+    {
+        let path_str = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        if !path_str.is_empty() {
+            return Some(PathBuf::from(path_str));
         }
     }
     // Fallback: check PATH entries manually

--- a/crates/agileplus-triage/src/claim_store_sqlite.rs
+++ b/crates/agileplus-triage/src/claim_store_sqlite.rs
@@ -226,10 +226,11 @@ impl ClaimStoreTrait for SqliteClaimStore {
     ) -> Option<Claim> {
         // Honour the in-memory semantics: if there is already an
         // Active claim for (kind, resource) by a *different* id, refuse.
-        if let Some(existing) = self.lookup(kind, resource) {
-            if existing.id != id && existing.state == ClaimState::Active {
-                return None;
-            }
+        if let Some(existing) = self.lookup(kind, resource)
+            && existing.id != id
+            && existing.state == ClaimState::Active
+        {
+            return None;
         }
         let now = Utc::now();
         let c = Claim {

--- a/crates/agileplus-triage/src/codebert.rs
+++ b/crates/agileplus-triage/src/codebert.rs
@@ -83,11 +83,4 @@ mod tests {
             .with_base_url("https://staging.example.com");
         assert_eq!(b.name(), "codebert");
     }
-
-    #[test]
-    fn codebert_feature_gate_compiles() {
-        // If the `codebert` feature is off, this module still compiles
-        // but the struct is unavailable.  We just verify the module exists.
-        assert!(true);
-    }
 }

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -18,7 +18,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/agileplus_mcp"]
+packages = ["src/agileplus_mcp", "src/agileplus_proto"]
 
 [project.scripts]
 agileplus-mcp = "agileplus_mcp.server:main"

--- a/python/src/agileplus_mcp/server.py
+++ b/python/src/agileplus_mcp/server.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import logging
 import os
+from ipaddress import ip_address
 from typing import Any
 
 from fastmcp import FastMCP
@@ -276,6 +277,97 @@ async def sample_retrospective(feature_slug: str) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
+def register_compatibility_tools(app: FastMCP, client: AgilePlusCoreClient) -> None:
+    """Register the canonical Codex-facing AgilePlus tool names."""
+
+    @app.tool(name="health_check")
+    async def health_check() -> dict[str, str]:
+        try:
+            await client.list_features()
+        except Exception as exc:
+            return {
+                "status": "unhealthy",
+                "mcp_server": "ok",
+                "grpc_core": "unreachable",
+                "version": "0.1.0",
+                "error": str(exc),
+            }
+        return {"status": "healthy", "mcp_server": "ok", "grpc_core": "ok", "version": "0.1.0"}
+
+    @app.tool(name="list_features")
+    async def list_features(state: str | None = None) -> list[dict[str, Any]]:
+        return await client.list_features(state)
+
+    @app.tool(name="get_feature")
+    async def get_feature(slug: str) -> dict[str, Any]:
+        return await client.get_feature(slug)
+
+    @app.tool(name="get_work_packages")
+    async def get_work_packages(feature_slug: str) -> list[dict[str, Any]]:
+        return await client.list_work_packages(feature_slug)
+
+    @app.tool(name="get_work_package")
+    async def get_work_package(feature_slug: str, wp_id: str) -> dict[str, Any]:
+        if not wp_id.startswith("WP") or not wp_id[2:].isdigit():
+            raise ValueError("wp_id must use the canonical WP<positive integer> form")
+        sequence = int(wp_id[2:])
+        if sequence < 1:
+            raise ValueError("wp_id sequence must be positive")
+        return await client.get_work_package_status(feature_slug, sequence)
+
+    @app.tool(name="get_tasks")
+    async def get_tasks(feature_slug: str, wp_id: str | None = None) -> dict[str, str]:
+        del feature_slug, wp_id
+        return {"error": "not_implemented", "capability": "tasks"}
+
+    @app.tool(name="get_metrics")
+    async def get_metrics(feature_slug: str | None = None) -> dict[str, str]:
+        del feature_slug
+        return {"error": "not_implemented", "capability": "metrics"}
+
+    @app.tool(name="get_governance_rules")
+    async def get_governance_rules(feature_slug: str | None = None) -> dict[str, str]:
+        del feature_slug
+        return {"error": "not_implemented", "capability": "governance_rules"}
+
+    @app.tool(name="check_governance")
+    async def check_governance(feature_slug: str) -> dict[str, Any]:
+        return await client.check_governance_gate(feature_slug, "")
+
+    @app.tool(name="get_audit_trail")
+    async def get_audit_trail(feature_slug: str, limit: int = 50) -> list[dict[str, Any]]:
+        return (await client.get_audit_trail(feature_slug))[:limit]
+
+    @app.tool(name="verify_audit_chain")
+    async def verify_audit_chain(feature_slug: str) -> dict[str, Any]:
+        return await client.verify_audit_chain(feature_slug)
+
+    @app.tool(name="get_dashboard")
+    async def get_dashboard() -> dict[str, Any]:
+        features = await client.list_features()
+        counts: dict[str, int] = {}
+        active_work_packages: list[dict[str, Any]] = []
+        recent_audit_entries: list[dict[str, Any]] = []
+        for feature in features:
+            state = str(feature.get("state", "unknown"))
+            counts[state] = counts.get(state, 0) + 1
+            slug = str(feature.get("slug", ""))
+            work_packages = await client.list_work_packages(slug)
+            active_work_packages.extend(
+                work_package
+                for work_package in work_packages
+                if str(work_package.get("state", "")).lower() in {"doing", "in_progress", "blocked"}
+            )
+            recent_audit_entries.extend(await client.get_audit_trail(slug))
+        recent_audit_entries.sort(key=lambda entry: str(entry.get("timestamp", "")), reverse=True)
+        return {
+            "feature_counts": counts,
+            "active_work_packages": active_work_packages,
+            "recent_audit_entries": recent_audit_entries[:10],
+            "health": "healthy",
+        }
+
+
 async def startup(grpc_address: str = GRPC_ADDRESS) -> None:
     """Initialise the gRPC client and register all tools."""
     global _client, _sampling
@@ -293,52 +385,11 @@ async def startup(grpc_address: str = GRPC_ADDRESS) -> None:
     _client = client
     _sampling = SamplingHandler(client)
 
-    # Register domain tool modules
     features_module.register_tools(mcp, client)
     governance_module.register_tools(mcp, client)
     queue_module.register_tools(mcp, client)
     status_module.register_tools(mcp, client)
-
-    @mcp.tool(name="health_check")
-    async def health_check() -> dict[str, str]:
-        try:
-            await client.list_features()
-        except Exception as exc:
-            return {"status": "unhealthy", "mcp_server": "ok", "grpc_core": "unreachable", "version": "0.1.0", "error": str(exc)}
-        return {"status": "healthy", "mcp_server": "ok", "grpc_core": "ok", "version": "0.1.0"}
-
-    @mcp.tool(name="list_features")
-    async def list_features(state: str | None = None) -> list[dict[str, Any]]:
-        return await client.list_features(state)
-
-    @mcp.tool(name="get_feature")
-    async def get_feature(slug: str) -> dict[str, Any]:
-        return await client.get_feature(slug)
-
-    @mcp.tool(name="get_work_packages")
-    async def get_work_packages(feature_slug: str) -> list[dict[str, Any]]:
-        return await client.list_work_packages(feature_slug)
-
-    @mcp.tool(name="check_governance")
-    async def check_governance(feature_slug: str) -> dict[str, Any]:
-        return await client.check_governance_gate(feature_slug, "")
-
-    @mcp.tool(name="get_audit_trail")
-    async def get_audit_trail(feature_slug: str, limit: int = 50) -> list[dict[str, Any]]:
-        return (await client.get_audit_trail(feature_slug))[:limit]
-
-    @mcp.tool(name="verify_audit_chain")
-    async def verify_audit_chain(feature_slug: str) -> dict[str, Any]:
-        return await client.verify_audit_chain(feature_slug)
-
-    @mcp.tool(name="get_dashboard")
-    async def get_dashboard() -> dict[str, Any]:
-        features = await client.list_features()
-        counts: dict[str, int] = {}
-        for feature in features:
-            state = str(feature.get("state", "unknown"))
-            counts[state] = counts.get(state, 0) + 1
-        return {"feature_counts": counts, "active_work_packages": [], "recent_audit_entries": [], "health": "healthy"}
+    register_compatibility_tools(mcp, client)
 
     logger.info("AgilePlus MCP server ready (gRPC: %s)", grpc_address)
 
@@ -359,18 +410,32 @@ def main() -> None:
 
     async def _run() -> None:
         await startup()
-        transport = os.environ.get("AGILEPLUS_MCP_TRANSPORT", "stdio")
-        kwargs: dict[str, Any] = {}
-        if transport == "http":
-            kwargs = {
-                "host": os.environ.get("AGILEPLUS_MCP_HOST", "127.0.0.1"),
-                "port": int(os.environ.get("AGILEPLUS_MCP_PORT", "8765")),
-                "path": os.environ.get("AGILEPLUS_MCP_PATH", "/mcp"),
-            }
-        await mcp.run_async(transport=transport, show_banner=False, **kwargs)
-        await shutdown()
+        try:
+            transport = os.environ.get("AGILEPLUS_MCP_TRANSPORT", "stdio")
+            kwargs = _transport_kwargs(transport)
+            await mcp.run_async(transport=transport, show_banner=False, **kwargs)
+        finally:
+            await shutdown()
 
     asyncio.run(_run())
+
+
+def _transport_kwargs(transport: str) -> dict[str, Any]:
+    if transport != "http":
+        return {}
+    host = os.environ.get("AGILEPLUS_MCP_HOST", "127.0.0.1")
+    if host != "localhost":
+        try:
+            is_loopback = ip_address(host).is_loopback
+        except ValueError:
+            is_loopback = False
+        if not is_loopback:
+            raise ValueError("plaintext AgilePlus MCP must bind to a loopback address")
+    return {
+        "host": host,
+        "port": int(os.environ.get("AGILEPLUS_MCP_PORT", "8765")),
+        "path": os.environ.get("AGILEPLUS_MCP_PATH", "/mcp"),
+    }
 
 
 if __name__ == "__main__":

--- a/python/src/agileplus_mcp/server.py
+++ b/python/src/agileplus_mcp/server.py
@@ -299,6 +299,47 @@ async def startup(grpc_address: str = GRPC_ADDRESS) -> None:
     queue_module.register_tools(mcp, client)
     status_module.register_tools(mcp, client)
 
+    @mcp.tool(name="health_check")
+    async def health_check() -> dict[str, str]:
+        try:
+            await client.list_features()
+        except Exception as exc:
+            return {"status": "unhealthy", "mcp_server": "ok", "grpc_core": "unreachable", "version": "0.1.0", "error": str(exc)}
+        return {"status": "healthy", "mcp_server": "ok", "grpc_core": "ok", "version": "0.1.0"}
+
+    @mcp.tool(name="list_features")
+    async def list_features(state: str | None = None) -> list[dict[str, Any]]:
+        return await client.list_features(state)
+
+    @mcp.tool(name="get_feature")
+    async def get_feature(slug: str) -> dict[str, Any]:
+        return await client.get_feature(slug)
+
+    @mcp.tool(name="get_work_packages")
+    async def get_work_packages(feature_slug: str) -> list[dict[str, Any]]:
+        return await client.list_work_packages(feature_slug)
+
+    @mcp.tool(name="check_governance")
+    async def check_governance(feature_slug: str) -> dict[str, Any]:
+        return await client.check_governance_gate(feature_slug, "")
+
+    @mcp.tool(name="get_audit_trail")
+    async def get_audit_trail(feature_slug: str, limit: int = 50) -> list[dict[str, Any]]:
+        return (await client.get_audit_trail(feature_slug))[:limit]
+
+    @mcp.tool(name="verify_audit_chain")
+    async def verify_audit_chain(feature_slug: str) -> dict[str, Any]:
+        return await client.verify_audit_chain(feature_slug)
+
+    @mcp.tool(name="get_dashboard")
+    async def get_dashboard() -> dict[str, Any]:
+        features = await client.list_features()
+        counts: dict[str, int] = {}
+        for feature in features:
+            state = str(feature.get("state", "unknown"))
+            counts[state] = counts.get(state, 0) + 1
+        return {"feature_counts": counts, "active_work_packages": [], "recent_audit_entries": [], "health": "healthy"}
+
     logger.info("AgilePlus MCP server ready (gRPC: %s)", grpc_address)
 
 
@@ -318,7 +359,15 @@ def main() -> None:
 
     async def _run() -> None:
         await startup()
-        await mcp.run_async()
+        transport = os.environ.get("AGILEPLUS_MCP_TRANSPORT", "stdio")
+        kwargs: dict[str, Any] = {}
+        if transport == "http":
+            kwargs = {
+                "host": os.environ.get("AGILEPLUS_MCP_HOST", "127.0.0.1"),
+                "port": int(os.environ.get("AGILEPLUS_MCP_PORT", "8765")),
+                "path": os.environ.get("AGILEPLUS_MCP_PATH", "/mcp"),
+            }
+        await mcp.run_async(transport=transport, show_banner=False, **kwargs)
         await shutdown()
 
     asyncio.run(_run())

--- a/python/src/agileplus_mcp/server.py
+++ b/python/src/agileplus_mcp/server.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 from ipaddress import ip_address
 from typing import Any
 
@@ -40,6 +41,8 @@ GRPC_ADDRESS = os.environ.get("AGILEPLUS_GRPC_ADDRESS", "localhost:50051")
 mcp: FastMCP = FastMCP("AgilePlus")
 _client: AgilePlusCoreClient | None = None
 _sampling: SamplingHandler | None = None
+_registered_app: FastMCP | None = None
+_runtime_tool_names: set[str] = set()
 
 
 def _get_client() -> AgilePlusCoreClient:
@@ -331,8 +334,19 @@ def register_compatibility_tools(app: FastMCP, client: AgilePlusCoreClient) -> N
         return {"error": "not_implemented", "capability": "governance_rules"}
 
     @app.tool(name="check_governance")
-    async def check_governance(feature_slug: str) -> dict[str, Any]:
-        return await client.check_governance_gate(feature_slug, "")
+    async def check_governance(feature_slug: str, transition: str | None = None) -> dict[str, Any]:
+        """Check governance rules for one transition.
+
+        When ``transition`` is omitted, the core evaluates only rules that
+        apply globally (rules whose transition is empty). An explicit value
+        must use the canonical ``from->to`` form.
+        """
+        if (
+            transition is not None
+            and re.fullmatch(r"[a-z][a-z0-9_-]*->[a-z][a-z0-9_-]*", transition) is None
+        ):
+            raise ValueError("transition must use the canonical from->to form")
+        return await client.check_governance_gate(feature_slug, transition or "")
 
     @app.tool(name="get_audit_trail")
     async def get_audit_trail(feature_slug: str, limit: int = 50) -> list[dict[str, Any]]:
@@ -370,7 +384,18 @@ def register_compatibility_tools(app: FastMCP, client: AgilePlusCoreClient) -> N
 
 async def startup(grpc_address: str = GRPC_ADDRESS) -> None:
     """Initialise the gRPC client and register all tools."""
-    global _client, _sampling
+    global _client, _registered_app, _runtime_tool_names, _sampling
+
+    if _client is not None:
+        await _client.close()
+
+    if _registered_app is mcp:
+        for tool_name in _runtime_tool_names:
+            mcp.local_provider.remove_tool(tool_name)
+    else:
+        _runtime_tool_names = set()
+
+    existing_tool_names = {tool.name for tool in await mcp.list_tools()}
 
     client = AgilePlusCoreClient(grpc_address)
     try:
@@ -390,16 +415,21 @@ async def startup(grpc_address: str = GRPC_ADDRESS) -> None:
     queue_module.register_tools(mcp, client)
     status_module.register_tools(mcp, client)
     register_compatibility_tools(mcp, client)
+    _runtime_tool_names = {
+        tool.name for tool in await mcp.list_tools() if tool.name not in existing_tool_names
+    }
+    _registered_app = mcp
 
     logger.info("AgilePlus MCP server ready (gRPC: %s)", grpc_address)
 
 
 async def shutdown() -> None:
     """Close the gRPC connection."""
-    global _client
+    global _client, _sampling
     if _client is not None:
         await _client.close()
         _client = None
+    _sampling = None
 
 
 def main() -> None:

--- a/python/tests/test_mcp_tools.py
+++ b/python/tests/test_mcp_tools.py
@@ -146,6 +146,16 @@ async def test_canonical_compatibility_tools_round_trip_to_the_grpc_client() -> 
         "governance_rules"
     )
     assert (await (await _tool(mcp, "check_governance"))("feature-one"))["passed"]
+    assert (
+        await (await _tool(mcp, "check_governance"))(
+            "feature-one", transition="planned->implementing"
+        )
+    )["passed"]
+    assert client.check_governance_gate.await_args_list[-2].args == ("feature-one", "")
+    assert client.check_governance_gate.await_args_list[-1].args == (
+        "feature-one",
+        "planned->implementing",
+    )
     assert await (await _tool(mcp, "get_audit_trail"))("feature-one", 1) == [
         {"id": 1, "timestamp": "2026-08-29T01:00:00Z"}
     ]
@@ -196,3 +206,41 @@ def test_http_transport_requires_loopback(monkeypatch: pytest.MonkeyPatch) -> No
         "path": "/mcp",
     }
     assert server._transport_kwargs("stdio") == {}
+
+
+@pytest.mark.asyncio
+async def test_canonical_governance_rejects_ambiguous_transition() -> None:
+    mcp = FastMCP("governance-transition-validation")
+    client = _client()
+    server.register_compatibility_tools(mcp, client)
+
+    with pytest.raises(ValueError, match="from->to"):
+        await (await _tool(mcp, "check_governance"))("feature-one", transition="implementing")
+
+    client.check_governance_gate.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_repeated_startup_replaces_client_used_by_registered_tools(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = FastMCP("repeated-startup")
+    first = _client()
+    second = _client()
+    clients = iter((first, second))
+
+    monkeypatch.setattr(server, "mcp", app)
+    monkeypatch.setattr(server, "AgilePlusCoreClient", lambda _address: next(clients))
+    first.connect = AsyncMock()
+    first.close = AsyncMock()
+    second.connect = AsyncMock()
+    second.close = AsyncMock()
+
+    await server.startup("127.0.0.1:50051")
+    await server.startup("127.0.0.1:50051")
+    await (await _tool(app, "get_feature"))("feature-one")
+
+    first.close.assert_awaited_once()
+    first.get_feature.assert_not_awaited()
+    second.get_feature.assert_awaited_once_with("feature-one")
+    await server.shutdown()

--- a/python/tests/test_mcp_tools.py
+++ b/python/tests/test_mcp_tools.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from fastmcp import FastMCP
 
+from agileplus_mcp import server
 from agileplus_mcp.tools import features, governance, queue, status
 
 
@@ -113,3 +114,85 @@ async def test_queue_tools_use_the_canonical_create_list_and_promote_contract() 
     client.list_backlog.assert_awaited_once_with(
         type_filter="task", state_filter="triaged", feature_slug=None
     )
+
+
+@pytest.mark.asyncio
+async def test_canonical_compatibility_tools_round_trip_to_the_grpc_client() -> None:
+    mcp = FastMCP("compatibility-tools")
+    client = _client()
+    client.list_features = AsyncMock(
+        return_value=[
+            {"slug": "feature-one", "state": "planned"},
+            {"slug": "feature-two", "state": "planned"},
+            {"slug": "feature-three"},
+        ]
+    )
+    client.list_work_packages = AsyncMock(return_value=[{"sequence": 1, "state": "doing"}])
+    client.get_audit_trail = AsyncMock(
+        return_value=[{"id": 1, "timestamp": "2026-08-29T01:00:00Z"}]
+    )
+    server.register_compatibility_tools(mcp, client)
+
+    assert (await (await _tool(mcp, "health_check"))())["grpc_core"] == "ok"
+    assert len(await (await _tool(mcp, "list_features"))("planned")) == 3
+    assert (await (await _tool(mcp, "get_feature"))("feature-one"))["slug"] == "feature-one"
+    assert await (await _tool(mcp, "get_work_packages"))("feature-one") == [
+        {"sequence": 1, "state": "doing"}
+    ]
+    assert (await (await _tool(mcp, "get_work_package"))("feature-one", "WP01"))["sequence"] == 1
+    assert (await (await _tool(mcp, "get_tasks"))("feature-one"))["error"] == "not_implemented"
+    assert (await (await _tool(mcp, "get_metrics"))())["capability"] == "metrics"
+    assert (await (await _tool(mcp, "get_governance_rules"))())["capability"] == (
+        "governance_rules"
+    )
+    assert (await (await _tool(mcp, "check_governance"))("feature-one"))["passed"]
+    assert await (await _tool(mcp, "get_audit_trail"))("feature-one", 1) == [
+        {"id": 1, "timestamp": "2026-08-29T01:00:00Z"}
+    ]
+    assert (await (await _tool(mcp, "verify_audit_chain"))("feature-one"))["valid"]
+    dashboard = await (await _tool(mcp, "get_dashboard"))()
+    assert dashboard["feature_counts"] == {"planned": 2, "unknown": 1}
+    assert len(dashboard["active_work_packages"]) == 3
+    assert len(dashboard["recent_audit_entries"]) == 3
+
+
+@pytest.mark.asyncio
+async def test_canonical_health_reports_grpc_failures() -> None:
+    mcp = FastMCP("unhealthy-compatibility-tools")
+    client = _client()
+    client.list_features = AsyncMock(side_effect=RuntimeError("core offline"))
+    server.register_compatibility_tools(mcp, client)
+
+    health = await (await _tool(mcp, "health_check"))()
+
+    assert health["status"] == "unhealthy"
+    assert health["grpc_core"] == "unreachable"
+    assert health["error"] == "core offline"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("wp_id", ["1", "WP", "WP0", "wp01", "WP-1"])
+async def test_canonical_get_work_package_rejects_invalid_ids(wp_id: str) -> None:
+    mcp = FastMCP("invalid-work-package-id")
+    client = _client()
+    server.register_compatibility_tools(mcp, client)
+
+    with pytest.raises(ValueError, match="wp_id"):
+        await (await _tool(mcp, "get_work_package"))("feature-one", wp_id)
+
+    client.get_work_package_status.assert_not_awaited()
+
+
+def test_http_transport_requires_loopback(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGILEPLUS_MCP_HOST", "0.0.0.0")  # noqa: S104 - rejection fixture
+    with pytest.raises(ValueError, match="loopback"):
+        server._transport_kwargs("http")
+
+    monkeypatch.setenv("AGILEPLUS_MCP_HOST", "127.0.0.1")
+    monkeypatch.setenv("AGILEPLUS_MCP_PORT", "9876")
+    assert server._transport_kwargs("http") == {
+        "host": "127.0.0.1",
+        "port": 9876,
+        "path": "/mcp",
+    }
+    assert server._transport_kwargs("stdio") == {}


### PR DESCRIPTION
## Summary
- restore `agileplus-grpc` and canonical generated proto crate to the active Cargo workspace
- add a loopback-only Rust core backed by persistent SQLite
- start the Python MCP entrypoint and expose the canonical Codex compatibility names
- harden transport binding, shutdown, dashboard aggregation, WP identifier validation, and runtime coverage
- satisfy the workspace Rust 2024 clippy baseline

spec: eco-037-acceptance-contract

## Stack Topology
- base: `fix/benchmark-infra-criterion-20260826`
- head: `fix/core-mcp-runtime-20260829`
- this is a stacked repair PR; it must land after or be rebased from its base branch

## Validation
- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `cd python && uv run ruff check src tests`
- `cd python && uv run coverage run -m pytest -q && uv run coverage report --fail-under=85` (86%)

## Governance
- core and HTTP MCP bind only to loopback
- legacy SQLite source is preserved; durable cutover uses a staged backup and explicit timestamp normalization
- three advertised-but-unimplemented core capabilities return explicit `not_implemented`: tasks, metrics, governance rules
- no branch protection bypass requested

## CI Exception
No exception requested. Baseline workflow/dependency failures, if reproduced, remain visible merge gates.

## Deployment note
The currently running LaunchAgents prove local recovery but are not the durable release. Final cutover will pin immutable artifacts and a stable Application Support database path after this SHA is qualified.
